### PR TITLE
Allow options for filters to look at useroptions this allows us to ad…

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -139,7 +139,7 @@ Compile.prototype.filename = function (fn) {
     return fn;
 };
 
-Compile.prototype.optionsForFilter = function (filters, outputFilename) {
+Compile.prototype.optionsForFilter = function (filters, outputFilename, userOptions) {
     var options = ['-g', '-o', this.filename(outputFilename)];
     if (this.compiler.intelAsm && filters.intel && !filters.binary) {
         options = options.concat(this.compiler.intelAsm.split(" "));
@@ -149,7 +149,7 @@ Compile.prototype.optionsForFilter = function (filters, outputFilename) {
 };
 
 Compile.prototype.prepareArguments = function (userOptions, filters, backendOptions, inputFilename, outputFilename) {
-    var options = this.optionsForFilter(filters, outputFilename);
+    var options = this.optionsForFilter(filters, outputFilename, userOptions);
     backendOptions = backendOptions || {};
 
     if (this.compiler.options) {

--- a/lib/compilers/CL.js
+++ b/lib/compilers/CL.js
@@ -46,7 +46,7 @@ function compileCl(info, env) {
     compile.supportsObjdump = function () {
         return false;
     };
-    compile.optionsForFilter = function (filters, outputFilename) {
+    compile.optionsForFilter = function (filters, outputFilename, userOptions) {
         return [
             '/FAsc',
             '/c',

--- a/lib/compilers/haskell.js
+++ b/lib/compilers/haskell.js
@@ -2,7 +2,7 @@ var Compile = require('../base-compiler');
 
 function compileHaskell(info, env) {
     var compiler = new Compile(info, env);
-    compiler.optionsForFilter = function (filters, outputFilename) {
+    compiler.optionsForFilter = function (filters, outputFilename, userOptions) {
         return ['-S', '-g', '-o', this.filename(outputFilename)];
     };
     return compiler.initialise();

--- a/lib/compilers/ispc.js
+++ b/lib/compilers/ispc.js
@@ -2,7 +2,7 @@ var Compile = require('../base-compiler');
 
 function compileISPC(info, env) {
     var compiler = new Compile(info, env);
-    compiler.optionsForFilter = function (filters, outputFilename) {
+    compiler.optionsForFilter = function (filters, outputFilename, userOptions) {
         return ['--target=sse2-i32x4', '--emit-asm', '-g', '-o', this.filename(outputFilename)];
     };
     return compiler.initialise();

--- a/lib/compilers/ldc.js
+++ b/lib/compilers/ldc.js
@@ -28,7 +28,7 @@ var Compile = require('../base-compiler'),
 function compileLdc(info, env) {
     var compiler = new Compile(info, env);
     compiler.compiler.supportsIntel = true;
-    compiler.optionsForFilter = function (filters, outputFilename) {
+    compiler.optionsForFilter = function (filters, outputFilename, userOptions) {
         var options = ['-g', '-of', this.filename(outputFilename)];
         if (filters.intel && !filters.binary) options = options.concat('-x86-asm-syntax=intel');
         if (!filters.binary) options = options.concat('-output-s');

--- a/lib/compilers/rust.js
+++ b/lib/compilers/rust.js
@@ -22,16 +22,23 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-var Compile = require('../base-compiler');
+var Compile = require('../base-compiler'),
+    _ = require('underscore-node');
 
 function compileRust(info, env) {
     var compiler = new Compile(info, env);
     compiler.compiler.supportsIntel = true;
-    compiler.optionsForFilter = function (filters, outputFilename) {
+    compiler.optionsForFilter = function (filters, outputFilename, userOptions) {
         var options = ['-C', 'debuginfo=1', '-o', this.filename(outputFilename)];
-        // TODO: binary not supported(?)
+        
+        var userRequestedEmit = _.any(userOptions, function(opt) {
+            return opt.indexOf("--emit") > -1;
+        });
+        //TODO: Binary not supported (?)
         if (!filters.binary) {
-            options = options.concat('--emit', 'asm');
+            if(!userRequestedEmit) {
+                options = options.concat('--emit', 'asm');
+            }
             if (filters.intel) options = options.concat('-Cllvm-args=--x86-asm-syntax=intel');
         }
         options = options.concat(['--crate-type', 'rlib']);


### PR DESCRIPTION
…d/remove options per compiler such as for rust where we need to not add the --emit argument if the user has passed us one