### PR TITLE
support both asm output and objdumb output

### DIFF
--- a/lib/compilers/fpc.js
+++ b/lib/compilers/fpc.js
@@ -29,16 +29,20 @@ var Compile = require('../base-compiler'),
 function compileFPC(info, env) {
     var compiler = new Compile(info, env);
     compiler.supportsOptOutput = false;
+    compiler.originalPostProcess = compiler.postProcess;
 
-    compiler.getOutputFilename = function (dirPath, outputFilebase) {
-        var outputFilename = path.join(dirPath, outputFilebase + ".o");
-        return outputFilename;
+    compiler.postProcess = function (result, outputFilename, filters) {
+        if (filters.binary && this.supportsObjdump()) {
+            outputFilename = outputFilename.replace(".s", ".o");
+        }
+
+        return this.originalPostProcess(result, outputFilename, filters);
     };
 
     compiler.optionsForFilter = function (filters, outputFilename, userOptions) {
         filters.execute = false;
 
-        return ['@/opt/compiler-explorer/fpc/fpc.cfg'];
+        return ['@/opt/compiler-explorer/fpc/fpc.cfg', '-a'];
     };
 
     return compiler.initialise();


### PR DESCRIPTION
This change is not the prettiest, but this way the FPC compiler supports both it's original ASM output and the objdump output