### PR TITLE
gccdump: display message for empty dump files

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -515,6 +515,9 @@ Compile.prototype.processGccDumpOutput = function (opts) {
 
         if (fs.existsSync(passDump) && fs.statSync(passDump).isFile()) {
             output.currentPassOutput = fs.readFileSync(passDump, 'utf-8');
+            if (output.currentPassOutput.match('^\s*$')) {
+                output.currentPassOutput = 'File for selected pass is empty.';
+            }
         } else {
             // most probably filter has changed and the request is outdated.
             output.currentPassOutput = "Pass '" + output.selectedPass + "' was requested\n";


### PR DESCRIPTION
Some passes can produce empty file. Avoid user confusion by making
this emptyness explicit to the user.

This was suggested by @honggyukim