### PR TITLE
Conformance viewer

### DIFF
--- a/app.js
+++ b/app.js
@@ -189,7 +189,8 @@ function ClientOptionsHandler(fileSources) {
         raven: gccProps('ravenUrl', ''),
         release: gitReleaseName,
         environment: env,
-        localStoragePrefix: gccProps('localStoragePrefix')
+        localStoragePrefix: gccProps('localStoragePrefix'),
+        cvCompilerCountMax: gccProps('cvCompilerCountMax', 6)
     };
     this.setCompilers = function (compilers) {
         options.compilers = compilers;

--- a/etc/config/compiler-explorer.defaults.properties
+++ b/etc/config/compiler-explorer.defaults.properties
@@ -14,3 +14,4 @@ allowedShortUrlHostRe=^([-a-z.]+\.)?(xania|godbolt)\.org$
 googleShortLinkRewrite=^https?://goo.gl/(.*)$|https://godbolt.org/g/$1
 
 wine=/opt/wine-devel/bin/wine64
+cvCompilerCountMax=6

--- a/static/components.js
+++ b/static/components.js
@@ -107,7 +107,27 @@ define(function () {
                     editorid: editorid
                 }
             };
-        }        
+        },
+        getConformanceView: function (editorid, source) {
+            return {
+                type: 'component',
+                componentName: 'conformance',
+                componentState: {
+                    editorid: editorid,
+                    source: source
+                }
+            };
+        },
+        getConformanceViewWith: function (editorid, source) {
+            return {
+                type: 'component',
+                componentName: 'conformance',
+                componentState: {
+                    editorid: editorid,
+                    source: source
+                }
+            };
+        }
     };
 
 });

