### PR TITLE
d/ldc: Enable Intel syntax (?)

### DIFF
--- a/lib/compilers/ldc.js
+++ b/lib/compilers/ldc.js
@@ -27,6 +27,7 @@ var Compile = require('../base-compiler');
 function compileLdc(info, env) {
     var compiler = new Compile(info, env);
     // TODO this needs testing!
+    compiler.compiler.supportsIntel = true;
     compiler.optionsForFilter = function (filters, outputFilename) {
         var options = ['-g', '-of', this.filename(outputFilename)];
         if (filters.intel && !filters.binary) options.concat('-x86-asm-syntax=intel');


### PR DESCRIPTION
I'm having trouble building the project, but it seems like there shouldn't be any extra changes required. (LLVM's `-x86-asm-syntax=intel` mode is already being used for Rust.)