### PR TITLE
Add explicit WSL option to resolve issue #468

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,14 +53,16 @@ var opts = nopt({
     'static': [String],
     'archivedVersions': [String],
     'noRemoteFetch': [Boolean],
-    'tmpDir': [String]
+    'tmpDir': [String],
+    'wsl': [Boolean]
 });
 
 if (opts.debug) logger.level = 'debug';
 
 // AP: Detect if we're running under Windows Subsystem for Linux. Temporary modification
 // of process.env is allowed: https://nodejs.org/api/process.html#process_process_env
-if (child_process.execSync('uname -a').toString().indexOf('Microsoft') > -1)
+if ((child_process.execSync('uname -a').toString().indexOf('Microsoft') > -1)
+    && (opts.wsl))
     process.env.wsl = true;
 
 // AP: Allow setting of tmpDir (used in lib/base-compiler.js & lib/exec.js) through

--- a/app.js
+++ b/app.js
@@ -61,8 +61,7 @@ if (opts.debug) logger.level = 'debug';
 
 // AP: Detect if we're running under Windows Subsystem for Linux. Temporary modification
 // of process.env is allowed: https://nodejs.org/api/process.html#process_process_env
-if ((child_process.execSync('uname -a').toString().indexOf('Microsoft') > -1)
-    && (opts.wsl))
+if ((child_process.execSync('uname -a').toString().indexOf('Microsoft') > -1) && (opts.wsl))
     process.env.wsl = true;
 
 // AP: Allow setting of tmpDir (used in lib/base-compiler.js & lib/exec.js) through


### PR DESCRIPTION
The WSL support is beta at best, and is waiting on WSL features/fixes from @benhillis such as exposing Windows environment variables to WSL. But it seemed harmless to integrate, so we did. 

I didn't consider that people would want to run the Compiler Explorer under WSL *without* trying to set up MSVC to run on Windows. My changes broke that scenario, as pointed out in #468. This PR adds an option to explicitly specify that you want to run under WSL.

If you want to run under WSL with Windows support, with this change you will need to invoke as `make EXTRA_ARGS="--wsl"` in order to allow MSVC to find its temporary files. If you do not pass this argument, WSL will work with any non-MSVC compilers as per usual. 