--- a/static/conformance-view.js
+++ b/static/conformance-view.js
@@ -1,0 +1,238 @@
+// Copyright (c) 2012-2017, Rubén Rincón
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+define(function (require) {
+    "use strict";
+
+    var options = require('options');
+    var _ = require('underscore');
+
+    require('selectize');
+
+    var Compiler = require('./compiler');
+
+    var compilers = options.compilers;
+    var compilersById = {};
+    _.forEach(compilers, function (compiler) {
+        compilersById[compiler.id] = compiler;
+        if (compiler.alias) compilersById[compiler.alias] = compiler;
+    });
+
+    function Conformance(hub, container, state) {
+        this.container = container;
+        this.eventHub = hub.createEventHub();
+        this.domRoot = container.getElement();
+        this.domRoot.html($('#conformance').html());
+        this.selectorList = this.domRoot.find('.compiler-list');
+        this.addCompilerButton = this.domRoot.find('.add-compiler');
+        this.compileButton = this.domRoot.find('.compile');
+        this.editorId = state.editorid;
+        this.source = state.source || "";
+        this.currentExpandedSource = "";
+        this.nextSelectorId = 0;
+
+        this.maxCompilations = 6;
+
+        this.status = {
+            allowCompile: false,
+            allowAdd: true
+        };
+
+        this.container.on('destroy', function () {
+            this.eventHub.emit("conformanceViewClose", this.editorId);
+            this.eventHub.unsubscribe();
+        }, this);
+
+        this.eventHub.on('editorChange', this.onEditorChange, this);
+        this.eventHub.on('editorClose', this.onEditorClose, this);
+        this.eventHub.emit("conformanceViewOpen", this.editorId);
+
+        this.addCompilerButton.on('click', _.bind(function() {
+            this.addCompilerSelector();
+        }, this));
+
+        this.compileButton.on('click', _.bind(function() {
+            Compiler.Compiler.prototype.expand(this.source).then(_.bind(function (expanded) {
+                this.currentExpandedSource = expanded;
+                // And trun off every icon
+                this.selectorList.find('.status').css("visibility", "hidden");
+                this.compileAll();
+            }, this));
+        }, this));
+
+        this.handleUiStatus();
+
+        this.setTitle();
+    }
+
+    Conformance.prototype.setTitle = function () {
+        this.container.setTitle("Conformance viewer (Editor #" + this.editorId + ")");
+    };
+
+    Conformance.prototype.addCompilerSelector = function() {
+        var self = this;
+        var selectorsCount = this.nextSelectorId;
+        this.nextSelectorId++;
+
+        var newSelector = $("<select>")
+            .attr("class", "compiler-picker")
+            .attr("placeholder", "Select a compiler...")
+            .attr("data-cv", selectorsCount);
+
+        this.selectorList.append($("<tr>")
+            .attr("data-cv", selectorsCount)
+            .append($("<td>")
+                .append($("<span>")
+                    .attr("class", "status glyphicon glyphicon-signal")
+                    .css("visibility", "hidden")
+                )
+            ).append($("<td>")
+                .append(newSelector)
+            ).append($("<td>")
+                .append($("<input>")
+                    .attr("class", "options form-control")
+                    .attr("type", "text")
+                    .attr("size","256")
+                    .attr("placeholder", "Compiler options...")
+                    .attr("data-cv", selectorsCount)
+                )
+            ).append($("<td>")
+                .append($("<button>")
+                    .attr("class", "close")
+                    .attr("aria-label", "Close")
+                    .attr("data-cv", selectorsCount)
+                    .append($("<span>")
+                        .html("&times;")
+                        .attr("aria-hidden", "true")
+                    )
+                    .on("click", function() {
+                        self.removeCompilerSelector(selectorsCount);
+                    })
+                )
+            )
+        );
+
+        newSelector.selectize({
+            sortField: 'name',
+            valueField: 'id',
+            labelField: 'name',
+            searchField: ['name'],
+            options: compilers,
+            items: []
+        }).on('change', function() {
+            // Hide the results button when a new compiler is selected
+            self.selectorList.find('[data-cv="' + selectorsCount + '"] .status').css("visibility", "hidden");
+        });
+
+        this.handleUiStatus();
+    };
+
+    Conformance.prototype.removeCompilerSelector = function(cv) {
+        _.each(this.selectorList.children(), function(row) {
+            var child = $(row);
+            if (Number(child.attr("data-cv")) === cv) {
+                child.remove();
+            }
+        }, this);
+
+        this.handleUiStatus();
+    };
+
+    // TODO: Maybe use premises
+    Conformance.prototype.compile = function(selector) {
+        if (!selector) return;
+        var val = selector.val();
+        if (val) {
+            var cv = Number(selector.attr("data-cv"));
+            var request = {
+                source: this.currentExpandedSource || "",
+                compiler: val,
+                options: this.selectorList.find(".options[data-cv='" + cv + "']").val(),
+                backendOptions: {produceAst: false},
+                filters: {},
+                extras: {
+                    cv: cv,
+                    storeAsm: false,
+                    emitCompilingEvent: false,
+                    ignorePendingRequest: true
+                }
+            };
+            Compiler.Compiler.prototype.sendCompile(request, _.bind(this.onCompileResponse, this));
+        }
+    };
+
+    Conformance.prototype.onEditorChange = function(editorId, newSource) {
+        if (editorId == this.editorId) this.source = newSource;
+    };
+
+    Conformance.prototype.onEditorClose = function(editorId) {
+        if (editorId == this.editorId) {
+            _.defer(function (self) {
+                self.container.close();
+            }, this);
+        }
+    };
+
+    Conformance.prototype.onCompileResponse = function (request, result, cached) {
+        var allText = _.pluck((result.stdout || []).concat(result.stderr || []), 'text').join("\n");
+        var failed = result.code !== 0;
+        var warns = !failed && !!allText;
+        var style = {
+            color: failed ? "red" : (warns ? "yellow" : "green"),
+            glyph: failed ? "remove-sign" : (warns ? "info-sign" : "ok-sign"),
+            aria: failed ? "Compilation failed" : (warns ? "Compiled with warnings" : "Compiled without warnings")
+        };
+        var statusIcon = this.selectorList.find('[data-cv="' + request.extras.cv + '"] .status');
+
+        statusIcon.attr("class", "status glyphicon glyphicon-" + style.glyph)
+            .css("visibility", "visible")
+            .css("color", style.color)
+            .attr("title", allText)
+            .attr("aria-label", style.aria);
+    };
+
+    Conformance.prototype.compileAll = function() {
+        var compileCount = 0;
+        _.each(this.selectorList.children(), _.bind(function(child) {
+            var picker = $(child).find('.compiler-picker');
+            if (picker && compileCount < this.maxCompilations) {
+                compileCount++;
+                this.compile(picker);
+            }
+        }, this));
+    };
+
+    Conformance.prototype.handleUiStatus = function() {
+        this.status.allowCompile = this.selectorList.children().length > 0;
+        this.status.allowAdd = this.selectorList.children().length < this.maxCompilations;
+
+        this.compileButton.attr("disabled", !this.status.allowCompile);
+        this.addCompilerButton.attr("disabled", !this.status.allowAdd);
+    };
+
+    return {
+        Conformance: Conformance
+    };
+});

