### PR TITLE
Add improvements to D language support in editor

### DIFF
--- a/static/d-mode.js
+++ b/static/d-mode.js
@@ -200,6 +200,7 @@ define(function (require) {
                     // strings
                     [/"([^"\\]|\\.)*$/, 'string.invalid'],  // non-teminated string
                     [/"/, 'string', '@string'],
+                    [/`/, 'string', '@rawstring'],
 
                     // characters
                     [/'[^\\']'/, 'string'],
@@ -228,6 +229,11 @@ define(function (require) {
                     [/@escapes/, 'string.escape'],
                     [/\\./, 'string.escape.invalid'],
                     [/"/, 'string', '@pop']
+                ],
+
+                rawstring: [
+                    [/[^\`]/, "string"],
+                    [/`/, "string", "@pop"]
                 ],
             }
         };

--- a/static/d-mode.js
+++ b/static/d-mode.js
@@ -211,17 +211,22 @@ define(function (require) {
                 whitespace: [
                     [/[ \t\r\n]+/, 'white'],
                     [/\/\*/, 'comment', '@comment'],
-                    [/\/\+/, 'comment', '@comment'],
+                    [/\/\+/, 'comment', '@nestingcomment'],
                     [/\/\/.*$/, 'comment'],
                 ],
 
                 comment: [
                     [/[^\/*]+/, 'comment'],
-                    [/\/\+/, 'comment', '@push'],
-                    [/\/\*/, 'comment.invalid'],
-                    ["\\*/", 'comment', '@pop'],
-                    ["\\+/", 'comment', '@pop'],
+                    [/\*\//, 'comment', '@pop'],
                     [/[\/*]/, 'comment']
+                ],
+
+                nestingcomment: [
+                    [/[^\/+]+/, 'comment'],
+                    [/\/\+/, 'comment', '@push'],
+                    [/\/\+/, 'comment.invalid'],
+                    [/\+\//, 'comment', '@pop'],
+                    [/[\/+]/, 'comment']
                 ],
 
                 string: [

--- a/static/d-mode.js
+++ b/static/d-mode.js
@@ -244,6 +244,40 @@ define(function (require) {
         };
     }
 
+    function configuration() {
+        return {
+            comments: {
+                lineComment: '//',
+                blockComment: ['/*', '*/'],
+            },
+
+            brackets: [
+                ['{', '}'],
+                ['[', ']'],
+                ['(', ')']
+            ],
+
+            autoClosingPairs: [
+                { open: '{', close: '}' },
+                { open: '[', close: ']' },
+                { open: '(', close: ')' },
+                { open: '`', close: '`', notIn: ['string'] },
+                { open: '"', close: '"', notIn: ['string'] },
+                { open: '\'', close: '\'', notIn: ['string', 'comment'] },
+            ],
+
+            surroundingPairs: [
+                { open: '{', close: '}' },
+                { open: '[', close: ']' },
+                { open: '(', close: ')' },
+                { open: '`', close: '`' },
+                { open: '"', close: '"' },
+                { open: '\'', close: '\'' },
+            ]
+        };
+    }
+
     monaco.languages.register({id: 'd'});
     monaco.languages.setMonarchTokensProvider('d', definition());
+    monaco.languages.setLanguageConfiguration('d', configuration());
 });


### PR DESCRIPTION
- Support `` `wysiwyg` `` strings.
- Fix `/+ nesting /+ block +/ comments +/` highlighting
- Add language configuration for D, so that the editor auto-indents and adds closing braces as you type (you may also want to do this for other third party languages such as rust or swift).