### PR TITLE
Make AST view play nicely with other compilers

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -162,7 +162,8 @@ Compile.prototype.generateAST = function(inputFilename, options) {
     // A higher max output is needed for when the user includes headers
     execOptions.maxOutput = 1024*1024*1024 ;
 
-    return this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions);
+    return this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions)
+        .then(this.processAstOutput);
 };
 
 Compile.prototype.compile = function (source, options, backendOptions, filters) {
@@ -216,7 +217,12 @@ Compile.prototype.compile = function (source, options, backendOptions, filters) 
 
             var astPromise;
             if (backendOptions.produceAst) {
-                astPromise = self.generateAST(inputFilename, options);
+                if (self.couldSupportASTDump(options, self.compiler.version)){
+                    astPromise = self.generateAST(inputFilename, options);
+                }
+                else {
+                    astPromise = Promise.resolve("AST output is only supported in Clang >= 3.3");
+                }
             }
             else {
                 astPromise = Promise.resolve("");
@@ -242,7 +248,7 @@ Compile.prototype.compile = function (source, options, backendOptions, filters) 
                     }
                     if (astResult) {
                         asmResult.hasAstOutput = true;
-                        asmResult.astOutput = astResult.stdout;
+                        asmResult.astOutput = astResult;
                     }
                     
                     return self.postProcess(asmResult, outputFilename, filters);
@@ -312,8 +318,20 @@ Compile.prototype.processOptOutput = function (hasOptOutput, optPath) {
         });
 };
 
+Compile.prototype.couldSupportASTDump = function (options, version) {
+    var versionRegex = /version (\d.\d+)/;
+    var versionMatch = versionRegex.exec(version);
+
+    if (versionMatch) {
+        var versionNum = parseFloat(versionMatch[1]);
+        return version.toLowerCase().indexOf("clang") > -1 && versionNum >= 3.3;
+    }
+
+    return false;
+};
 
 Compile.prototype.processAstOutput = function (output) {
+    output = output.stdout;
     output = output.map(function(x) { return x.text; });
 
     // Top level decls start with |- or `-
@@ -337,8 +355,8 @@ Compile.prototype.processAstOutput = function (output) {
             // remove everything up to the next top level decl
             else if (!output[i].match(sourceRegex)) {
                 // Top level decls with invalid sloc as the file don't change the most recent file
-                var slocRegex = /<<invalid sloc>>/;
-                if (!output[i].match(slocRegex)) {
+                var slocFileRegex = /<<invalid sloc>>/;
+                if (!output[i].match(slocFileRegex)) {
                     mostRecentIsSource = false;
                 }
                 
@@ -381,10 +399,6 @@ Compile.prototype.postProcess = function (result, outputFilename, filters) {
         optPromise = Promise.resolve("");
     }
 
-    if (result.hasAstOutput) {
-        result.astOutput = this.processAstOutput(result.astOutput);
-    }
-    
     if (filters.binary && this.supportsObjdump()) {
         asmPromise = this.objdump(outputFilename, result, maxSize, filters.intel);
     } else {

--- a/static/ast-view.js
+++ b/static/ast-view.js
@@ -91,11 +91,13 @@ define(function (require) {
     };
 
     Ast.prototype.onCompileResult = function (id, compiler, result) {
-        if(result.hasAstOutput && this._compilerid == id) {
-            this.showAstResults(result.astOutput);
-        }
-        else {
-            this.showAstResults("AST output is only supported in Clang >= 3.3");
+        if (this._compilerid == id) {
+            if(result.hasAstOutput) {
+                this.showAstResults(result.astOutput);
+            }
+            else {
+                this.showAstResults("<No output>");
+            }
         }
     };
     Ast.prototype.setTitle = function () {

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -291,22 +291,10 @@ define(function (require) {
         return filters;
     };
 
-    Compiler.prototype.couldSupportASTDump = function (options, version) {
-        var versionRegex = /version (\d.\d+)/;
-        var versionMatch = versionRegex.exec(version);
-
-        if (versionMatch) {
-            var versionNum = parseFloat(versionMatch[1]);
-            console.log(versionNum);
-            return version.toLowerCase().indexOf("clang") > -1 && versionNum >= 3.3;
-        }
-
-        return false;
-    };
 
 
     Compiler.prototype.compile = function () {
-        var shouldProduceAst = this.astViewOpen && this.couldSupportASTDump(this.options, this.compiler.version);
+        var shouldProduceAst = this.astViewOpen;
         var request = {
             source: this.source || "",
             compiler: this.compiler ? this.compiler.id : "",


### PR DESCRIPTION
This fixes the issue mentioned by Björn Fahller on Slack with the AST view not playing nicely with multiple compilers.