### PR TITLE
Ensure that backendOptions is defined

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -89,7 +89,7 @@ Compile.prototype.runCompiler = function (compiler, options, inputFilename, exec
     if (!execOptions) {
         execOptions = this.getDefaultExecOptions();
     }
-    
+
     return this.exec(compiler, options, execOptions).then(function (result) {
         result.stdout = utils.parseOutput(result.stdout, inputFilename);
         result.stderr = utils.parseOutput(result.stderr, inputFilename);
@@ -219,7 +219,7 @@ Compile.prototype.compile = function (source, options, backendOptions, filters) 
             var asmPromise = self.runCompiler(self.compiler.exe, options, self.filename(inputFilename));
 
             var astPromise;
-            if (backendOptions.produceAst) {
+            if (backendOptions && backendOptions.produceAst) {
                 if (self.couldSupportASTDump(options, self.compiler.version)){
                     astPromise = self.generateAST(inputFilename, options);
                 }
@@ -230,7 +230,7 @@ Compile.prototype.compile = function (source, options, backendOptions, filters) 
             else {
                 astPromise = Promise.resolve("");
             }
-            
+
             return Promise.all([asmPromise, astPromise])
                 .then(function (results) {
                     var asmResult = results[0];
@@ -253,7 +253,7 @@ Compile.prototype.compile = function (source, options, backendOptions, filters) 
                         asmResult.hasAstOutput = true;
                         asmResult.astOutput = astResult;
                     }
-                    
+
                     return self.postProcess(asmResult, outputFilename, filters);
                 });
         });
@@ -362,7 +362,7 @@ Compile.prototype.processAstOutput = function (output) {
                 if (!output[i].match(slocRegex)) {
                     mostRecentIsSource = false;
                 }
-                
+
                 var spliceMax = i+1;
                 while (output[spliceMax] && !output[spliceMax].match(topLevelRegex)) {
                     spliceMax++;
@@ -387,7 +387,7 @@ Compile.prototype.processAstOutput = function (output) {
     output = output.replace(slocRegex, '');
 
     // Unify file references
-    output = output.replace(sourceRegex, 'line');    
+    output = output.replace(sourceRegex, 'line');
 
     return output;
 };


### PR DESCRIPTION
`backendOptions` in `base-compiler.js` is apparently not defined sometimes (may be due to caching). This fix ensures that it's defined before attempting to read from it.