### PR TITLE
[WIP] Teach the haskell backend about -ddump-stg (to dump out the haskell IR)

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -462,7 +462,7 @@ Compile.prototype.postProcess = function (result, outputFilename, filters) {
                     const postCommand = 'cat "' + outputFilename + '" | ' + postProcess.join(" | ");
                     return this.exec("bash", ["-c", postCommand], {maxOutput: maxSize})
                         .then((postResult) => {
-                            return this.handlePostProcessResult(result, postResult);
+                            return this.handlePostProcessResult(result, postResult, outputFilename);
                         });
                 } else {
                     return this.readFile(outputFilename).then(function (contents) {

--- a/lib/compilers/haskell.js
+++ b/lib/compilers/haskell.js
@@ -1,5 +1,4 @@
 var Compile = require('../base-compiler');
-var logger = require('../../lib/logger').logger;
 var child_process = require('child_process');
 var path = require('path');
 var _ = require('underscore-node');
@@ -12,8 +11,6 @@ function compileHaskell(info, env) {
             return opt.indexOf("-ddump-stg") > -1;
         });
 
-        logger.warn("usedStg: ", usedStg);
-
         if (usedStg) {
             return ["-ddump-stg", "-ddump-to-file", "-o", this.filename(outputFilename)];
         } else {
@@ -23,11 +20,8 @@ function compileHaskell(info, env) {
 
     compiler.handlePostProcessResult = function (result, postResult, outputFilename) {
         if (usedStg) {
-            logger.info("handlePostProcessResult::usedStg");
             const dirExploded = path.parse(outputFilename);
-            logger.info(dirExploded);
             const catStgFileCommand = 'cat ' + dirExploded.dir + '/' + 'example' + '.dump-stg';
-            logger.info(catStgFileCommand);
             const stgData = child_process.execSync(catStgFileCommand).toString();
             result.asm = stgData;
             return result;

--- a/lib/compilers/haskell.js
+++ b/lib/compilers/haskell.js
@@ -15,7 +15,7 @@ function compileHaskell(info, env) {
         logger.warn("usedStg: ", usedStg);
 
         if (usedStg) {
-            return ["-ddump-stg", "-ddump-to-file", "-o", this.filename(outputFilename)]
+            return ["-ddump-stg", "-ddump-to-file", "-o", this.filename(outputFilename)];
         } else {
             return ['-S', '-g', '-o', this.filename(outputFilename)];
         }

--- a/lib/compilers/haskell.js
+++ b/lib/compilers/haskell.js
@@ -22,8 +22,7 @@ function compileHaskell(info, env) {
         if (usedStg) {
             const dirExploded = path.parse(outputFilename);
             const catStgFileCommand = 'cat ' + dirExploded.dir + '/' + 'example' + '.dump-stg';
-            const stgData = child_process.execSync(catStgFileCommand).toString();
-            result.asm = stgData;
+            result.asm = child_process.execSync(catStgFileCommand).toString();
             return result;
         }
         else {

--- a/lib/compilers/haskell.js
+++ b/lib/compilers/haskell.js
@@ -1,10 +1,43 @@
 var Compile = require('../base-compiler');
+var logger = require('../../lib/logger').logger;
+var child_process = require('child_process');
+var path = require('path');
+var _ = require('underscore-node');
 
 function compileHaskell(info, env) {
     var compiler = new Compile(info, env);
     compiler.optionsForFilter = function (filters, outputFilename, userOptions) {
-        return ['-S', '-g', '-o', this.filename(outputFilename)];
+
+        usedStg = _.any(userOptions, function(opt) {
+            return opt.indexOf("-ddump-stg") > -1;
+        });
+
+        logger.warn("usedStg: ", usedStg);
+
+        if (usedStg) {
+            return ["-ddump-stg", "-ddump-to-file", "-o", this.filename(outputFilename)]
+        } else {
+            return ['-S', '-g', '-o', this.filename(outputFilename)];
+        }
     };
+
+    compiler.handlePostProcessResult = function (result, postResult, outputFilename) {
+        if (usedStg) {
+            logger.info("handlePostProcessResult::usedStg");
+            const dirExploded = path.parse(outputFilename);
+            logger.info(dirExploded);
+            const catStgFileCommand = 'cat ' + dirExploded.dir + '/' + 'example' + '.dump-stg';
+            logger.info(catStgFileCommand);
+            const stgData = child_process.execSync(catStgFileCommand).toString();
+            result.asm = stgData;
+            return result;
+        }
+        else {
+            result.asm = postResult.stdout;
+            return result;
+        }
+    };
+
     return compiler.initialise();
 }
 

--- a/lib/compilers/haskell.js
+++ b/lib/compilers/haskell.js
@@ -5,6 +5,10 @@ var _ = require('underscore-node');
 
 function compileHaskell(info, env) {
     var compiler = new Compile(info, env);
+    // this is "global" to share state between optionsForFilter and
+    // handlePostProcessResult.
+    var usedStg = false;
+
     compiler.optionsForFilter = function (filters, outputFilename, userOptions) {
 
         usedStg = _.any(userOptions, function(opt) {


### PR DESCRIPTION
Since I'm working on [`simplexhc`](http://github.com/bollu/simplexhc), I want to use `godbolt` to show off the differences between my compiler and GHC. However, to do this, I need to be able to dump `stg` from `ghc`.

This patch is very rough, so I'll iterate on this. Do you have any initial feedback about _how_ I'm doing this?