### PR TITLE
made fira mono the new default font for code

### DIFF
--- a/static/editor.js
+++ b/static/editor.js
@@ -83,6 +83,7 @@ define(function (require) {
             value: state.source || defaultSrc || "",
             scrollBeyondLastLine: false,
             language: cmMode,
+            fontFamily: 'Fira Mono',
             readOnly: !!options.readOnly || legacyReadOnly,
             glyphMargin: true,
             quickSuggestions: false,

--- a/static/explorer.css
+++ b/static/explorer.css
@@ -4,6 +4,7 @@
 @import url("ext/selectize/dist/css/selectize.bootstrap2.css");
 @import url("ext/seiyria-bootstrap-slider/dist/css/bootstrap-slider.css");
 @import url("colours.css");
+@import url('https://fonts.googleapis.com/css?family=Fira+Mono');
 
 /* TEMP HACK: https://github.com/Microsoft/monaco-editor/issues/349 */
 .quick-open-tree .row {


### PR DESCRIPTION
This will fix https://github.com/mattgodbolt/compiler-explorer/issues/386
If the font install is failing the editor will default to the os font.