### PR TITLE
Add Haskell support

### DIFF
--- a/etc/config/builtin.haskell.properties
+++ b/etc/config/builtin.haskell.properties
@@ -1,0 +1,2 @@
+sourcepath=./examples/haskell/
+extensionRe=.*\.hs$

--- a/etc/config/haskell.defaults.properties
+++ b/etc/config/haskell.defaults.properties
@@ -1,0 +1,4 @@
+compilers=/usr/bin/ghc
+compileFilename=example.hs
+supportsBinary=false
+compilerType=haskell

--- a/examples/haskell/sumOverArray.hs
+++ b/examples/haskell/sumOverArray.hs
@@ -1,0 +1,5 @@
+sumOverArray :: [Int] -> Int
+sumOverArray (x:xs) = x + sumOverArray xs
+sumOverArray [] =  0
+
+main = return $ sumOverArray [1,3,4]

--- a/lib/compilation-env.js
+++ b/lib/compilation-env.js
@@ -61,7 +61,8 @@ function CompilationEnvironment(gccProps, compilerProps) {
 
 CompilationEnvironment.prototype.getEnv = function (needsMulti) {
     var env = {
-        PATH: process.env.PATH
+        PATH: process.env.PATH,
+        HOME: process.env.HOME
     };
     if (needsMulti && this.multiarch) {
         env.LIBRARY_PATH = '/usr/lib/' + this.multiarch;

--- a/lib/compilers/haskell.js
+++ b/lib/compilers/haskell.js
@@ -1,0 +1,11 @@
+var Compile = require('../base-compiler');
+
+function compileHaskell(info, env) {
+    var compiler = new Compile(info, env);
+    compiler.optionsForFilter = function (filters, outputFilename) {
+        return ['-S', '-g', '-o', this.filename(outputFilename)];
+    };
+    return compiler.initialise();
+}
+
+module.exports = compileHaskell;

--- a/views/example.hs
+++ b/views/example.hs
@@ -1,0 +1,5 @@
+module Example where
+
+sumOverArray :: [Int] -> Int
+sumOverArray (x:xs) = x + sumOverArray xs
+sumOverArray [] =  0

--- a/views/head.pug
+++ b/views/head.pug
@@ -8,6 +8,8 @@ case language
     meta(name="description" content="Compiler Explorer for Go is an interactive online compiler which shows the assembly output of compiled Go code.")
   when "D"
     meta(name="description" content="Compiler Explorer for D is an interactive online compiler which shows the assembly output of compiled D code.")
+  when "Haskell"
+    meta(name="description" content="Compiler Explorer for Haskell is an interactive online compiler which shows the assembly output of compiled Haskell code.")
   when "C++"
   default
     meta(name="description" content="Compiler Explorer is an interactive online compiler which shows the assembly output of compiled C/C++/Rust/Go/D code.")

--- a/views/index.pug
+++ b/views/index.pug
@@ -93,5 +93,6 @@ html(lang="en")
           when "Go": include example.go
           when "D": include example.d
           when "ispc": include example.ispc
+          when "Haskell": include example.hs
 
     include popups.pug


### PR DESCRIPTION
Adds support for Haskell using GHC.

Fixes #444 

- [ ]  Add syntax highlighting -- it looks like someone is working on a [Haskell highlighter for Monaco](https://github.com/byteally/monaco-haskell) at the moment. I couldn't get it integrated successfully, but it seems super early so I might give it a week and see if it's updated. 

