### PR TITLE
Use LDC 1.4.0 as default D compiler

### DIFF
--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -1,6 +1,6 @@
 compilers=gdc48:gdc49:gdc52:&ldc
 textBanner=Compilation provided by Compiler Explorer at https://d.godbolt.org/
-defaultCompiler=gdc52
+defaultCompiler=ldc140
 objdumper=/opt/compiler-explorer/gcc-6.3.0/bin/objdump
 
 compiler.gdc49.exe=/opt/compiler-explorer/gdc4.9.3/x86_64-pc-linux-gnu/bin/gdc


### PR DESCRIPTION
...because it supports a much newer dlang version (2.074) compared to GDC 5.2.0 (dlang 2.066).