### PR TITLE
Adds a numerical constants tooltip conversion

### DIFF
--- a/static/compiler.js
+++ b/static/compiler.js
@@ -74,6 +74,11 @@ define(function (require) {
         this.settings = {};
 
         this.decorations = [];
+        this.rawDecorations = [];
+        this.rawDecorations.push({
+            range: new monaco.Range(0, 1, 0, 1),
+            options: {}
+        });
 
         this.domRoot.find(".compiler-picker").selectize({
             sortField: 'name',
@@ -117,9 +122,30 @@ define(function (require) {
         });
 
         this.outputEditor.onMouseMove(function (e) {
+            if (e === null || e.target === null) return;
             if (self.settings.hoverShowSource === true && e.target.position !== null) {
                 var desiredLine = e.target.position.lineNumber - 1;
                 self.eventHub.emit('editorSetDecoration', self.sourceEditorId, self.assembly[desiredLine].source);
+            }
+            if (e.target.element !== null && $.isNumeric(e.target.element.textContent)) {
+                var elementContent = e.target.element.textContent;
+                self.rawDecorations[0] = {
+                    range: e.target.range,
+                    options: {
+                        isWholeLine: false,
+                        hoverMessage: [
+                            parseInt(elementContent,16).toString(16) === elementContent.toLowerCase() ? // Is Hex?
+                                '0x' + parseInt(elementContent).toString(16)
+                            :
+                            (parseInt(elementContent,10) === elementContent ? // Is Decimal
+                                parseInt(elementContent).toString(10) 
+                            : // Else ... Show both
+                            ('0x' + parseInt(elementContent, 16).toString() + ' (' + parseInt(elementContent, 10).toString() + ')'))
+                            
+                        ]
+                    }
+                };
+                self.decorations = self.outputEditor.deltaDecorations(self.decorations, self.rawDecorations);
             }
         });
 
@@ -507,6 +533,7 @@ define(function (require) {
     Compiler.prototype.onCompilerSetDecorations = function (id, lineNums) {
         if (id == this.id) {
             var ranges = [];
+            ranges.push(this.rawDecorations[0]);
             _.each(lineNums, function (line) {
                 ranges.push({
                     range: new monaco.Range(line, 1, line, 1),
@@ -516,6 +543,7 @@ define(function (require) {
                 });
             });
             this.decorations = this.outputEditor.deltaDecorations(this.decorations, ranges);
+            this.rawDecorations = ranges;
         }
     };
 

--- a/static/editor.js
+++ b/static/editor.js
@@ -120,7 +120,7 @@ define(function (require) {
         });
 
         this.mouseMoveThrottledFunction = _.throttle(function (e) {
-                if (self.settings.hoverShowSource === true && e.target.position !== null) {
+                if (e !== null && e.target !== null && self.settings.hoverShowSource === true && e.target.position !== null) {
                     tryCompilerSelectLine(e.target.position.lineNumber);
                 }
             },


### PR DESCRIPTION
I open this PR so I can get some opinions on the code for this one. I have annottated few fragments that I will polish Soon™ once I get some feedback/help

Note that the tooltip api is nowhere to be found on the Monaco Editor, but decorations are able to access them, so we just create a decoration on the mouse position that opens a tooltip with the converted value. In order to do this and **not** lose the linking code decorations, we now have to store the decoration arrays separatedly, and emply the first one of this array for the tooltip. I think it's a good solution but I'm open to suggestions.

I'm quite sure binary numerals will get parsed as decimals by javascript, so there's that

Closes #27 #107 