### PR TITLE
Made some changes to the way we parse arguments as a stab at a start …

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -32,7 +32,6 @@ var child_process = require('child_process'),
     Promise = require('promise'), // jshint ignore:line
     asm = require('./asm'),
     utils = require('./utils'),
-    quote = require('shell-quote'),
     _ = require('underscore-node'),
     exec = require('./exec'),
     logger = require('./logger').logger,
@@ -59,10 +58,9 @@ Compile.prototype.newTempDir = function () {
 Compile.prototype.writeFile = Promise.denodeify(fs.writeFile);
 Compile.prototype.readFile = Promise.denodeify(fs.readFile);
 Compile.prototype.stat = Promise.denodeify(fs.stat);
-Compile.prototype.couldHaveOptOutput = function (options, version) {
-    //TODO(jared): a compiler meta data gatherer could improve this
-    return version.toLowerCase().indexOf("clang") > -1 &&
-        options.some((x) => x == "-fsave-optimization-record");
+
+Compile.prototype.optOutputRequested = function(options) {
+    return options.some((x) => x == "-fsave-optimization-record");
 };
 
 Compile.prototype.getRemote = function () {
@@ -144,6 +142,9 @@ Compile.prototype.optionsForFilter = function (filters, outputFilename) {
     var options = ['-g', '-o', this.filename(outputFilename)];
     if (this.compiler.intelAsm && filters.intel && !filters.binary) {
         options = options.concat(this.compiler.intelAsm.split(" "));
+    }
+    if(this.compiler.supportsOptOutput && filters.optOutput) {
+        options = options.concat(this.compiler.optArg);
     }
     if (!filters.binary) options = options.concat('-S');
     return options;
@@ -242,7 +243,8 @@ Compile.prototype.compile = function (source, options, backendOptions, filters) 
                         return asmResult;
                     }
                     asmResult.hasOptOutput = false;
-                    if (self.couldHaveOptOutput(options, self.compiler.version)) {
+                    if(self.compiler.supportsOptOutput && self.optOutputRequested(options)) {
+                        asmResult.hasOptOutput = false;
                         const optPath = path.join(dirPath, outputFilebase + ".opt.yaml");
                         if (fs.existsSync(optPath)) {
                             asmResult.hasOptOutput = true;
@@ -304,21 +306,36 @@ Compile.prototype.postProcessAsm = function (result) {
             return result;
         });
 };
-
-
-Compile.prototype.processOptOutput = function (hasOptOutput, optPath) {
-    var output = [];
+Compile.prototype.processOptOutput = function(hasOptOutput, optPath) {
+    var output = [],
+    //if we have no compileFilename for whatever reason 
+    //let everything through
+    inputFile = this.env.compilerProps("compileFilename", "");
     return new Promise(
-        function (resolve, reject) {
+        function (resolve) { 
             fs.createReadStream(optPath, {encoding: "utf-8"})
                 .pipe(new compilerOptInfo.LLVMOptTransformer())
-                .on("data", function (opt) {
-                    output.push(opt);
-                })
-                .on("end", function () {
+                .on("data", function(opt) {
+                    if(opt.DebugLoc && 
+                       opt.DebugLoc.File &&
+                       opt.DebugLoc.File.indexOf(inputFile) > -1) {
+                        
+                        output.push(opt);
+                    }
+                }.bind(this))
+                .on("end", function() {
+                    if(this.compiler.demangler) {
+                        var result = JSON.stringify(output, null, 4);
+                        this.exec(this.compiler.demangler, ["-n","-p"], {input: result})
+                            .then(function(demangleResult) {
+                                output = JSON.parse(demangleResult.stdout);
+                                resolve(output);
+                            }.bind(this));
+                    } else {
                     resolve(output);
-                });
-        });
+                    }
+                }.bind(this));
+    }.bind(this));
 };
 
 Compile.prototype.couldSupportASTDump = function (options, version) {
@@ -470,8 +487,11 @@ Compile.prototype.checkSource = function (source) {
     return null;
 };
 
-Compile.prototype.initialise = function () {
+Compile.prototype.initialise = function (argumentParser) {
     if (this.getRemote()) return Promise.resolve(this);
+    argumentParser = argumentParser || function() {
+        return Promise.resolve(this);
+    }.bind(this);
     var compiler = this.compiler.exe;
     var versionFlag = this.compiler.versionFlag || '--version';
     var versionRe = new RegExp(this.compiler.versionRe || '.*');
@@ -496,26 +516,10 @@ Compile.prototype.initialise = function () {
                 logger.info(compiler + " is version '" + version + "'");
                 this.compiler.version = version;
                 if (this.compiler.intelAsm) return this;
-                return this.exec(compiler, ['--target-help'])
-                    .then(_.bind(function (result) {
-                        var options = {};
-                        if (result.code === 0) {
-                            var splitness = /--?[-a-zA-Z]+( ?[-a-zA-Z]+)/;
-                            utils.eachLine(result.stdout + result.stderr, function (line) {
-                                var match = line.match(splitness);
-                                if (!match) return;
-                                options[match[0]] = true;
-                            });
-                        }
-                        if (options['-masm']) {
-                            this.compiler.intelAsm = "-masm=intel";
-                            this.compiler.supportsIntel = true;
-                        }
-
-                        logger.debug("compiler options: ", options);
-
-                        return this;
-                    }, this));
+                return argumentParser(this).then(function(compiler) {
+                    delete compiler.compiler.supportedOptions;
+                    return compiler;
+                });
             }, this),
             _.bind(function (err) {
                 logger.error("Unable to get version for compiler '" + compiler + "' - " + err);
@@ -533,7 +537,8 @@ Compile.prototype.getDefaultFilters = function () {
         intel: true,
         commentOnly: true,
         directives: true,
-        labels: true
+        labels: true,
+        optOutput: false
     };
 };
 

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -143,18 +143,22 @@ Compile.prototype.optionsForFilter = function (filters, outputFilename) {
     if (this.compiler.intelAsm && filters.intel && !filters.binary) {
         options = options.concat(this.compiler.intelAsm.split(" "));
     }
-    if(this.compiler.supportsOptOutput && filters.optOutput) {
-        options = options.concat(this.compiler.optArg);
-    }
     if (!filters.binary) options = options.concat('-S');
     return options;
 };
 
-Compile.prototype.prepareArguments = function (userOptions, filters, inputFilename, outputFilename) {
+Compile.prototype.prepareArguments = function (userOptions, filters, backendOptions, inputFilename, outputFilename) {
     var options = this.optionsForFilter(filters, outputFilename);
+    backendOptions = backendOptions || {};
+    
     if (this.compiler.options) {
         options = options.concat(this.compiler.options.split(" "));
     }
+    
+    if(this.compiler.supportsOptOutput && backendOptions.produceOptInfo) {
+        options = options.concat(this.compiler.optArg);
+    }
+
     return options.concat(userOptions || []).concat([this.filename(inputFilename)]);
 };
 
@@ -213,7 +217,7 @@ Compile.prototype.compile = function (source, options, backendOptions, filters) 
             var dirPath = info.dirPath;
             var outputFilebase = "output";
             var outputFilename = path.join(dirPath, outputFilebase + ".s"); // NB keep lower case as ldc compiler `tolower`s the output name
-            options = self.prepareArguments(options, filters, inputFilename, outputFilename);
+            options = self.prepareArguments(options, filters, backendOptions, inputFilename, outputFilename);
 
             options = options.filter(_.identity);
 

--- a/lib/compile-handler.js
+++ b/lib/compile-handler.js
@@ -94,10 +94,11 @@ function CompileHandler(gccProps, compilerProps) {
             // JSON-style request
             compiler = this.compilersById[req.compiler || req.body.compiler];
             if (!compiler) return next();
+            var requestOptions = req.body.options;
             source = req.body.source;
-            options = req.body.options;
-            backendOptions = req.body.backendOptions;
-            filters = req.body.filters || compiler.getDefaultFilters();
+            options = requestOptions.userArguments;
+            backendOptions = requestOptions.compilerOptions;
+            filters = requestOptions.filters || compiler.getDefaultFilters();
         } else {
             // API-style
             compiler = this.compilersById[req.compiler];

--- a/lib/compilers/argument-parsers.js
+++ b/lib/compilers/argument-parsers.js
@@ -1,0 +1,72 @@
+// Copyright (c) 2012-2017, Jared Wyles
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const   _ = require('underscore-node'),
+      logger = require('../logger').logger,
+      utils = require('../utils');
+
+const getOptions = function(compiler, helpArg) {
+    return compiler.exec(compiler.compiler.exe, [helpArg])
+            .then(_.bind(function (result) {
+                var options = {};
+                if (result.code === 0) {
+                    var splitness = /--?[-a-zA-Z]+( ?[-a-zA-Z]+)/;
+                
+                    utils.eachLine(result.stdout + result.stderr, function (line) {
+                        var match = line.match(splitness);
+                        if (!match) return;
+                        options[match[0]] = true;
+                    });
+                }
+                compiler.compiler.supportedOptions = options;
+                logger.debug("compiler options: ", compiler.compiler.supportedOptions);
+                return compiler;
+        }));
+};
+
+const gccparser = function(compiler) {
+    return getOptions(compiler, "--target-help").then(function(compiler) {
+        if (compiler.compiler.supportedOptions['-masm']) {
+            compiler.compiler.intelAsm = "-masm=intel";
+            compiler.compiler.supportsIntel = true;
+        }
+        return compiler;
+    });
+};
+
+const clangparser = function(compiler) {
+    return getOptions(compiler, "--help").then(function(compiler) {
+        if (compiler.compiler.supportedOptions['-fsave-optimization-record']) {
+            compiler.compiler.optArg = "-fsave-optimization-record";
+            compiler.compiler.supportsOptOutput = true;
+        }
+        return compiler;
+    });
+};
+
+
+module.exports = {
+    "clang": clangparser,
+    "gcc": gccparser
+};

--- a/lib/compilers/default.js
+++ b/lib/compilers/default.js
@@ -22,9 +22,10 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-var Compile = require('../base-compiler');
+const Compile = require('../base-compiler'),
+    argumentParsers = require("./argument-parsers");
 
 module.exports = function (info, env) {
     var comp = new Compile(info, env);
-    return comp.initialise();
+    return comp.initialise(argumentParsers[info.type]);
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bower": "*",
     "chai": "3.5.x",
     "jshint": "*",
-    "mocha": "3.1.x",
+    "mocha": "^3.3.0",
     "requirejs": "*",
     "supervisor": "*",
     "uglify-js": "*"

--- a/static/opt-view.js
+++ b/static/opt-view.js
@@ -75,6 +75,7 @@ define(function (require) {
               this.showOptResults(state.optOutput);
         }
         this.setTitle();
+        this.eventHub.emit("optViewOpened", this._compilerid);
     }
 
     // TODO: de-dupe with compiler etc
@@ -118,11 +119,12 @@ define(function (require) {
         _.mapObject(results, function(value, key) {
             var linenumber = Number(key);
             var className = value.reduce(function(acc, x) {
-                if(acc && acc !== "Analysis" && x.optType !== acc) {
-                    return "Mixed";
-                } else {
-                    return x.optType;
+                if(x.optType == "Missed" || acc == "Missed") {
+                    return "Missed";
+                } else if(x.optType == "Passed" || acc == "Passed") {
+                    return "Passed";
                 }
+                return x.optType;
             },"");
             var contents = _.map(value, this.getDisplayableOpt, this);
             opt.push({

--- a/static/themes.js
+++ b/static/themes.js
@@ -44,7 +44,6 @@ define(function (require) {
     function Themer(eventHub, initialSettings) {
         this.currentTheme = null;
         this.eventHub = eventHub;
-        this.root = root;
 
         this.setTheme = function (theme) {
             if (this.currentTheme === theme) return;

--- a/static/toggles.js
+++ b/static/toggles.js
@@ -47,7 +47,8 @@ define(function (require) {
             .each(function () {
                 $(this).toggleClass('active', !!state[$(this).data().bind]);
             });
-        this.state = get(this.domRoot);
+        _.extend(state, this.domRoot);
+        this.state = state;
     }
 
     _.extend(Toggles.prototype, EventEmitter.prototype);
@@ -56,13 +57,25 @@ define(function (require) {
         return _.clone(this.state);
     };
 
+    Toggles.prototype.set = function (key, value) {
+        this._change(function() {
+            this.state[key] = value;
+        }.bind(this));
+    };
+
+    Toggles.prototype._change = function(update) {
+        var before = this.get();
+        update();
+        this.emit('change', before, this.get()); 
+    };
+
     Toggles.prototype.onClick = function (event) {
         var button = $(event.currentTarget);
         if (button.hasClass("disabled")) return;
         button.toggleClass('active');
-        var before = this.state;
-        var after = this.state = get(this.domRoot);
-        this.emit('change', before, after);
+        this._change(function() {
+            this.state = get(this.domRoot);
+        }.bind(this));
     };
 
     return Toggles;


### PR DESCRIPTION
…of a meta data gatherer

This allows you to name something in a property file with a group. 
You can then use that group name (if it can't infer it) to pick up the argument parser of choice, or we default to llvm.

It tags some options on the filter options, which isn't the greatest. 
I want to merge a single option that gets passed back which is more inline with @TartanLlama work on the ast view. 

This also cleans a few things up for the llvm opt view.
You now just have to click the button and it appends the option, no more having to put it there.
Strip out results that don't exist (no loc) and are not in this file.
Also change the colours a bit, so that if there is any missed opt, it defaults to red. 