### PR TITLE
doc: Add syntax highlighting for javascript in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If JSON is present in the request's `Accept` header, the compilation results are
 
 Optional values are marked with a '**'
 
-```
+```javascript
 {
   "code": 0 if successful, else compiler return code,
   "stdout": [


### PR DESCRIPTION
It'd be better to have color in JavsScript code in README.