### PR TITLE
Use 'trunk' instead of 'snapshot' to indicate gcc built from source

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -64,7 +64,7 @@ compiler.g71.name=x86-64 gcc 7.1
 compiler.g72.exe=/opt/compiler-explorer/gcc-7.2.0/bin/g++
 compiler.g72.name=x86-64 gcc 7.2
 compiler.gsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/g++
-compiler.gsnapshot.name=x86-64 gcc (snapshot)
+compiler.gsnapshot.name=x86-64 gcc (trunk)
 compiler.gsnapshot.alias=g7snapshot
 
 # Clang for x86


### PR DESCRIPTION
It's easy to confuse and relate the word 'snapshot' with other things
and it doesn't seem quite communicative. Moreover, we already identify
the compiler built from clang's source as 'trunk'.

So, in order to use clear wordings and to be consistent, use the word
'trunk' (at least in the user interface) to identify the compiler built
from gcc's "trunk" ;-)