### PR TITLE
First pass at adding a opt view mode for compiler explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /node_modules
 /.npm-updated
 /.bower-updated
+*.vscode
 /out
 *.heapsnapshot
 etc/config/*.local.properties

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -238,7 +238,7 @@ Compile.prototype.postProcessAsm = function (result) {
         });
 };
 
-Compile.prototype.processOptoutput = function(hasOptOutput, optPath) {
+Compile.prototype.processOptOutput = function(hasOptOutput, optPath) {
     var output = [];
     return new Promise(
         function (resolve, reject) { 
@@ -259,7 +259,7 @@ Compile.prototype.postProcess = function (result, outputFilename, filters) {
     var maxSize = this.env.gccProps("max-asm-size", 8 * 1024 * 1024);
     var optPromise;
     if(result.hasOptOutput) {
-        optPromise = this.processOptoutput (result.hasOptOutput, result.optPath);
+        optPromise = this.processOptOutput(result.hasOptOutput, result.optPath);
     } else {
         optPromise = Promise.resolve("");
     }

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -32,8 +32,9 @@ var child_process = require('child_process'),
     quote = require('shell-quote'),
     _ = require('underscore-node'),
     exec = require('./exec'),
-    logger = require('./logger').logger;
-
+    logger = require('./logger').logger,
+    compilerOptInfo = require("compiler-opt-info");
+    
 function Compile(compiler, env) {
     this.compiler = compiler;
     this.env = env;
@@ -55,6 +56,11 @@ Compile.prototype.newTempDir = function () {
 Compile.prototype.writeFile = Promise.denodeify(fs.writeFile);
 Compile.prototype.readFile = Promise.denodeify(fs.readFile);
 Compile.prototype.stat = Promise.denodeify(fs.stat);
+Compile.prototype.couldHaveOptOutput = function(options, version) {
+    //TODO(jared): a compiler meta data gatherer could improve this
+    return version.toLowerCase().indexOf("clang") > -1 && 
+          options.some((x) => x == "-fsave-optimization-record");
+};
 
 Compile.prototype.getRemote = function () {
     if (this.compiler.exe === null && this.compiler.remote)
@@ -161,9 +167,10 @@ Compile.prototype.compile = function (source, options, filters) {
         var compileToAsmPromise = tempFileAndDirPromise.then(function (info) {
             var inputFilename = info.inputFilename;
             var dirPath = info.dirPath;
-            var outputFilename = path.join(dirPath, 'output.s'); // NB keep lower case as ldc compiler `tolower`s the output name
+            var outputFilebase = "output";
+            var outputFilename = path.join(dirPath, outputFilebase + ".s"); // NB keep lower case as ldc compiler `tolower`s the output name
             options = self.prepareArguments(options, filters, inputFilename, outputFilename);
-
+            
             options = options.filter(_.identity);
             return self.runCompiler(self.compiler.exe, options, self.filename(inputFilename))
                 .then(function (result) {
@@ -172,12 +179,27 @@ Compile.prototype.compile = function (source, options, filters) {
                         result.asm = "<Compilation failed>";
                         return result;
                     }
+                    result.hasOptOutput = false;
+                    if(self.couldHaveOptOutput(options, self.compiler.version)) {
+                        const optPath = path.join(dirPath, outputFilebase + ".opt.yaml");
+                        if(fs.existsSync(optPath)) {
+                            result.hasOptOutput = true;
+                            result.optPath = optPath;
+                        }
+                    }
                     return self.postProcess(result, outputFilename, filters);
                 });
         });
 
         return compileToAsmPromise
-            .then(function (result) {
+            .then(function (results) { 
+                //TODO(jared): this isn't ideal. Rethink
+                if(results.length) {
+                    var result = results[0];
+                    var optOutput = results[1];
+                } else {
+                    result = results;
+                }
                 if (result.dirPath) {
                     fs.remove(result.dirPath);
                     result.dirPath = undefined;
@@ -186,6 +208,10 @@ Compile.prototype.compile = function (source, options, filters) {
                     result.asm = self.asm.process(result.asm, filters);
                 } else {
                     result.asm = {text: result.asm};
+                }
+                if(result.hasOptOutput) {
+                    result.optPath = undefined;
+                    result.optOutput = optOutput;
                 }
                 return result;
             })
@@ -210,9 +236,31 @@ Compile.prototype.postProcessAsm = function (result) {
         });
 };
 
+Compile.prototype.processOptoutput = function(hasOptOutput, optPath) {
+    var output = [];
+    return new Promise(
+        function (resolve, reject) { 
+            fs.createReadStream(optPath, {encoding: "utf-8"})
+                .pipe(new compilerOptInfo.LLVMOptTransformer())
+                .on("data", function(opt) {
+                    output.push(opt);
+                })
+                .on("end", function() {
+                    resolve(output);
+                });
+    });
+}
+
+
 Compile.prototype.postProcess = function (result, outputFilename, filters) {
     var postProcess = this.compiler.postProcess.filter(_.identity);
     var maxSize = this.env.gccProps("max-asm-size", 8 * 1024 * 1024);
+    var optPromise;
+    if(result.hasOptOutput) {
+        optPromise = this.processOptoutput (result.hasOptOutput, result.optPath);
+    } else {
+        optPromise = Promise.resolve("");
+    }
     if (filters.binary && this.supportsObjdump()) {
         var promise = this.objdump(outputFilename, result, maxSize, filters.intel);
         var executeIt = false; // TODO: when execution is supported, edit here...
@@ -224,7 +272,7 @@ Compile.prototype.postProcess = function (result, outputFilename, filters) {
         }
         return promise;
     }
-    return this.stat(outputFilename).then(_.bind(function (stat) {
+    var readASM = this.stat(outputFilename).then(_.bind(function (stat) {
             if (stat.size >= maxSize) {
                 result.asm = "<No output: generated assembly was too large (" + stat.size + " > " + maxSize + " bytes)>";
                 return result;
@@ -251,6 +299,7 @@ Compile.prototype.postProcess = function (result, outputFilename, filters) {
             return result;
         }
     );
+    return Promise.all([readASM, optPromise]);
 };
 
 Compile.prototype.checkOptions = function (options) {

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -194,9 +194,11 @@ Compile.prototype.compile = function (source, options, filters) {
         return compileToAsmPromise
             .then(function (results) { 
                 //TODO(jared): this isn't ideal. Rethink
+                var result;
+                var optOutput;
                 if(results.length) {
-                    var result = results[0];
-                    var optOutput = results[1];
+                    result = results[0];
+                    optOutput = results[1];
                 } else {
                     result = results;
                 }
@@ -249,7 +251,7 @@ Compile.prototype.processOptoutput = function(hasOptOutput, optPath) {
                     resolve(output);
                 });
     });
-}
+};
 
 
 Compile.prototype.postProcess = function (result, outputFilename, filters) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "aws-sdk": "*",
     "body-parser": "1.14.x",
-    "compiler-opt-info": "0.0.3",
+    "compiler-opt-info": "0.0.4",
     "compression": "1.6.x",
     "express": "4.13.x",
     "fs-extra": "0.26.x",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "aws-sdk": "*",
     "body-parser": "1.14.x",
+    "compiler-opt-info": "0.0.3",
     "compression": "1.6.x",
     "express": "4.13.x",
     "fs-extra": "0.26.x",

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -459,7 +459,7 @@ define(function (require) {
         if(this.id == id) {
             this.optButton.prop('disabled', false);
         }
-    }
+    };
 
     Compiler.prototype.updateButtons = function () {
         if (!this.compiler) return;
@@ -541,9 +541,10 @@ define(function (require) {
             this.colours = colour.applyColours(this.outputEditor, asmColours, scheme, this.colours);
         }
     };
+
     Compiler.prototype.getCompilerName = function() {
         return this.compiler ? this.compiler.name : "no compiler set";
-    }
+    };
 
     Compiler.prototype.updateCompilerName = function () {
         var compilerName = this.getCompilerName();

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -76,6 +76,7 @@ define(function (require) {
 
         this.decorations = {};
         this.prevDecorations = [];
+        this.optButton = this.domRoot.find('.btn.view-optimization');
 
         this.domRoot.find(".compiler-picker").selectize({
             sortField: 'name',
@@ -192,13 +193,27 @@ define(function (require) {
                 componentState: self.currentState()
             };
         }
+        function createOptView() {
+            return Components.getOptViewWith(self.id, self.source, self.lastResult.optOutput);
+        }
+
 
         this.container.layoutManager.createDragSource(
             this.domRoot.find('.btn.add-compiler'), cloneComponent);
+            
         this.domRoot.find('.btn.add-compiler').click(_.bind(function () {
             var insertPoint = hub.findParentRowOrColumn(this.container) ||
                 this.container.layoutManager.root.contentItems[0];
             insertPoint.addChild(cloneComponent());
+        }, this));
+
+        this.container.layoutManager.createDragSource(
+            this.domRoot.optButton, createOptView.bind(this));
+
+        this.optButton.click(_.bind(function () {
+            var insertPoint = hub.findParentRowOrColumn(this.container) ||
+                this.container.layoutManager.root.contentItems[0];
+            insertPoint.addChild(createOptView());
         }, this));
 
         this.saveState();
@@ -385,6 +400,7 @@ define(function (require) {
         status.toggleClass('error', failed);
         status.toggleClass('warning', warns);
         status.parent().attr('title', allText);
+        this.optButton.toggleClass("hidden", !result.hasOptOutput);
         var compileTime = this.domRoot.find('.compile-time');
         if (cached) {
             compileTime.text("- cached");

--- a/static/components.js
+++ b/static/components.js
@@ -73,6 +73,13 @@ define(function (require) {
                 componentName: 'diff',
                 componentState: {}
             };
+        },
+        getOptViewWith: function (id, source, optimization) {
+            return {
+                type: 'component',
+                componentName: 'opt',
+                componentState: {id: id, source: source, optOutput: optimization}
+            };
         }
     };
 

--- a/static/components.js
+++ b/static/components.js
@@ -74,11 +74,18 @@ define(function (require) {
                 componentState: {}
             };
         },
-        getOptViewWith: function (id, source, optimization) {
+        getOptView: function() {
             return {
                 type: 'component',
                 componentName: 'opt',
-                componentState: {id: id, source: source, optOutput: optimization}
+                componentState: {}
+            };
+        },
+        getOptViewWith: function (id, source, optimization, compilerName, editorid) {
+            return {
+                type: 'component',
+                componentName: 'opt',
+                componentState: {id: id, source: source, optOutput: optimization, compilerName: compilerName, editorid: editorid}
             };
         }
     };

--- a/static/explorer.css
+++ b/static/explorer.css
@@ -235,3 +235,21 @@ pre.content {
     background-color: gray;
     color: black;
 }
+
+
+.opt-decoration {
+	width: 8px !important;
+	left: 3px;
+}
+
+.analysis,
+.mixed {
+    background: #fdfd96;
+}
+
+.passed {
+    background: #77dd77;
+}
+.missed {
+    background: #ff6961;
+}

--- a/static/hub.js
+++ b/static/hub.js
@@ -78,7 +78,7 @@ define(function (require) {
             function (container, state) {
                 return self.diffFactory(container, state);
             });
-        layout.registerComponent(optView.getComponent().componentName,
+        layout.registerComponent(Components.getOptView().componentName,
             function (container, state) {
                 return self.optViewFactory(container, state);
             });
@@ -126,8 +126,7 @@ define(function (require) {
     Hub.prototype.optViewFactory = function (container, state) {
         return new optView.Opt(this, container, state);
     };
-
-
+    
     function WrappedEventHub(eventHub) {
         this.eventHub = eventHub;
         this.subscriptions = [];

--- a/static/hub.js
+++ b/static/hub.js
@@ -33,6 +33,7 @@ define(function (require) {
     var output = require('output');
     var Components = require('components');
     var diff = require('diff');
+    var optView = require('opt-view');
 
     function Ids() {
         this.used = {};
@@ -77,6 +78,10 @@ define(function (require) {
             function (container, state) {
                 return self.diffFactory(container, state);
             });
+        layout.registerComponent(optView.getComponent().componentName,
+            function (container, state) {
+                return self.optViewFactory(container, state);
+            });
 
         layout.eventHub.on('editorOpen', function (id) {
             this.editorIds.add(id);
@@ -118,6 +123,10 @@ define(function (require) {
     Hub.prototype.diffFactory = function (container, state) {
         return new diff.Diff(this, container, state);
     };
+    Hub.prototype.optViewFactory = function (container, state) {
+        return new optView.Opt(this, container, state);
+    };
+
 
     function WrappedEventHub(eventHub) {
         this.eventHub = eventHub;

--- a/static/main.js
+++ b/static/main.js
@@ -181,7 +181,6 @@ define(function (require) {
         setupAdd($('#add-editor'), function () {
             return Components.getEditor();
         });
-
         $('#ui-reset').click(function () {
             local.remove('gl');
             window.location.reload();

--- a/static/opt-view.js
+++ b/static/opt-view.js
@@ -1,0 +1,158 @@
+// Copyright (c) 2012-2017, Jared Wyles
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+define(function (require) {
+    "use strict";
+
+    var FontScale = require('fontscale');
+    var monaco = require('monaco');
+    var options = require('options');
+    var hoverContent = {};
+
+    monaco.languages.registerHoverProvider('cpp', {
+	    provideHover: function(model, position) {
+            if(hoverContent[position.lineNumber]) {
+                return {
+                    range: new monaco.Range(1, 1, position.lineNumber, model.getLineMaxColumn(position.lineNumber)),
+				    contents: hoverContent[position.lineNumber]
+                }
+            }
+        }
+    });
+
+    require('asm-mode');
+    require('selectize');
+
+    function Opt(hub, container, state) {
+        this.container = container;
+        this.eventHub = hub.createEventHub();
+        this.domRoot = container.getElement();
+        this.domRoot.html($('#opt').html());
+        this.compilers = {};
+        this.optEditor = monaco.editor.create(this.domRoot.find(".monaco-placeholder")[0], {
+            value: state.source || "",
+            scrollBeyondLastLine: false,
+            language: 'cpp', //we only support cpp for now
+            readOnly: true,
+            glyphMargin: true,
+            quickSuggestions: false,
+            fixedOverflowWidgets: true
+        });
+
+        this.fontScale = new FontScale(this.domRoot, state, this.optEditor);
+        this.fontScale.on('change', _.bind(this.updateState, this));
+
+        this.eventHub.on('compileResult', this.onCompileResult, this);
+        this.eventHub.on('compiler', this.onCompiler, this);
+        this.eventHub.on('compilerClose', this.onCompilerClose, this);
+        this.eventHub.on('editorChange', this.onEditorChange, this);
+
+
+        this.container.on('destroy', function () {
+            this.eventHub.unsubscribe();
+            this.optEditor.dispose();
+        }, this);
+        container.on('resize', this.resize, this);
+        container.on('shown', this.resize, this);
+        if(state && state.optOutput) {
+              this.showOptResults(state.optOutput);
+        }
+    }
+
+    // TODO: de-dupe with compiler etc
+    Opt.prototype.resize = function () {
+        var topBarHeight = this.domRoot.find(".top-bar").outerHeight(true);
+        this.optEditor.layout({
+            width: this.domRoot.width(),
+            height: this.domRoot.height() - topBarHeight
+        });
+    };
+    Opt.prototype.onEditorChange = function(id, source) {
+        this.optEditor.setValue(source);
+    }
+    Opt.prototype.onCompileResult = function (id, compiler, result) {
+        if(result.hasOptOutput) {
+            this.showOptResults(result.optOutput);
+        }
+    };
+    Opt.prototype.getDisplayableOpt = function (optResult) {
+       return "**" + optResult.optType + "** - " + optResult.displayString;
+    }
+    Opt.prototype.showOptResults = function(results) {
+        var opt = [],
+            hasPassed = false;
+
+        hoverContent = {};
+        results = _.groupBy(results, function(x) {
+            return x.DebugLoc.Line;
+        });
+        _.mapObject(results, function(value, key) {
+            var linenumber = Number(key);
+            var className = value.reduce(function(acc, x) {
+                if(acc && acc !== "Analysis" && x.optType !== acc) {
+                    return "Mixed";
+                } else {
+                    return x.optType;
+                }
+            },"");
+            opt.push({
+                range: new monaco.Range(linenumber,1,linenumber,1), 
+                options: { 
+                    isWholeLine: true, 
+                    glyphMarginClassName: "opt-decoration." + className.toLowerCase()
+                }
+            });
+            hoverContent[linenumber] = value.map(function(x) {
+                return this.getDisplayableOpt(x);
+            }, this);
+        }, this);
+        
+        this.optEditor.deltaDecorations([], opt);
+    }
+
+
+    Opt.prototype.onCompiler = function (id, compiler, options, editorId) {
+    
+    };
+
+    Opt.prototype.onCompilerClose = function (id) {
+        delete this.compilers[id];
+    };
+
+
+    Opt.prototype.updateState = function () {
+    };
+
+    return {
+        Opt: Opt,
+        getComponent: function (lhs, rhs) {
+            return {
+                type: 'component',
+                componentName: 'opt',
+                componentState: { },
+            };
+        }
+    };
+});

--- a/static/opt-view.js
+++ b/static/opt-view.js
@@ -106,7 +106,8 @@ define(function (require) {
     };
     Opt.prototype.setTitle = function () {
           this.container.setTitle(this._compilerName + " (Editor #" + this._editorid + ", Compiler #" + this._compilerid + ")");
-    }
+    };
+
     Opt.prototype.getDisplayableOpt = function (optResult) {
        return "**" + optResult.optType + "** - " + optResult.displayString;
     };
@@ -163,5 +164,5 @@ define(function (require) {
 
     return {
         Opt: Opt
-    }
+    };
 });

--- a/static/opt-view.js
+++ b/static/opt-view.js
@@ -37,7 +37,7 @@ define(function (require) {
                 return {
                     range: new monaco.Range(1, 1, position.lineNumber, model.getLineMaxColumn(position.lineNumber)),
 				    contents: hoverContent[position.lineNumber]
-                }
+                };
             }
         }
     });
@@ -91,7 +91,7 @@ define(function (require) {
     };
     Opt.prototype.onEditorChange = function(id, source) {
         this.optEditor.setValue(source);
-    }
+    };
     Opt.prototype.onCompileResult = function (id, compiler, result) {
         if(result.hasOptOutput) {
             this.showOptResults(result.optOutput);
@@ -99,7 +99,7 @@ define(function (require) {
     };
     Opt.prototype.getDisplayableOpt = function (optResult) {
        return "**" + optResult.optType + "** - " + optResult.displayString;
-    }
+    };
     Opt.prototype.showOptResults = function(results) {
         var opt = [],
             hasPassed = false;
@@ -130,7 +130,7 @@ define(function (require) {
         }, this);
         
         this.optEditor.deltaDecorations([], opt);
-    }
+    };
 
 
     Opt.prototype.onCompiler = function (id, compiler, options, editorId) {

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -34,7 +34,7 @@
         .btn-group.btn-group-sm
           button.btn.btn-default.btn-sm.add-compiler(title="Clone this compiler window (click or drag)")
             span.glyphicon.glyphicon-new-window
-          button.btn.btn-default.btn-sm.view-optimization.hidden(title="View the results from the optimizer")
+          button.btn.btn-default.btn-sm.view-optimization(title="Show optimization output (Clang only)" disabled=true)
             span.glyphicon.glyphicon-scale
     .monaco-placeholder
     .bottom-bar

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -34,6 +34,8 @@
         .btn-group.btn-group-sm
           button.btn.btn-default.btn-sm.add-compiler(title="Clone this compiler window (click or drag)")
             span.glyphicon.glyphicon-new-window
+          button.btn.btn-default.btn-sm.view-optimization.hidden(title="View the results from the optimizer")
+            span.glyphicon.glyphicon-scale
     .monaco-placeholder
     .bottom-bar
       if !embedded
@@ -54,3 +56,8 @@
           td: select.diff-picker.lhs(placeholder="Select compiler output...")
           td: select.diff-picker.rhs(placeholder="Select compiler output...")
     .monaco-placeholder
+  
+    #opt
+      .top-bar.btn-toolbar(role="toolbar")
+        include font-size.pug
+      .monaco-placeholder


### PR DESCRIPTION
WIP: But the code structure should largely be unchanged.
This closes out #332 

- [ ] There are two todos I want to address. [deferred] 
- [x] A couple of bugs I need to look at.
    - [x] Change the title of the tab view
- [x] Look into the cache, it is doing strange things.
   - this actually turned out to be unrelated. It looks like im getting 2 on compileResults on load
- [x] Make the button a toggle, currently it just keeps opening editors, this isn’t much use to anyone.
- [x] Just check it works with two versions of clang (i need to install another version locally)
- [x] Why am I getting 2 compileResults events (this seems to be due to some cache higher up).  https://github.com/mattgodbolt/compiler-explorer/issues/394 


This should hopefully work now, if there are any problems let me know.

I usually use code from to test it out. 

https://github.com/llvm-mirror/test-suite/tree/master/SingleSource/Benchmarks