### PR TITLE
Add syntax highlighting for ISPC

### DIFF
--- a/static/editor.js
+++ b/static/editor.js
@@ -36,6 +36,7 @@ define(function (require) {
     var Alert = require('alert');
     require('./d-mode');
     require('./rust-mode');
+    require('./ispc-mode');
 
     var loadSave = new loadSaveLib.LoadSave();
 
@@ -84,6 +85,10 @@ define(function (require) {
             case "go":
                 cmMode = "go";
                 extensions = ['.go'];
+                break;
+            case "ispc":
+                cmMode = "ispc";
+                extensions = ['.ispc'];
                 break;
         }
 

--- a/static/ispc-mode.js
+++ b/static/ispc-mode.js
@@ -1,0 +1,57 @@
+define(function (require) {
+    'use strict';
+    var jquery = require('jquery');
+    var monaco = require('monaco');
+    var cpp = require('vs/basic-languages/src/cpp');
+
+    function definition() {
+        var ispc = jquery.extend(true, {}, cpp.language); // deep copy
+
+        ispc.tokenPostfix = '.ispc';
+
+        ispc.keywords.push(
+            'cbreak',
+            'ccontinue',
+            'cdo',
+            'cfor',
+            'cif',
+            'creturn',
+            'cwhile',
+            'delete',
+            'export',
+            'foreach',
+            'foreach_active',
+            'foreach_tiled',
+            'foreach_unique',
+            'int16',
+            'int32',
+            'int64',
+            'int8',
+            'launch',
+            'new',
+            'operator',
+            'print',
+            'programCount',
+            'programIndex',
+            'reference',
+            'soa',
+            'sync',
+            'task',
+            'taskCount',
+            'taskCount0',
+            'taskCount1',
+            'taskCount3',
+            'taskIndex',
+            'taskIndex0',
+            'taskIndex1',
+            'taskIndex2',
+            'uniform',
+            'varying'
+        );
+
+        return ispc;
+    }
+
+    monaco.languages.register({id: 'ispc'});
+    monaco.languages.setMonarchTokensProvider('ispc', definition());
+});

--- a/static/ispc-mode.js
+++ b/static/ispc-mode.js
@@ -40,11 +40,13 @@ define(function (require) {
             'taskCount',
             'taskCount0',
             'taskCount1',
-            'taskCount3',
+            'taskCount2',
             'taskIndex',
             'taskIndex0',
             'taskIndex1',
             'taskIndex2',
+            'threadCount',
+            'threadIndex',
             'uniform',
             'varying'
         );


### PR DESCRIPTION
...or rather, clone Monaco's C++ syntax and hack in the ISPC keywords. Close enough 😛

![capture](https://cloud.githubusercontent.com/assets/3153547/26766495/316ba9d8-498b-11e7-9914-347b3a437227.PNG)
