### PR TITLE
Don't filter out AST declarations after an implicit declaration

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -333,15 +333,21 @@ Compile.prototype.processAstOutput = function (output) {
             if (output[i].match(lineRegex) && mostRecentIsSource) {
                 //do nothing
             }
-            // This is a system header, remove everything up to the next top level decl
+            // This is a system header or implicit definition,
+            // remove everything up to the next top level decl
             else if (!output[i].match(sourceRegex)) {
+                // Top level decls with invalid sloc as the file don't change the most recent file
+                var slocRegex = /<<invalid sloc>>/;
+                if (!output[i].match(slocRegex)) {
+                    mostRecentIsSource = false;
+                }
+                
                 var spliceMax = i+1;
                 while (output[spliceMax] && !output[spliceMax].match(topLevelRegex)) {
                     spliceMax++;
                 }
                 output.splice(i, spliceMax-i);
                 --i;
-                mostRecentIsSource = false;
             }
             else {
                 mostRecentIsSource = true;


### PR DESCRIPTION
Currently AST declarations are filtered out if an implicit declaration (e.g. operator new) occurs between two explicit declarations.

Example:

```
struct foo {
    virtual ~foo() = default;
};

int a;
```

Current output:

```
TranslationUnitDecl
|-CXXRecordDecl <line:1:1, line:3:1> line:1:8 struct foo definition
| |-CXXRecordDecl <col:1, col:8> col:8 implicit referenced struct foo
| |-CXXDestructorDecl <line:2:5, col:28> col:13 ~foo 'void (void) noexcept' virtual default
| `-CXXMethodDecl <line:1:8, col:8 implicit operator= 'struct foo &(const struct foo &)' inline default noexcept-unevaluated 0x526f328
|   `-ParmVarDecl <col:8> col:8 'const struct foo &'
```

Fixed output:

```
TranslationUnitDecl
|-CXXRecordDecl <line:1:1, line:3:1> line:1:8 struct foo definition
| |-CXXRecordDecl <col:1, col:8> col:8 implicit referenced struct foo
| |-CXXDestructorDecl <line:2:5, col:28> col:13 ~foo 'void (void) noexcept' virtual default
| `-CXXMethodDecl <line:1:8, col:8 implicit operator= 'struct foo &(const struct foo &)' inline default noexcept-unevaluated 0x24d15e8
|   `-ParmVarDecl <col:8> col:8 'const struct foo &'
`-VarDecl <line:5:1, col:5> col:5 a 'int'
```