--- a/static/conformance-view.js
+++ b/static/conformance-view.js
@@ -271,7 +271,7 @@ define(function (require) {
     };
 
     Conformance.prototype.resize = function () {
-
+        this.selectorList.css("height", this.domRoot.height() - this.domRoot.find('.top-bar').outerHeight(true));
     };
     
 

--- a/static/conformance-view.js
+++ b/static/conformance-view.js
@@ -226,7 +226,10 @@ define(function (require) {
                                 ignorePendingRequest: true
                             }
                         };
-                        Compiler.prototype.sendCompile(request);
+                        Compiler.prototype.sendCompile(request, _.bind(this.onCompileResponse, this), function(text) {
+                                return {asm: "", code: -1, stdout: "", stderr: text};
+                            }
+                        );
                     }
                 }
             }, this));
@@ -286,8 +289,7 @@ define(function (require) {
     };
 
     Conformance.prototype.resize = function () {
-        var topBarHeight = this.domRoot.find(".top-bar").outerHeight(true);
-        this.domRoot.find(".wrapper").css("height", this.domRoot.outerHeight(true) - topBarHeight);
+
     };
     
 

--- a/static/editor.js
+++ b/static/editor.js
@@ -263,6 +263,8 @@ define(function (require) {
         this.eventHub.on('editorSetDecoration', this.onEditorSetDecoration, this);
         this.eventHub.on('settingsChange', this.onSettingsChange, this);
         this.eventHub.on('themeChange', this.onThemeChange, this);
+        this.eventHub.on('conformanceViewOpen', this.onConformanceViewOpen, this);
+        this.eventHub.on('conformanceViewClose', this.onConformanceViewClose, this);
         this.eventHub.emit('requestSettings');
         this.eventHub.emit('requestTheme');
 
@@ -281,6 +283,20 @@ define(function (require) {
             var insertPoint = hub.findParentRowOrColumn(this.container) ||
                 this.container.layoutManager.root.contentItems[0];
             insertPoint.addChild(compilerConfig());
+        }, this));
+
+        var conformanceConfig = _.bind(function () {
+            return Components.getConformanceView(this.id, this.getSource());
+        }, this);
+
+        this.conformanceViewerButton = this.domRoot.find('.btn.conformance');
+
+        this.container.layoutManager.createDragSource(
+            this.conformanceViewerButton, conformanceConfig());
+        this.conformanceViewerButton.click(_.bind(function () {
+            var insertPoint = hub.findParentRowOrColumn(this.container) ||
+                this.container.layoutManager.root.contentItems[0];
+            insertPoint.addChild(conformanceConfig());
         }, this));
 
         this.updateState();
@@ -461,6 +477,18 @@ define(function (require) {
     Editor.prototype.updateDecorations = function () {
         this.prevDecorations = this.editor.deltaDecorations(
             this.prevDecorations, _.flatten(_.values(this.decorations), true));
+    };
+
+    Editor.prototype.onConformanceViewOpen = function(editorId) {
+        if (editorId == this.id) {
+            this.conformanceViewerButton.attr("disabled", true);
+        }
+    };
+
+    Editor.prototype.onConformanceViewClose = function(editorId) {
+        if (editorId == this.id) {
+            this.conformanceViewerButton.attr("disabled", false);
+        }
     };
 
     return {

--- a/static/explorer.css
+++ b/static/explorer.css
@@ -200,3 +200,8 @@ pre.content {
 	width: 8px !important;
 	left: 3px;
 }
+
+.compiler-list {
+    display: block;
+    overflow: auto;
+}

--- a/static/hub.js
+++ b/static/hub.js
@@ -35,6 +35,7 @@ define(function (require) {
     var diff = require('diff');
     var optView = require('opt-view');
     var astView = require('ast-view');
+    var conformanceView = require('conformance-view');
 
     function Ids() {
         this.used = {};
@@ -87,6 +88,10 @@ define(function (require) {
             function (container, state) {
                 return self.astViewFactory(container, state);
             });
+        layout.registerComponent(Components.getConformanceView().componentName,
+            function (container, state) {
+                return self.confomanceFactory(container, state);
+            });
 
         layout.eventHub.on('editorOpen', function (id) {
             this.editorIds.add(id);
@@ -134,7 +139,9 @@ define(function (require) {
     Hub.prototype.astViewFactory = function (container, state) {
         return new astView.Ast(this, container, state);
     };
-
+    Hub.prototype.confomanceFactory = function (container, state) {
+        return new conformanceView.Conformance(this, container, state);
+    };
     
     function WrappedEventHub(eventHub) {
         this.eventHub = eventHub;

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -8,6 +8,9 @@
         if !embedded
           button.btn.btn-default.btn-sm.add-compiler(title="Add a new compiler for this source (click or drag)")
             span.glyphicon.glyphicon-open
+      .btn-group.btn-group-sm
+        button.btn.btn-default.btn-sm.conformance(title="Add a new conformance view")
+          span.glyphicon.glyphicon-apple
     .monaco-placeholder
 
   #compiler
@@ -70,3 +73,12 @@
     .top-bar.btn-toolbar(role="toolbar")
       include font-size.pug
     .monaco-placeholder
+
+  #conformance
+    .top-bar.tn-toolbar(role="toolbar")
+      .btn-group.btn-group-sm
+        button.btn.btn-default.btn-sm.add-compiler(title="Add compiler")
+          span.glyphicon.glyphicon-plus-sign
+        button.btn.btn-default.btn-sm.compile(title="Compile")
+          span.glyphicon.glyphicon-wrench
+    table.compiler-list

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -5,12 +5,12 @@
       .btn-group.btn-group-sm
         button.btn.btn-default.btn-sm.load-save(title="Load or save text")
           span.glyphicon.glyphicon-floppy-disk
-        if !embedded
+      if !embedded
+        .btn-group.btn-group-sm
           button.btn.btn-default.btn-sm.add-compiler(title="Add a new compiler for this source (click or drag)")
             span.glyphicon.glyphicon-open
-      .btn-group.btn-group-sm
-        button.btn.btn-default.btn-sm.conformance(title="Add a new conformance view")
-          span.glyphicon.glyphicon-apple
+          button.btn.btn-default.btn-sm.conformance(title="Add a new conformance view")
+            span.glyphicon.glyphicon-list-alt
     .monaco-placeholder
 
   #compiler
@@ -79,20 +79,18 @@
       .btn-group.btn-group-sm
         button.btn.btn-default.btn-sm.add-compiler(title="Add compiler")
           span.glyphicon.glyphicon-plus-sign
-        button.btn.btn-default.btn-sm.compile(title="Compile")
-          span.glyphicon.glyphicon-wrench
     table.compiler-list
 
   #compiler-selector
     table
-      tr(class="compiler-row")
+      tr.compiler-row
         td
-          span(class="status")
+          span.status.glyphicon.glyphicon-signal
         td
-          select(class="compiler-picker" placeholder="Select a compiler...")
+          select.compiler-picker(placeholder="Select a compiler...")
         td
-          input(class="options form-control" type="text" size="256" placeholder="Compiler options...")
+          input.options.form-control(type="text" size="256" placeholder="Compiler options...")
         td
-          button(class="close" aria-label="Close")
+          button.close(aria-label="Close")
             span(aria-hidden="true")
               | &times;

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -82,3 +82,17 @@
         button.btn.btn-default.btn-sm.compile(title="Compile")
           span.glyphicon.glyphicon-wrench
     table.compiler-list
+
+  #compiler-selector
+    table
+      tr(class="compiler-row")
+        td
+          span(class="status")
+        td
+          select(class="compiler-picker" placeholder="Select a compiler...")
+        td
+          input(class="options form-control" type="text" size="256" placeholder="Compiler options...")
+        td
+          button(class="close" aria-label="Close")
+            span(aria-hidden="true")
+              | &times;


### PR DESCRIPTION
What
---
A view that allows compiling with multiple compilers at once and informs on the results of each one. It is able to display warnings/compilation errors *but not the produced asm*

Why
---
I liked @adishavit's (Slack) request for something like this (It also gave me few ideas for the formatting tool #346 #111 )

Limitations
---
Some limitations are in place but none are necessary, so tell me if you don't feel the need for some to be there
- Produced asm is descarted (We only care about the compilation status, but maybe having a "Show me asm" button would be cool?)
- 6 compilers per view
- 1 view per editor
The last two are there so we don't ddos ourselves. Maybe they are a bit too harsh? Maybe more than 6 compilers per view is ok?

TODO
---
- [x] Currently, when the table with the compilers overflows, you can't access the overflowing elements (No scroll appears) I've tried and failed. *Any help is would be really appreciated*
- [X] ~We don't store the compilers we are using anywhere but as child elements of the main table. Maybe change this for less overhead?~ It's actually an ok solution
- [ ] On my local dev env, I only have C++ set up on CE. Could someone with any other language confirm that this works with it, please?
- [X] An apple as an icon is quite irrelevant. Find a more fitting glyph

Notes
---
- This PR changes the signature of compiler.js' Compile() function but the default behaviour remains unchanged (Done so we only had 1 version of it instead of c&p'ing it)
- Few minor improvements need to be made still. I'll merge once those and the TODO are done
- I first tought that one compiler should only be able to be present once, but that killed the case when comparing different flags/commands
- I don't know how useful this could be (I'm guessing not much) but it was atleast fun to implement (And I got to understand the whole components/state stuff!)

Closes #461 
