### PR TITLE
Make ISPC default to SSE2 if no target is specified

### DIFF
--- a/lib/compilers/ispc.js
+++ b/lib/compilers/ispc.js
@@ -3,7 +3,7 @@ var Compile = require('../base-compiler');
 function compileISPC(info, env) {
     var compiler = new Compile(info, env);
     compiler.optionsForFilter = function (filters, outputFilename) {
-        return ['--emit-asm', '-g', '-o', this.filename(outputFilename)];
+        return ['--target=sse2-i32x4', '--emit-asm', '-g', '-o', this.filename(outputFilename)];
     };
     return compiler.initialise();
 }


### PR DESCRIPTION
ISPC uses the host's CPU to determine the default instruction set if no `--target` option is passed, so the live site is currently defaulting to `avx1.1-i32x8` or `avx2-i32x8` at random depending on which Amazon node happens to serve the request.

Users probably won't appreciate the compiler options changing erratically as they type, so I've added a hard-coded target that will serve as the default unless the user overrides it with their own `--target` setting. `sse2-i32x4` is used for consistency with most other x86-64 compiler's default behavior.