### PR TITLE
Mention force-aligned-memory in ISPC example

### DIFF
--- a/examples/ispc/max_array.ispc
+++ b/examples/ispc/max_array.ispc
@@ -1,3 +1,7 @@
+// Compile with --opt=force-aligned-memory to improve vectorization
+// by assuming the input arrays are aligned. SSE, AVX and AVX-512
+// targets will assume 16, 32 or 64 byte alignment respectively.
+
 void maxArray(uniform double x[], uniform double y[]) {
     foreach (i = 0 ... 65536) {
         x[i] = max(x[i], y[i]);


### PR DESCRIPTION
This flag is often vital for getting good codegen, so we should probably direct new users towards it.