### PR TITLE
For now lets just rip out anything that doesn't have a debugloc

### DIFF
--- a/static/opt-view.js
+++ b/static/opt-view.js
@@ -118,7 +118,10 @@ define(function (require) {
         var opt = [];
 
         hoverContent = {};
-
+        results = _.filter(results, function(x) {
+            return x.DebugLoc !== undefined;
+        });
+        
         results = _.groupBy(results, function(x) {
             return x.DebugLoc.Line;
         });


### PR DESCRIPTION
I can't really display it, so for now we just ignore them.

this fixes https://github.com/mattgodbolt/compiler-explorer/issues/409

