### PR TITLE
base-compiler.js: acknowledge checkSource weakness

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -237,6 +237,10 @@ Compile.prototype.checkOptions = function (options) {
     return null;
 };
 
+// This check for arbitrary user-controlled preprocessor inclusions
+// can be circumvented in more than one way. The goal here is to respond
+// to simple attempts with a clear diagnostic; the service still needs to
+// assume that malicious actors can make the compiler open arbitrary files.
 Compile.prototype.checkSource = function (source) {
     var re = /^\s*#\s*i(nclude|mport)(_next)?\s+["<"](\/|.*\.\.)/;
     var failed = [];


### PR DESCRIPTION
To potentially make the intent clearer for future inquiring minds, add a comment to checkSource function explaining that it's not meant to prevent arbitrary file inclusion, only to diagnose unsophisticated attempts. 