### PR TITLE
Support displaying the Clang AST

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -61,6 +61,9 @@ Compile.prototype.couldHaveOptOutput = function (options, version) {
     return version.toLowerCase().indexOf("clang") > -1 &&
         options.some((x) => x == "-fsave-optimization-record");
 };
+Compile.prototype.couldHaveASTOutput = function (options, version) {
+    return version.toLowerCase().indexOf("clang") > -1;
+};
 
 Compile.prototype.getRemote = function () {
     if (this.compiler.exe === null && this.compiler.remote)
@@ -73,13 +76,17 @@ Compile.prototype.exec = function (compiler, args, options) {
     return exec.execute(compiler, args, options);
 };
 
-Compile.prototype.runCompiler = function (compiler, options, inputFilename) {
-    return this.exec(compiler, options, {
-        timeoutMs: this.env.gccProps("compileTimeoutMs", 100),
-        maxErrorOutput: this.env.gccProps("max-error-output", 5000),
-        env: this.env.getEnv(this.compiler.needsMulti),
-        wrapper: this.env.compilerProps("compiler-wrapper")
-    }).then(function (result) {
+Compile.prototype.runCompiler = function (compiler, options, inputFilename, execOptions) {
+    if (typeof(execOptions)==='undefined') {
+        execOptions = {
+            timeoutMs: this.env.gccProps("compileTimeoutMs", 100),
+            maxErrorOutput: this.env.gccProps("max-error-output", 5000),
+            env: this.env.getEnv(this.compiler.needsMulti),
+            wrapper: this.env.compilerProps("compiler-wrapper")
+        }
+    }
+    
+    return this.exec(compiler, options, execOptions).then(function (result) {
         result.stdout = utils.parseOutput(result.stdout, inputFilename);
         result.stderr = utils.parseOutput(result.stderr, inputFilename);
         return result;
@@ -146,6 +153,20 @@ Compile.prototype.prepareArguments = function (userOptions, filters, inputFilena
     return options.concat(userOptions || []).concat([this.filename(inputFilename)]);
 };
 
+Compile.prototype.generateAST = function(inputFilename, options) {
+    var newOptions = options.concat(["-Xclang", "-ast-dump"]);
+
+    execOptions = {
+        timeoutMs: this.env.gccProps("compileTimeoutMs", 100),
+        maxErrorOutput: this.env.gccProps("max-error-output", 5000),
+        env: this.env.getEnv(this.compiler.needsMulti),
+        wrapper: this.env.compilerProps("compiler-wrapper"),
+        maxOutput: 1024*1024*1024
+    }
+    
+    return this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions);
+}
+
 Compile.prototype.compile = function (source, options, filters) {
     var self = this;
     var optionsError = self.checkOptions(options);
@@ -185,22 +206,32 @@ Compile.prototype.compile = function (source, options, filters) {
             options = self.prepareArguments(options, filters, inputFilename, outputFilename);
 
             options = options.filter(_.identity);
-            return self.runCompiler(self.compiler.exe, options, self.filename(inputFilename))
-                .then(function (result) {
-                    result.dirPath = dirPath;
-                    if (result.code !== 0) {
-                        result.asm = "<Compilation failed>";
-                        return result;
+
+            var asmPromise = self.runCompiler(self.compiler.exe, options, self.filename(inputFilename))
+            var astPromise = self.generateAST(inputFilename, options)
+            
+            return Promise.all([asmPromise, astPromise])
+                .then(function (results) {
+                    var asmResult = results[0];
+                    var astResult = results[1];
+
+                    asmResult.dirPath = dirPath;
+                    if (asmResult.code !== 0) {
+                        asmResult.asm = "<Compilation failed>";
+                        return asmResult;
                     }
-                    result.hasOptOutput = false;
+                    asmResult.hasOptOutput = false;
                     if (self.couldHaveOptOutput(options, self.compiler.version)) {
                         const optPath = path.join(dirPath, outputFilebase + ".opt.yaml");
                         if (fs.existsSync(optPath)) {
-                            result.hasOptOutput = true;
-                            result.optPath = optPath;
+                            asmResult.hasOptOutput = true;
+                            asmResult.optPath = optPath;
                         }
                     }
-                    return self.postProcess(result, outputFilename, filters);
+                    asmResult.hasAstOutput = true;
+                    asmResult.astOutput = astResult.stdout;
+                    
+                    return self.postProcess(asmResult, outputFilename, filters);
                 });
         });
 
@@ -251,6 +282,7 @@ Compile.prototype.postProcessAsm = function (result) {
         });
 };
 
+
 Compile.prototype.processOptOutput = function (hasOptOutput, optPath) {
     var output = [];
     return new Promise(
@@ -267,6 +299,51 @@ Compile.prototype.processOptOutput = function (hasOptOutput, optPath) {
 };
 
 
+Compile.prototype.processAstOutput = function (output) {
+    output = output.map(function(x) { return x.text; });
+
+    var topLevelRegex = /^(\||`)-/;
+    var sourceRegex = /<source>/;
+    var lineRegex = /<line:/;
+
+    var mostRecentIsSource = false;
+
+    console.log(output);
+
+    for (var i = 0; i < output.length; ++i) {
+        if (output[i].match(topLevelRegex)) {
+            if (output[i].match(lineRegex) && mostRecentIsSource) {
+                //do nothing
+            }
+            else if (!output[i].match(sourceRegex)) {
+                var spliceMax = i+1;
+                while (output[spliceMax] && !output[spliceMax].match(topLevelRegex)) {
+                    spliceMax++;
+                }
+                output.splice(i, spliceMax-i);
+                --i;
+                mostRecentIsSource = false;
+            }
+            else {
+                mostRecentIsSource = true;
+            }
+        }
+    }
+
+    output = output.join('\n');
+    
+    var addressRegex = /^([^A-Za-z]*[A-Za-z]+) 0x[a-z0-9]+/mg;
+    output = output.replace(addressRegex, '$1');
+
+    var slocRegex = / ?<?<invalid sloc>>?/g;
+    output = output.replace(slocRegex, '');
+
+    var sourceRegex = /<source>/g;
+    output = output.replace(sourceRegex, 'line');    
+
+    return output;
+}
+
 Compile.prototype.postProcess = function (result, outputFilename, filters) {
     var postProcess = this.compiler.postProcess.filter(_.identity);
     var maxSize = this.env.gccProps("max-asm-size", 8 * 1024 * 1024);
@@ -276,6 +353,11 @@ Compile.prototype.postProcess = function (result, outputFilename, filters) {
     } else {
         optPromise = Promise.resolve("");
     }
+
+    if (result.hasAstOutput) {
+        result.astOutput = this.processAstOutput(result.astOutput);
+    }
+    
     if (filters.binary && this.supportsObjdump()) {
         asmPromise = this.objdump(outputFilename, result, maxSize, filters.intel);
     } else {

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -83,7 +83,7 @@ Compile.prototype.runCompiler = function (compiler, options, inputFilename, exec
             maxErrorOutput: this.env.gccProps("max-error-output", 5000),
             env: this.env.getEnv(this.compiler.needsMulti),
             wrapper: this.env.compilerProps("compiler-wrapper")
-        }
+        };
     }
     
     return this.exec(compiler, options, execOptions).then(function (result) {
@@ -162,10 +162,10 @@ Compile.prototype.generateAST = function(inputFilename, options) {
         env: this.env.getEnv(this.compiler.needsMulti),
         wrapper: this.env.compilerProps("compiler-wrapper"),
         maxOutput: 1024*1024*1024
-    }
+    };
     
     return this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions);
-}
+};
 
 Compile.prototype.compile = function (source, options, filters) {
     var self = this;
@@ -207,8 +207,8 @@ Compile.prototype.compile = function (source, options, filters) {
 
             options = options.filter(_.identity);
 
-            var asmPromise = self.runCompiler(self.compiler.exe, options, self.filename(inputFilename))
-            var astPromise = self.generateAST(inputFilename, options)
+            var asmPromise = self.runCompiler(self.compiler.exe, options, self.filename(inputFilename));
+            var astPromise = self.generateAST(inputFilename, options);
             
             return Promise.all([asmPromise, astPromise])
                 .then(function (results) {
@@ -303,7 +303,7 @@ Compile.prototype.processAstOutput = function (output) {
     output = output.map(function(x) { return x.text; });
 
     var topLevelRegex = /^(\||`)-/;
-    var sourceRegex = /<source>/;
+    var sourceRegex = /<source>/g;
     var lineRegex = /<line:/;
 
     var mostRecentIsSource = false;
@@ -338,11 +338,10 @@ Compile.prototype.processAstOutput = function (output) {
     var slocRegex = / ?<?<invalid sloc>>?/g;
     output = output.replace(slocRegex, '');
 
-    var sourceRegex = /<source>/g;
     output = output.replace(sourceRegex, 'line');    
 
     return output;
-}
+};
 
 Compile.prototype.postProcess = function (result, outputFilename, filters) {
     var postProcess = this.compiler.postProcess.filter(_.identity);

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -83,7 +83,7 @@ Compile.prototype.getDefaultExecOptions = function () {
         env: this.env.getEnv(this.compiler.needsMulti),
         wrapper: this.env.compilerProps("compiler-wrapper")
     };
-}
+};
 
 Compile.prototype.runCompiler = function (compiler, options, inputFilename, execOptions) {
     if (!execOptions) {

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -61,9 +61,6 @@ Compile.prototype.couldHaveOptOutput = function (options, version) {
     return version.toLowerCase().indexOf("clang") > -1 &&
         options.some((x) => x == "-fsave-optimization-record");
 };
-Compile.prototype.couldHaveASTOutput = function (options, version) {
-    return version.toLowerCase().indexOf("clang") > -1;
-};
 
 Compile.prototype.getRemote = function () {
     if (this.compiler.exe === null && this.compiler.remote)

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -76,14 +76,18 @@ Compile.prototype.exec = function (compiler, args, options) {
     return exec.execute(compiler, args, options);
 };
 
+Compile.prototype.getDefaultExecOptions = function () {
+    return {
+        timeoutMs: this.env.gccProps("compileTimeoutMs", 100),
+        maxErrorOutput: this.env.gccProps("max-error-output", 5000),
+        env: this.env.getEnv(this.compiler.needsMulti),
+        wrapper: this.env.compilerProps("compiler-wrapper")
+    };
+}
+
 Compile.prototype.runCompiler = function (compiler, options, inputFilename, execOptions) {
-    if (typeof(execOptions)==='undefined') {
-        execOptions = {
-            timeoutMs: this.env.gccProps("compileTimeoutMs", 100),
-            maxErrorOutput: this.env.gccProps("max-error-output", 5000),
-            env: this.env.getEnv(this.compiler.needsMulti),
-            wrapper: this.env.compilerProps("compiler-wrapper")
-        };
+    if (!execOptions) {
+        execOptions = this.getDefaultExecOptions();
     }
     
     return this.exec(compiler, options, execOptions).then(function (result) {
@@ -157,14 +161,10 @@ Compile.prototype.generateAST = function(inputFilename, options) {
     // These options make Clang produce an AST dump
     var newOptions = options.concat(["-Xclang", "-ast-dump", "-fsyntax-only"]);
 
-    execOptions = {
-        timeoutMs: this.env.gccProps("compileTimeoutMs", 100),
-        maxErrorOutput: this.env.gccProps("max-error-output", 5000),
-        env: this.env.getEnv(this.compiler.needsMulti),
-        wrapper: this.env.compilerProps("compiler-wrapper"),
-        maxOutput: 1024*1024*1024 // A higher max output is needed for when the user includes headers
-    };
-    
+    execOptions = this.getDefaultExecOptions();
+    // A higher max output is needed for when the user includes headers
+    execOptions.maxOutput = 1024*1024*1024 ;
+
     return this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions);
 };
 

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -180,8 +180,14 @@ Compile.prototype.compile = function (source, options, backendOptions, filters) 
         delete filters.binary;
     }
 
-    var key = JSON.stringify({compiler: this.compiler, source: source, options: options,
-                              backendOptions: backendOptions, filters: filters});
+    var key = JSON.stringify({
+        compiler: this.compiler,
+        source: source,
+        options: options,
+        backendOptions: backendOptions,
+        filters: filters
+    });
+
     var cached = this.env.cacheGet(key);
     if (cached) {
         return Promise.resolve(cached);

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -308,9 +308,7 @@ Compile.prototype.processAstOutput = function (output) {
 
     var mostRecentIsSource = false;
 
-    console.log(output);
-
-    for (var i = 0; i < output.length; ++i) {
+      for (var i = 0; i < output.length; ++i) {
         if (output[i].match(topLevelRegex)) {
             if (output[i].match(lineRegex) && mostRecentIsSource) {
                 //do nothing

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -154,6 +154,7 @@ Compile.prototype.prepareArguments = function (userOptions, filters, inputFilena
 };
 
 Compile.prototype.generateAST = function(inputFilename, options) {
+    // These options make Clang produce an AST dump
     var newOptions = options.concat(["-Xclang", "-ast-dump"]);
 
     execOptions = {
@@ -161,13 +162,13 @@ Compile.prototype.generateAST = function(inputFilename, options) {
         maxErrorOutput: this.env.gccProps("max-error-output", 5000),
         env: this.env.getEnv(this.compiler.needsMulti),
         wrapper: this.env.compilerProps("compiler-wrapper"),
-        maxOutput: 1024*1024*1024
+        maxOutput: 1024*1024*1024 // A higher max output is needed for when the user includes headers
     };
     
     return this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions);
 };
 
-Compile.prototype.compile = function (source, options, filters) {
+Compile.prototype.compile = function (source, options, backendOptions, filters) {
     var self = this;
     var optionsError = self.checkOptions(options);
     if (optionsError) return Promise.reject(optionsError);
@@ -179,7 +180,8 @@ Compile.prototype.compile = function (source, options, filters) {
         delete filters.binary;
     }
 
-    var key = JSON.stringify({compiler: this.compiler, source: source, options: options, filters: filters});
+    var key = JSON.stringify({compiler: this.compiler, source: source, options: options,
+                              backendOptions: backendOptions, filters: filters});
     var cached = this.env.cacheGet(key);
     if (cached) {
         return Promise.resolve(cached);
@@ -208,7 +210,14 @@ Compile.prototype.compile = function (source, options, filters) {
             options = options.filter(_.identity);
 
             var asmPromise = self.runCompiler(self.compiler.exe, options, self.filename(inputFilename));
-            var astPromise = self.generateAST(inputFilename, options);
+
+            var astPromise;
+            if (backendOptions.produceAst) {
+                astPromise = self.generateAST(inputFilename, options);
+            }
+            else {
+                astPromise = Promise.resolve("");
+            }
             
             return Promise.all([asmPromise, astPromise])
                 .then(function (results) {
@@ -228,8 +237,10 @@ Compile.prototype.compile = function (source, options, filters) {
                             asmResult.optPath = optPath;
                         }
                     }
-                    asmResult.hasAstOutput = true;
-                    asmResult.astOutput = astResult.stdout;
+                    if (astResult) {
+                        asmResult.hasAstOutput = true;
+                        asmResult.astOutput = astResult.stdout;
+                    }
                     
                     return self.postProcess(asmResult, outputFilename, filters);
                 });
@@ -302,17 +313,24 @@ Compile.prototype.processOptOutput = function (hasOptOutput, optPath) {
 Compile.prototype.processAstOutput = function (output) {
     output = output.map(function(x) { return x.text; });
 
+    // Top level decls start with |- or `-
     var topLevelRegex = /^(\||`)-/;
+
+    // Refers to the user's source file rather than a system header
     var sourceRegex = /<source>/g;
+
+    // Refers to whatever the most recent file specified was
     var lineRegex = /<line:/;
 
     var mostRecentIsSource = false;
 
-      for (var i = 0; i < output.length; ++i) {
+    // Remove all AST nodes which aren't directly from the user's source code
+    for (var i = 0; i < output.length; ++i) {
         if (output[i].match(topLevelRegex)) {
             if (output[i].match(lineRegex) && mostRecentIsSource) {
                 //do nothing
             }
+            // This is a system header, remove everything up to the next top level decl
             else if (!output[i].match(sourceRegex)) {
                 var spliceMax = i+1;
                 while (output[spliceMax] && !output[spliceMax].match(topLevelRegex)) {
@@ -329,13 +347,16 @@ Compile.prototype.processAstOutput = function (output) {
     }
 
     output = output.join('\n');
-    
+
+    // Filter out the symbol addresses
     var addressRegex = /^([^A-Za-z]*[A-Za-z]+) 0x[a-z0-9]+/mg;
     output = output.replace(addressRegex, '$1');
 
+    // Filter out <invalid sloc> and <<invalid sloc>>
     var slocRegex = / ?<?<invalid sloc>>?/g;
     output = output.replace(slocRegex, '');
 
+    // Unify file references
     output = output.replace(sourceRegex, 'line');    
 
     return output;

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -155,7 +155,7 @@ Compile.prototype.prepareArguments = function (userOptions, filters, inputFilena
 
 Compile.prototype.generateAST = function(inputFilename, options) {
     // These options make Clang produce an AST dump
-    var newOptions = options.concat(["-Xclang", "-ast-dump"]);
+    var newOptions = options.concat(["-Xclang", "-ast-dump", "-fsyntax-only"]);
 
     execOptions = {
         timeoutMs: this.env.gccProps("compileTimeoutMs", 100),

--- a/lib/compile-handler.js
+++ b/lib/compile-handler.js
@@ -96,6 +96,7 @@ function CompileHandler(gccProps, compilerProps) {
             if (!compiler) return next();
             source = req.body.source;
             options = req.body.options;
+            backendOptions = req.body.backendOptions;
             filters = req.body.filters || compiler.getDefaultFilters();
         } else {
             // API-style
@@ -144,7 +145,7 @@ function CompileHandler(gccProps, compilerProps) {
             return _.pluck(array || [], 'text').join("\n");
         }
 
-        compiler.compile(source, options, filters).then(
+        compiler.compile(source, options, backendOptions, filters).then(
             function (result) {
                 if (req.accepts(['text', 'json']) === 'json') {
                     res.set('Content-Type', 'application/json');

--- a/static/ast-view.js
+++ b/static/ast-view.js
@@ -41,7 +41,7 @@ define(function (require) {
         this.compilers = {};
         this._currentDecorations = [];
         this.astEditor = monaco.editor.create(this.domRoot.find(".monaco-placeholder")[0], {
-            value: state.source || "",
+            value: "",
             scrollBeyondLastLine: false,
             language: 'cpp', //we only support cpp for now
             readOnly: true,

--- a/static/ast-view.js
+++ b/static/ast-view.js
@@ -62,6 +62,7 @@ define(function (require) {
         this.eventHub.on('editorChange', this.onEditorChange, this);
         this.eventHub.on('themeChange', this.onThemeChange, this);
         this.eventHub.emit('requestTheme');
+        this.eventHub.emit('astViewOpened', this._compilerid);
 
         this.container.on('destroy', function () {
             this.eventHub.emit("astViewClosed", this._compilerid);

--- a/static/ast-view.js
+++ b/static/ast-view.js
@@ -87,10 +87,8 @@ define(function (require) {
     };
 
     Ast.prototype.onEditorChange = function(id, source) {
-        if (this._editorid == id) {
-            //this.astEditor.setValue(source);
-        }
     };
+    
     Ast.prototype.onCompileResult = function (id, compiler, result) {
         if(result.hasAstOutput && this._compilerid == id) {
             this.showAstResults(result.astOutput);

--- a/static/ast-view.js
+++ b/static/ast-view.js
@@ -89,10 +89,13 @@ define(function (require) {
 
     Ast.prototype.onEditorChange = function(id, source) {
     };
-    
+
     Ast.prototype.onCompileResult = function (id, compiler, result) {
         if(result.hasAstOutput && this._compilerid == id) {
             this.showAstResults(result.astOutput);
+        }
+        else {
+            this.showAstResults("AST output is only supported in Clang >= 3.3");
         }
     };
     Ast.prototype.setTitle = function () {

--- a/static/ast-view.js
+++ b/static/ast-view.js
@@ -1,0 +1,136 @@
+// Copyright (c) 2012-2017, Simon Brand
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+define(function (require) {
+    "use strict";
+
+    var FontScale = require('fontscale');
+    var monaco = require('monaco');
+    var options = require('options');
+
+    require('asm-mode');
+    require('selectize');
+
+    function Ast(hub, container, state) {
+        this.container = container;
+        this.eventHub = hub.createEventHub();
+        this.domRoot = container.getElement();
+        this.domRoot.html($('#ast').html());
+        this.compilers = {};
+        this._currentDecorations = [];
+        this.astEditor = monaco.editor.create(this.domRoot.find(".monaco-placeholder")[0], {
+            value: state.source || "",
+            scrollBeyondLastLine: false,
+            language: 'cpp', //we only support cpp for now
+            readOnly: true,
+            glyphMargin: true,
+            quickSuggestions: false,
+            fixedOverflowWidgets: true
+        });
+
+        this._compilerid = state.id;
+        this._compilerName = state.compilerName;
+        this._editorid = state.editorid;
+        this.fontScale = new FontScale(this.domRoot, state, this.astEditor);
+        this.fontScale.on('change', _.bind(this.updateState, this));
+
+        this.eventHub.on('compileResult', this.onCompileResult, this);
+        this.eventHub.on('compiler', this.onCompiler, this);
+        this.eventHub.on('compilerClose', this.onCompilerClose, this);
+        this.eventHub.on('editorChange', this.onEditorChange, this);
+        this.eventHub.on('themeChange', this.onThemeChange, this);
+        this.eventHub.emit('requestTheme');
+
+        this.container.on('destroy', function () {
+            this.eventHub.emit("astViewClosed", this._compilerid);
+            this.eventHub.unsubscribe();
+            this.astEditor.dispose();
+        }, this);
+
+        container.on('resize', this.resize, this);
+        container.on('shown', this.resize, this);
+        if(state && state.astOutput) {
+              this.showAstResults(state.astOutput);
+        }
+        this.setTitle();
+    }
+
+    // TODO: de-dupe with compiler etc
+    Ast.prototype.resize = function () {
+        var topBarHeight = this.domRoot.find(".top-bar").outerHeight(true);
+        this.astEditor.layout({
+            width: this.domRoot.width(),
+            height: this.domRoot.height() - topBarHeight
+        });
+    };
+
+    Ast.prototype.onEditorChange = function(id, source) {
+        if (this._editorid == id) {
+            //this.astEditor.setValue(source);
+        }
+    };
+    Ast.prototype.onCompileResult = function (id, compiler, result) {
+        if(result.hasAstOutput && this._compilerid == id) {
+            this.showAstResults(result.astOutput);
+        }
+    };
+    Ast.prototype.setTitle = function () {
+          this.container.setTitle(this._compilerName + " Ast Viewer (Editor #" + this._editorid + ", Compiler #" + this._compilerid + ")");
+    };
+
+    Ast.prototype.getDisplayableAst = function (astResult) {
+       return "**" + astResult.astType + "** - " + astResult.displayString;
+    };
+
+    Ast.prototype.showAstResults = function(results) {
+        this.astEditor.setValue(results);
+    };
+
+    Ast.prototype.onCompiler = function (id, compiler, options, editorid) {
+        if(id == this._compilerid) {
+            this._compilerName = compiler.name;
+            this._editorid = editorid;
+            this.setTitle();
+        }
+    };
+
+    Ast.prototype.onCompilerClose = function (id) {
+        delete this.compilers[id];
+    };
+
+    Ast.prototype.onThemeChange = function (newTheme) {
+        if (this.astEditor) {
+            this.astEditor.updateOptions({theme: newTheme.monaco});
+        }
+    };
+
+
+    Ast.prototype.updateState = function () {
+    };
+
+    return {
+        Ast: Ast
+    };
+});

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -198,6 +198,7 @@ define(function (require) {
         this.eventHub.on('settingsChange', this.onSettingsChange, this);
         this.eventHub.on('themeChange', this.onThemeChange, this);
         this.eventHub.on('optViewClosed', this.onOptViewClosed, this);
+        this.eventHub.on('astViewClosed', this.onAstViewClosed, this);        
         this.eventHub.emit('requestSettings');
         this.eventHub.emit('requestTheme');
         this.sendCompiler();
@@ -253,7 +254,9 @@ define(function (require) {
         this.astButton.click(_.bind(function () {
             var insertPoint = hub.findParentRowOrColumn(this.container) ||
                 this.container.layoutManager.root.contentItems[0];
+            this.produceAst = true;
             insertPoint.addChild(createAstView());
+            this.astButton.prop("disabled", true);            
         }, this));        
 
         this.saveState();
@@ -290,6 +293,7 @@ define(function (require) {
             source: this.source || "",
             compiler: this.compiler ? this.compiler.id : "",
             options: this.options,
+            backendOptions: { produceAst: this.produceAst },
             filters: this.getEffectiveFilters()
         };
 
@@ -517,7 +521,8 @@ define(function (require) {
     Compiler.prototype.onAstViewClosed = function (id) {
         if (this.id == id) {
             this.astButton.prop('disabled', false);
-        }
+            this.produceAst = false;
+        }        
     };    
 
     Compiler.prototype.updateButtons = function () {
@@ -535,6 +540,8 @@ define(function (require) {
         // Disable any of the options which don't make sense in binary mode.
         var filtersDisabled = !!filters.binary && !this.compiler.supportsFiltersInBinary;
         this.domRoot.find('.nonbinary').toggleClass("disabled", filtersDisabled);
+        // The AST printing functionality only works with Clang
+        this.astButton.prop("disabled", !this.compiler.name.includes('clang++'));
     };
 
     Compiler.prototype.onOptionsChange = function (options) {

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -79,6 +79,7 @@ define(function (require) {
         this.decorations = {};
         this.prevDecorations = [];
         this.optButton = this.domRoot.find('.btn.view-optimization');
+        this.astButton = this.domRoot.find('.btn.view-ast');        
 
         this.linkedFadeTimeoutId = -1;
 
@@ -226,6 +227,10 @@ define(function (require) {
             return Components.getOptViewWith(self.id, self.unexpandedSource, self.lastResult.optOutput, self.getCompilerName(), self.sourceEditorId);
         }
 
+        function createAstView() {
+            return Components.getAstViewWith(self.id, self.unexpandedSource, self.lastResult.astOutput, self.getCompilerName(), self.sourceEditorId);
+        }        
+
         this.container.layoutManager.createDragSource(
             this.domRoot.find('.btn.add-compiler'), cloneComponent);
 
@@ -244,6 +249,12 @@ define(function (require) {
             insertPoint.addChild(createOptView());
             this.optButton.prop("disabled", true);
         }, this));
+
+        this.astButton.click(_.bind(function () {
+            var insertPoint = hub.findParentRowOrColumn(this.container) ||
+                this.container.layoutManager.root.contentItems[0];
+            insertPoint.addChild(createAstView());
+        }, this));        
 
         this.saveState();
     }
@@ -502,6 +513,12 @@ define(function (require) {
             this.optButton.prop('disabled', false);
         }
     };
+
+    Compiler.prototype.onAstViewClosed = function (id) {
+        if (this.id == id) {
+            this.astButton.prop('disabled', false);
+        }
+    };    
 
     Compiler.prototype.updateButtons = function () {
         if (!this.compiler) return;

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -198,7 +198,8 @@ define(function (require) {
         this.eventHub.on('settingsChange', this.onSettingsChange, this);
         this.eventHub.on('themeChange', this.onThemeChange, this);
         this.eventHub.on('optViewClosed', this.onOptViewClosed, this);
-        this.eventHub.on('astViewClosed', this.onAstViewClosed, this);        
+        this.eventHub.on('astViewOpened', this.onAstViewOpened, this);
+        this.eventHub.on('astViewClosed', this.onAstViewClosed, this);
         this.eventHub.emit('requestSettings');
         this.eventHub.emit('requestTheme');
         this.sendCompiler();
@@ -254,10 +255,7 @@ define(function (require) {
         this.astButton.click(_.bind(function () {
             var insertPoint = hub.findParentRowOrColumn(this.container) ||
                 this.container.layoutManager.root.contentItems[0];
-            this.produceAst = true;            
-
             insertPoint.addChild(createAstView());
-            this.astButton.prop("disabled", true);
             this.compile();
         }, this));        
 
@@ -520,6 +518,13 @@ define(function (require) {
         }
     };
 
+    Compiler.prototype.onAstViewOpened = function (id) {
+        if (this.id == id) {
+            this.astButton.prop("disabled", true);
+            this.produceAst = true;
+        }
+    };
+    
     Compiler.prototype.onAstViewClosed = function (id) {
         if (this.id == id) {
             this.astButton.prop('disabled', false);

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -1,26 +1,26 @@
 // Copyright (c) 2012-2017, Matt Godbolt
 //
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-//     * Redistributions of source code must retain the above copyright notice, 
+//
+//     * Redistributions of source code must retain the above copyright notice,
 //       this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in the 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
 //       documentation and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 define(function (require) {
@@ -79,7 +79,7 @@ define(function (require) {
         this.decorations = {};
         this.prevDecorations = [];
         this.optButton = this.domRoot.find('.btn.view-optimization');
-        this.astButton = this.domRoot.find('.btn.view-ast');        
+        this.astButton = this.domRoot.find('.btn.view-ast');
 
         this.linkedFadeTimeoutId = -1;
 
@@ -231,7 +231,7 @@ define(function (require) {
 
         function createAstView() {
             return Components.getAstViewWith(self.id, self.unexpandedSource, self.lastResult.astOutput, self.getCompilerName(), self.sourceEditorId);
-        }        
+        }
 
         this.container.layoutManager.createDragSource(
             this.domRoot.find('.btn.add-compiler'), cloneComponent);
@@ -252,12 +252,15 @@ define(function (require) {
             this.optButton.prop("disabled", true);
         }, this));
 
+        this.container.layoutManager.createDragSource(
+            this.astButton, createAstView.bind(this));
+
         this.astButton.click(_.bind(function () {
             var insertPoint = hub.findParentRowOrColumn(this.container) ||
                 this.container.layoutManager.root.contentItems[0];
             insertPoint.addChild(createAstView());
             this.compile();
-        }, this));        
+        }, this));
 
         this.saveState();
     }
@@ -524,13 +527,13 @@ define(function (require) {
             this.produceAst = true;
         }
     };
-    
+
     Compiler.prototype.onAstViewClosed = function (id) {
         if (this.id == id) {
             this.astButton.prop('disabled', false);
             this.produceAst = false;
-        }        
-    };    
+        }
+    };
 
     Compiler.prototype.updateButtons = function () {
         if (!this.compiler) return;
@@ -677,7 +680,7 @@ define(function (require) {
         if (match) {
             return value + ' = ' + bigInt(match[2], 16).toString(10);
         }
-        match = decimalLike.exec(value); 
+        match = decimalLike.exec(value);
         if (match) {
             var asBig = bigInt(match[2]);
             if (asBig.isNegative()) {
@@ -685,7 +688,7 @@ define(function (require) {
             }
             return value + ' = 0x' + asBig.toString(16).toUpperCase();
         }
-        
+
         return null;
     }
 

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -254,9 +254,11 @@ define(function (require) {
         this.astButton.click(_.bind(function () {
             var insertPoint = hub.findParentRowOrColumn(this.container) ||
                 this.container.layoutManager.root.contentItems[0];
-            this.produceAst = true;
+            this.produceAst = true;            
+
             insertPoint.addChild(createAstView());
-            this.astButton.prop("disabled", true);            
+            this.astButton.prop("disabled", true);
+            this.compile();
         }, this));        
 
         this.saveState();

--- a/static/components.js
+++ b/static/components.js
@@ -87,7 +87,21 @@ define(function () {
                 componentName: 'opt',
                 componentState: {id: id, source: source, optOutput: optimization, compilerName: compilerName, editorid: editorid}
             };
-        }
+        },
+        getAstView: function() {
+            return {
+                type: 'component',
+                componentName: 'ast',
+                componentState: {}
+            };
+        },
+        getAstViewWith: function (id, source, optimization, compilerName, editorid) {
+            return {
+                type: 'component',
+                componentName: 'ast',
+                componentState: {id: id, source: source, optOutput: optimization, compilerName: compilerName, editorid: editorid}
+            };
+        }        
     };
 
 });

--- a/static/components.js
+++ b/static/components.js
@@ -95,11 +95,17 @@ define(function () {
                 componentState: {}
             };
         },
-        getAstViewWith: function (id, source, optimization, compilerName, editorid) {
+        getAstViewWith: function (id, source, astOutput, compilerName, editorid) {
             return {
                 type: 'component',
                 componentName: 'ast',
-                componentState: {id: id, source: source, optOutput: optimization, compilerName: compilerName, editorid: editorid}
+                componentState: {
+                    id: id,
+                    source: source,
+                    astOutput: astOutput,
+                    compilerName: compilerName,
+                    editorid: editorid
+                }
             };
         }        
     };

--- a/static/hub.js
+++ b/static/hub.js
@@ -34,6 +34,7 @@ define(function (require) {
     var Components = require('components');
     var diff = require('diff');
     var optView = require('opt-view');
+    var astView = require('ast-view');
 
     function Ids() {
         this.used = {};
@@ -82,6 +83,10 @@ define(function (require) {
             function (container, state) {
                 return self.optViewFactory(container, state);
             });
+        layout.registerComponent(Components.getAstView().componentName,
+            function (container, state) {
+                return self.astViewFactory(container, state);
+            });
 
         layout.eventHub.on('editorOpen', function (id) {
             this.editorIds.add(id);
@@ -126,6 +131,10 @@ define(function (require) {
     Hub.prototype.optViewFactory = function (container, state) {
         return new optView.Opt(this, container, state);
     };
+    Hub.prototype.astViewFactory = function (container, state) {
+        return new astView.Ast(this, container, state);
+    };
+
     
     function WrappedEventHub(eventHub) {
         this.eventHub = eventHub;

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -38,6 +38,8 @@
             span.glyphicon.glyphicon-new-window
           button.btn.btn-default.btn-sm.view-optimization(title="Show optimization output (Clang only)" disabled=true)
             span.glyphicon.glyphicon-scale
+          button.btn.btn-default.btn-sm.view-ast(title="Show AST output (Clang only)")
+            span.glyphicon.glyphicon-tree-deciduous            
     .monaco-placeholder
     .bottom-bar
       if !embedded
@@ -60,6 +62,11 @@
     .monaco-placeholder
 
   #opt
+    .top-bar.btn-toolbar(role="toolbar")
+      include font-size.pug
+    .monaco-placeholder
+
+  #ast
     .top-bar.btn-toolbar(role="toolbar")
       include font-size.pug
     .monaco-placeholder


### PR DESCRIPTION
Opened this pull request to track support for viewing the Clang AST. I still need to ensure that the functionality is enabled/disabled as required and clean up the code. Please let me know if you'd like me to change the approach of anything.

### Todo:
- [ ] Allow collapsing of tree nodes for brevity
- [ ] Maybe add a colour toggle so that users can switch between colouring from the ASM and AST

