### PR TITLE
Fixed typo that prevented code highlighting

### DIFF
--- a/static/compiler.js
+++ b/static/compiler.js
@@ -125,7 +125,7 @@ define(function (require) {
             if (e === null || e.target === null || e.target.position === null) return;
             if (self.settings.hoverShowSource === true && self.assembly) {
                 var desiredLine = e.target.position.lineNumber - 1;
-                if (!self.assembly[desiredLine]) {
+                if (self.assembly[desiredLine]) {
                     // We check that we actually have something to show at this point!
                     self.eventHub.emit('editorSetDecoration', self.sourceEditorId, self.assembly[desiredLine].source);
                 }

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -123,7 +123,7 @@ define(function (require) {
 
         this.outputEditor.onMouseMove(function (e) {
             if (e === null || e.target === null || e.target.position === null) return;
-            if (self.settings.hoverShowSource === true && !self.assembly) {
+            if (self.settings.hoverShowSource === true && self.assembly) {
                 var desiredLine = e.target.position.lineNumber - 1;
                 if (!self.assembly[desiredLine]) {
                     // We check that we actually have something to show at this point!


### PR DESCRIPTION
I did not test it when I submitted it because the changes were minimal, yet I screwed it up!
Sorry about that 😞 

The issue came to be because I c&p the code from a previous iteration that instead of checking if we could do it and did it in case we could, it checked if we could **not** do it and returned in that case.

Again, sorry