### PR TITLE
Typo in language selection for ast view monaco editor

### DIFF
--- a/static/ast-view.js
+++ b/static/ast-view.js
@@ -44,7 +44,7 @@ define(function (require) {
         this.astEditor = monaco.editor.create(this.domRoot.find(".monaco-placeholder")[0], {
             value: "",
             scrollBeyondLastLine: false,
-            language: 'cppp', //we only support cpp for now
+            language: 'cpp', //we only support cpp for now
             readOnly: true,
             glyphMargin: true,
             quickSuggestions: false,


### PR DESCRIPTION
ast-view.js: invalid language selected: cppp in place of cpp