### PR TITLE
Fix upper bound in ISPC max_array

### DIFF
--- a/examples/ispc/max_array.ispc
+++ b/examples/ispc/max_array.ispc
@@ -1,5 +1,5 @@
 void maxArray(uniform double x[], uniform double y[]) {
-    foreach (i = 0 ... 65535) {
+    foreach (i = 0 ... 65536) {
         x[i] = max(x[i], y[i]);
     }
 }


### PR DESCRIPTION
Oops, `foreach(begin...end)` only iterates up to `end-1` so the end bound should be 65536.