### PR TITLE
gccdump: disable view when invalid compiler selected

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -305,7 +305,7 @@ Compile.prototype.compile = function (source, options, backendOptions, filters) 
                         asmResult.astOutput = astResult;
                     }
 
-                    if (gccDumpResult) {
+                    if (self.compiler.supportsGccDump && gccDumpResult) {
                         asmResult.hasGccDumpOutput = true;
                         asmResult.gccDumpOutput = gccDumpResult;
                     }

--- a/lib/compilers/argument-parsers.js
+++ b/lib/compilers/argument-parsers.js
@@ -48,6 +48,7 @@ const getOptions = function (compiler, helpArg) {
 
 const gccparser = function (compiler) {
     return getOptions(compiler, "--target-help").then(function (compiler) {
+        compiler.compiler.supportsGccDump = true;
         if (compiler.compiler.supportedOptions['-masm']) {
             compiler.compiler.intelAsm = "-masm=intel";
             compiler.compiler.supportsIntel = true;

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -779,7 +779,7 @@ define(function (require) {
 
     Compiler.prototype.onGccDumpViewClosed = function (id) {
         if (this.id === id) {
-            this.gccDumpButton.prop('disabled', false);
+            this.gccDumpButton.prop('disabled', !this.compiler.supportsGccDump);
             this.gccDumpViewOpen = false;
 
             delete this.gccDumpPassSelected;
@@ -844,6 +844,12 @@ define(function (require) {
             this.cfgButton.prop('disabled', !this.compilerSupportsCfg);
         } else {
             this.cfgButton.prop('disabled', true);
+        }
+
+        if (!this.gccDumpViewOpen) {
+            this.gccDumpButton.prop('disabled', !this.compiler.supportsGccDump);
+        } else {
+            this.gccDumpButton.prop('disabled', true);
         }
     };
 

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -53,7 +53,7 @@
             span.glyphicon.glyphicon-scale
           button.btn.btn-default.btn-sm.view-ast(title="Show AST output (Clang only)")
             span.glyphicon.glyphicon-tree-deciduous
-          button.btn.btn-default.btn-sm.view-gccdump(title="Show GCC's Tree/RTL dump")
+          button.btn.btn-default.btn-sm.view-gccdump(title="Show Tree/RTL dump (GCC only)")
             span.glyphicon.glyphicon-tree-conifer
           button.btn.btn-default.btn-sm.view-cfg(title="Show Graph Output")
             span.glyphicon.glyphicon-lamp


### PR DESCRIPTION
Try to disable view's UI when an invalid compiler (ie. non-GCC) is
selected after the view is opened.
Also changed the hover tip for gccdump to be more homogeneous with
other buttons.

fix #638 

I've decided to follow the «quick and not so clean» path, instead of trying to refactor the compiler type system (could be a good exercise, but ti would take weeks before I could come up with something...)