### PR TITLE
Improved the hover message

### DIFF
--- a/static/compiler.js
+++ b/static/compiler.js
@@ -696,7 +696,7 @@ define(function (require) {
                             range: e.target.range,
                             options: {
                                 isWholeLine: false,
-                                hoverMessage: [response.tooltip + " More information available in the context menu."]
+                                hoverMessage: [response.tooltip + "\n\nMore information available in the context menu."]
                             }
                         };
                         this.updateDecorations();


### PR DESCRIPTION
Added new lines before the string that gets appended to the hover message of asm docs to make it more explicit and to separate it from the doc message itself.