### PR TITLE
Add support for Intels ISPC compiler

### DIFF
--- a/etc/config/builtin.ispc.properties
+++ b/etc/config/builtin.ispc.properties
@@ -1,0 +1,2 @@
+sourcepath=./examples/ispc/
+extensionRe=.*\.ispc$

--- a/etc/config/ispc.defaults.properties
+++ b/etc/config/ispc.defaults.properties
@@ -1,0 +1,4 @@
+compilers=ispc
+compileFilename=example.ispc
+supportsBinary=false
+compilerType=ispc

--- a/examples/ispc/max_array.ispc
+++ b/examples/ispc/max_array.ispc
@@ -1,0 +1,5 @@
+void maxArray(uniform double x[], uniform double y[]) {
+    foreach (i = 0 ... 65535) {
+        x[i] = max(x[i], y[i]);
+    }
+}

--- a/examples/ispc/sum_array.ispc
+++ b/examples/ispc/sum_array.ispc
@@ -1,0 +1,7 @@
+uniform int sumArray(uniform int input[], uniform int length) {
+    varying int sum = 0;
+    foreach (i = 0 ... length) {
+        sum += input[i];
+    }
+    return reduce_add(sum);
+}

--- a/lib/compilers/ispc.js
+++ b/lib/compilers/ispc.js
@@ -1,0 +1,11 @@
+var Compile = require('../base-compiler');
+
+function compileISPC(info, env) {
+    var compiler = new Compile(info, env);
+    compiler.optionsForFilter = function (filters, outputFilename) {
+        return ['--emit-asm', '-g', '-o', this.filename(outputFilename)];
+    };
+    return compiler.initialise();
+}
+
+module.exports = compileISPC;


### PR DESCRIPTION
[Intel ISPC](https://ispc.github.io) is a C derivative with SPMD semantics baked into the language, which often allows for more effective auto-vectorization than is possible in standard C/C++. This patch integrates the ISPC compiler, and adds idiomatic ports of Compiler Explorer's `max_array` and `sum_array` examples.

The compiler is BSD licensed and Linux binaries are provided by the project, so it should be pretty straightforward to integrate into the server image.

Caveats:
ISPC doesn't support Intel assembly syntax, so that's disabled (ironic considering it's an Intel project)
Binary disassemble mode is disabled for now because I'm dumb and couldn't convince it to work.