### PR TITLE
Fixed haskell/demangle linker errors on systems without static ghc libs

### DIFF
--- a/haskell/Makefile
+++ b/haskell/Makefile
@@ -1,6 +1,6 @@
 GHC?=ghc
 demangle: demangle.hs
-	$(GHC) -package ghc demangle.hs
+	$(GHC) -package ghc -dynamic demangle.hs
 
 clean:
 	rm demangle.o demangle demangle.hi


### PR DESCRIPTION
Arch Linux does not install static ghc libraries by default. Running "make run"
without this commit leads to linker errors during the compilation of
haskell/demangle. Compiling demangle with -dynamic fixes this issue.

```
$ make run
make -C haskell
make[1]: Entering directory '/home/racko/gcc-explorer/haskell'
ghc -package ghc demangle.hs
Linking demangle ...
/usr/bin/ld.gold: error: cannot find -lHSghc-8.2.1
/usr/bin/ld.gold: error: cannot find -lHSterminfo-0.4.1.0
/usr/bin/ld.gold: error: cannot find -lHShoopl-3.10.2.2
/usr/bin/ld.gold: error: cannot find -lHSghci-8.2.1
/usr/bin/ld.gold: error: cannot find -lHSghc-boot-8.2.1
/usr/bin/ld.gold: error: cannot find -lHStransformers-0.5.2.0
/usr/bin/ld.gold: error: cannot find -lHShpc-0.6.0.3
/usr/bin/ld.gold: error: cannot find -lHStemplate-haskell-2.12.0.0
/usr/bin/ld.gold: error: cannot find -lHSpretty-1.1.3.3
/usr/bin/ld.gold: error: cannot find -lHSghc-boot-th-8.2.1
/usr/bin/ld.gold: error: cannot find -lHSbinary-0.8.5.1
/usr/bin/ld.gold: error: cannot find -lHScontainers-0.5.10.2
/usr/bin/ld.gold: error: cannot find -lHSprocess-1.6.1.0
/usr/bin/ld.gold: error: cannot find -lHSdirectory-1.3.0.2
/usr/bin/ld.gold: error: cannot find -lHSunix-2.7.2.2
/usr/bin/ld.gold: error: cannot find -lHSbytestring-0.10.8.2
/usr/bin/ld.gold: error: cannot find -lHSfilepath-1.4.1.2
/usr/bin/ld.gold: error: cannot find -lHStime-1.8.0.2
/usr/bin/ld.gold: error: cannot find -lHSdeepseq-1.4.3.0
/usr/bin/ld.gold: error: cannot find -lHSarray-0.5.2.0
/usr/bin/ld.gold: error: cannot find -lHSbase-4.10.0.0
/usr/bin/ld.gold: error: cannot find -lHSinteger-gmp-1.0.1.0
/usr/bin/ld.gold: error: cannot find -lHSghc-prim-0.5.1.0
/usr/bin/ld.gold: error: cannot find -lHSrts
demangle.o:s1LG_info: error: undefined reference to 'stg_upd_frame_info'
demangle.o:s1LG_info: error: undefined reference to 'base_DataziOldList_lines_closure'
demangle.o:s1LH_info: error: undefined reference to 'stg_upd_frame_info'
demangle.o:s1LH_info: error: undefined reference to 'ghc_Encoding_zzDecodeString_closure'
demangle.o:s1LH_info: error: undefined reference to 'base_GHCziBase_map_closure'
demangle.o:s1LI_info: error: undefined reference to 'base_SystemziIO_putStrLn_closure'
demangle.o:s1LI_info: error: undefined reference to 'base_GHCziBase_zdfMonadIO_closure'
demangle.o:s1LI_info: error: undefined reference to 'base_DataziFoldable_zdfFoldableZMZN_closure'
demangle.o:s1LI_info: error: undefined reference to 'base_DataziFoldable_mapMzu_closure'
demangle.o:Main_main_info: error: undefined reference to 'newCAF'
demangle.o:Main_main_info: error: undefined reference to 'stg_bh_upd_frame_info'
demangle.o:Main_main_info: error: undefined reference to 'base_GHCziBase_zdfMonadIO_closure'
demangle.o:Main_main_info: error: undefined reference to 'stg_ap_pp_info'
demangle.o:Main_main_info: error: undefined reference to 'base_SystemziIO_getContents_closure'
demangle.o:ZCMain_main_info: error: undefined reference to 'newCAF'
demangle.o:ZCMain_main_info: error: undefined reference to 'stg_bh_upd_frame_info'
demangle.o:ZCMain_main_info: error: undefined reference to 'base_GHCziTopHandler_runMainIO_closure'
demangle.o:s1LG_info: error: undefined reference to 'stg_ap_p_fast'
demangle.o:s1LH_info: error: undefined reference to 'stg_ap_pp_fast'
demangle.o:s1LI_info: error: undefined reference to 'stg_ap_pppp_fast'
demangle.o:Main_main_info: error: undefined reference to 'base_GHCziBase_zgzgze_info'
demangle.o:ZCMain_main_info: error: undefined reference to 'stg_ap_p_fast'
demangle.o(.data+0x0): error: undefined reference to 'ghczmprim_GHCziTypes_TrNameS_con_info'
demangle.o(.data+0x10): error: undefined reference to 'ghczmprim_GHCziTypes_TrNameS_con_info'
demangle.o(.data+0x20): error: undefined reference to 'ghczmprim_GHCziTypes_Module_con_info'
demangle.o(.data.rel.ro+0x0): error: undefined reference to 'base_DataziOldList_lines_closure'
demangle.o(.data.rel.ro+0x8): error: undefined reference to 'base_GHCziBase_map_closure'
demangle.o(.data.rel.ro+0x10): error: undefined reference to 'ghc_Encoding_zzDecodeString_closure'
demangle.o(.data.rel.ro+0x18): error: undefined reference to 'base_SystemziIO_putStrLn_closure'
demangle.o(.data.rel.ro+0x20): error: undefined reference to 'base_DataziFoldable_mapMzu_closure'
demangle.o(.data.rel.ro+0x28): error: undefined reference to 'base_GHCziBase_zdfMonadIO_closure'
demangle.o(.data.rel.ro+0x30): error: undefined reference to 'base_DataziFoldable_zdfFoldableZMZN_closure'
demangle.o(.data.rel.ro+0x40): error: undefined reference to 'base_SystemziIO_getContents_closure'
demangle.o(.data.rel.ro+0x48): error: undefined reference to 'base_GHCziTopHandler_runMainIO_closure'
/tmp/ghc23780_0/ghc_2.o:ghc_1.c:function main: error: undefined reference to 'defaultRtsConfig'
/tmp/ghc23780_0/ghc_2.o:ghc_1.c:function main: error: undefined reference to 'defaultRtsConfig'
/tmp/ghc23780_0/ghc_2.o:ghc_1.c:function main: error: undefined reference to 'defaultRtsConfig'
/tmp/ghc23780_0/ghc_2.o:ghc_1.c:function main: error: undefined reference to 'defaultRtsConfig'
/tmp/ghc23780_0/ghc_2.o:ghc_1.c:function main: error: undefined reference to 'hs_main'
collect2: error: ld returned 1 exit status
`gcc' failed in phase `Linker'. (Exit code: 1)
make[1]: *** [Makefile:3: demangle] Error 1
make[1]: Leaving directory '/home/racko/btsync/gcc-explorer/haskell'
make: *** [Makefile:36: optional-haskell-support] Error 2
```