### PR TITLE
[WIP] Support for reading PE32 ObjDumps provided there's a useful .map file

### DIFF
--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -4,6 +4,7 @@ defaultCompiler=fpc302
 group.fpc.compilers=fpc260:fpc262:fpc264:fpc302
 group.fpc.options=@/opt/compiler-explorer/fpc/fpc.cfg -g -al
 group.fpc.demangler=/dev/null
+group.fpc.objdumper=/opt/compiler-explorer/gcc-7.2.0/bin/objdump
 compiler.fpc260.exe=/opt/compiler-explorer/fpc-2.6.0.x86_64-linux/bin/fpc
 compiler.fpc260.name=x86-64 fpc 2.6.0
 compiler.fpc262.exe=/opt/compiler-explorer/fpc-2.6.2.x86_64-linux/bin/fpc

--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -25,6 +25,8 @@ compiler.delphi15.exe=/opt/compiler-explorer/delphi_15/Bin/DCC32.EXE
 compiler.delphi15.name=x86 Delphi 7 (15.0)
 compiler.delphi20.exe=/opt/compiler-explorer/delphi_20/bin/DCC32.EXE
 compiler.delphi20.name=x86 Delphi 2009 (20.0)
+compiler.delphi22.exe=/opt/compiler-explorer/delphi_22/bin/DCC32.EXE
+compiler.delphi22.name=x86 Delphi XE (22.0)
 
 #################################
 #################################

--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -1,10 +1,9 @@
-compilers=&fpc
+compilers=&fpc:&delphi
 defaultCompiler=fpc302
 
 group.fpc.compilers=fpc260:fpc262:fpc264:fpc302
 group.fpc.options=@/opt/compiler-explorer/fpc/fpc.cfg -g -al
 group.fpc.demangler=/dev/null
-group.fpc.objdumper=/opt/compiler-explorer/gcc-7.2.0/bin/objdump
 compiler.fpc260.exe=/opt/compiler-explorer/fpc-2.6.0.x86_64-linux/bin/fpc
 compiler.fpc260.name=x86-64 fpc 2.6.0
 compiler.fpc262.exe=/opt/compiler-explorer/fpc-2.6.2.x86_64-linux/bin/fpc
@@ -13,6 +12,16 @@ compiler.fpc264.exe=/opt/compiler-explorer/fpc-2.6.4.x86_64-linux/bin/fpc
 compiler.fpc264.name=x86-64 fpc 2.6.4
 compiler.fpc302.exe=/opt/compiler-explorer/fpc-3.0.2.x86_64-linux/bin/fpc
 compiler.fpc302.name=x86-64 fpc 3.0.2
+
+#################################
+# Delphi
+group.delphi.compilers=delphi15
+group.delphi.compilerType=pascal-win
+group.delphi.demangler=
+group.delphi.objdumper=objdump
+group.delphi.versionFlags=| grep "Version"
+compiler.delphi15.exe=/opt/compiler-explorer/delphi_15/Bin/DCC32.EXE
+compiler.delphi15.name=x86 Delphi 7 (15.0)
 
 #################################
 #################################

--- a/etc/config/pascal.amazon.properties
+++ b/etc/config/pascal.amazon.properties
@@ -23,6 +23,8 @@ group.delphi.objdumper=objdump
 group.delphi.versionFlags=| grep "Version"
 compiler.delphi15.exe=/opt/compiler-explorer/delphi_15/Bin/DCC32.EXE
 compiler.delphi15.name=x86 Delphi 7 (15.0)
+compiler.delphi20.exe=/opt/compiler-explorer/delphi_20/bin/DCC32.EXE
+compiler.delphi20.name=x86 Delphi 2009 (20.0)
 
 #################################
 #################################

--- a/lib/asm.js
+++ b/lib/asm.js
@@ -253,6 +253,10 @@ function AsmParser(compilerProps) {
             return [{text: asmLines[0], source: null}];
         }
 
+        if (filters.preProcessBinaryAsmLines !== undefined) {
+            asmLines = filters.preProcessBinaryAsmLines(asmLines);
+        }
+
         asmLines.forEach(function (line) {
             if (result.length >= maxAsmLines) {
                 if (result.length == maxAsmLines) {

--- a/lib/compilers/pascal-win.js
+++ b/lib/compilers/pascal-win.js
@@ -1,0 +1,152 @@
+// Copyright (c) 2017, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+var Compile = require('../base-compiler');
+var asm = require('../asm-cl');
+var path = require('path');
+var utils = require('../utils');
+var fs = require('fs');
+var logger = require('../logger').logger;
+var PascalDemangler = require('../pascal-support').demangler,
+    PascalLabelReconstructor = require('../pe32-support').labelReconstructor;
+
+function compilePascalWin32(info, env) {
+    var compile = new Compile(info, env);
+
+    info.supportsFiltersInBinary = true;
+    if (process.platform == "linux") {
+        var wine = env.gccProps("wine");
+        var origExec = compile.exec;
+        compile.exec = function (command, args, options) {
+            if (command.toLowerCase().endsWith(".exe")) {
+                args.unshift(command);
+                command = wine;
+            }
+            return origExec(command, args, options);
+        };
+        compile.filename = function (fn) {
+            return 'Z:' + fn;
+        };
+    }
+
+    var currentlyActiveFilters = [];
+    var mapFilename = false;
+
+    compile.objdump = function (outputFilename, result, maxSize, intelAsm, demangle) {
+        outputFilename = path.join(path.dirname(outputFilename), "prog.exe");
+
+        var args = ["-d", outputFilename];
+        //if (demangle) args = args.concat(["-um"]);
+        if (intelAsm) args = args.concat(["-M", "intel"]);
+        return this.exec(this.compiler.objdumper, args, {maxOutput: maxSize})
+           .then(function (objResult) {
+               if (objResult.code !== 0) {
+                   result.asm = "<No output: objdump returned " + objResult.code + ">";
+               } else {
+                   result.asm = objResult.stdout;
+               }
+
+               return result;
+           });
+    };
+
+    var saveDummyProjectFile = function (filename) {
+        if (filename.startsWith("Z:")) {
+            filename = filename.substr(2);
+        }
+        fs.writeFile(filename,
+            "program prog; " +
+            "uses output in 'output.pas'; " +
+            "begin " +
+            "end.");
+    };
+
+    compile.runCompiler = function (compiler, options, inputFilename, execOptions) {
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+
+        var libPath = path.dirname(path.dirname(compiler) + '../') + '/Lib/';
+
+        var tempPath = path.dirname(inputFilename);
+        var projectFile = path.join(tempPath, "prog.dpr");
+
+        mapFilename = path.join(tempPath.substr(2), "prog.map");
+
+        saveDummyProjectFile(projectFile);
+
+        options.pop();
+        options.push('-E' + tempPath.replace(/\//g, '\\'));
+        options.push('-N' + tempPath.replace(/\//g, '\\'));
+        options.push('-I' + tempPath.replace(/\//g, '\\'));
+        options.push('-CC');
+        options.push('-W');
+        options.push('-H');
+        options.push('-GD');
+        options.push('-$D+');
+        options.push('-V');
+        options.push('-B');
+        options.push('-U' + 'Z:' + libPath.replace(/\//g, '\\') + ';' + tempPath.replace(/\//g, '\\'));
+        options.push(inputFilename.replace(/\//g, '\\'));
+
+        var self = this;
+        return this.exec(compiler, options, execOptions).then(function (result) {
+            options.pop();
+            options.push(projectFile.replace(/\//g, '\\'));
+
+            return self.exec(compiler, options, execOptions).then(function (result) {
+                result.inputFilename = inputFilename;
+                result.stdout = utils.parseOutput(result.stdout, inputFilename);
+                result.stderr = utils.parseOutput(result.stderr, inputFilename);
+                return result;
+            });
+        });
+    };
+
+    var preProcessBinaryAsmLines = function(asmLines) {
+        var reconstructor = new PascalLabelReconstructor(asmLines, mapFilename, false);
+        reconstructor.Run();
+
+        fs.writeFile("/tmp/test.txt", reconstructor.asmLines.join("\n"));
+
+        return reconstructor.asmLines;
+    };
+
+    compile.optionsForFilter = function (filters, outputFilename, userOptions) {
+        currentlyActiveFilters = filters;
+        filters.preProcessBinaryAsmLines = preProcessBinaryAsmLines;
+
+        return [];
+
+        // return [
+        //     '/FAsc',
+        //     '/c',
+        //     '/Fa' + this.filename(outputFilename),
+        //     '/Fo' + this.filename(outputFilename + '.obj')
+        // ];
+    };
+    return compile.initialise();
+}
+
+module.exports = compilePascalWin32;

--- a/lib/compilers/pascal-win.js
+++ b/lib/compilers/pascal-win.js
@@ -106,7 +106,6 @@ function compilePascalWin32(info, env) {
         options.push('-$D+');
         options.push('-V');
         options.push('-B');
-        options.push('-U' + 'Z:' + libPath.replace(/\//g, '\\') + ';' + tempPath.replace(/\//g, '\\'));
         options.push(inputFilename.replace(/\//g, '\\'));
 
         return this.exec(compiler, options, execOptions).then(function (result) {

--- a/lib/compilers/pascal-win.js
+++ b/lib/compilers/pascal-win.js
@@ -57,7 +57,6 @@ function compilePascalWin32(info, env) {
         outputFilename = path.join(path.dirname(outputFilename), "prog.exe");
 
         var args = ["-d", outputFilename];
-        //if (demangle) args = args.concat(["-um"]);
         if (intelAsm) args = args.concat(["-M", "intel"]);
         return this.exec(this.compiler.objdumper, args, {maxOutput: maxSize})
            .then(function (objResult) {
@@ -110,25 +109,22 @@ function compilePascalWin32(info, env) {
         options.push('-U' + 'Z:' + libPath.replace(/\//g, '\\') + ';' + tempPath.replace(/\//g, '\\'));
         options.push(inputFilename.replace(/\//g, '\\'));
 
-        var self = this;
         return this.exec(compiler, options, execOptions).then(function (result) {
             options.pop();
             options.push(projectFile.replace(/\//g, '\\'));
 
-            return self.exec(compiler, options, execOptions).then(function (result) {
+            return this.exec(compiler, options, execOptions).then(function (result) {
                 result.inputFilename = inputFilename;
                 result.stdout = utils.parseOutput(result.stdout, inputFilename);
                 result.stderr = utils.parseOutput(result.stderr, inputFilename);
                 return result;
             });
-        });
+        }.bind(this));
     };
 
     var preProcessBinaryAsmLines = function(asmLines) {
         var reconstructor = new PascalLabelReconstructor(asmLines, mapFilename, false);
         reconstructor.Run();
-
-        fs.writeFile("/tmp/test.txt", reconstructor.asmLines.join("\n"));
 
         return reconstructor.asmLines;
     };
@@ -138,13 +134,6 @@ function compilePascalWin32(info, env) {
         filters.preProcessBinaryAsmLines = preProcessBinaryAsmLines;
 
         return [];
-
-        // return [
-        //     '/FAsc',
-        //     '/c',
-        //     '/Fa' + this.filename(outputFilename),
-        //     '/Fo' + this.filename(outputFilename + '.obj')
-        // ];
     };
     return compile.initialise();
 }

--- a/lib/compilers/pascal-win.js
+++ b/lib/compilers/pascal-win.js
@@ -70,13 +70,14 @@ function compilePascalWin32(info, env) {
            });
     };
 
-    var saveDummyProjectFile = function (filename) {
-        if (filename.startsWith("Z:")) {
-            filename = filename.substr(2);
+    var saveDummyProjectFile = function (dprfile, sourcefile) {
+        if (dprfile.startsWith("Z:")) {
+            dprfile = dprfile.substr(2);
         }
-        fs.writeFile(filename,
+
+        fs.writeFile(dprfile,
             "program prog; " +
-            "uses output in 'output.pas'; " +
+            "uses output in '" + sourcefile + "'; " +
             "begin " +
             "end.");
     };
@@ -86,19 +87,15 @@ function compilePascalWin32(info, env) {
             execOptions = this.getDefaultExecOptions();
         }
 
-        var libPath = path.dirname(path.dirname(compiler) + '../') + '/Lib/';
-
         var tempPath = path.dirname(inputFilename);
         var projectFile = path.join(tempPath, "prog.dpr");
 
         mapFilename = path.join(tempPath.substr(2), "prog.map");
 
-        saveDummyProjectFile(projectFile);
+        inputFilename = inputFilename.replace(/\//g, '\\');
+        saveDummyProjectFile(projectFile, inputFilename);
 
         options.pop();
-        options.push('-E' + tempPath.replace(/\//g, '\\'));
-        options.push('-N' + tempPath.replace(/\//g, '\\'));
-        options.push('-I' + tempPath.replace(/\//g, '\\'));
         options.push('-CC');
         options.push('-W');
         options.push('-H');
@@ -106,19 +103,14 @@ function compilePascalWin32(info, env) {
         options.push('-$D+');
         options.push('-V');
         options.push('-B');
-        options.push(inputFilename.replace(/\//g, '\\'));
+        options.push(projectFile.replace(/\//g, '\\'));
 
         return this.exec(compiler, options, execOptions).then(function (result) {
-            options.pop();
-            options.push(projectFile.replace(/\//g, '\\'));
-
-            return this.exec(compiler, options, execOptions).then(function (result) {
-                result.inputFilename = inputFilename;
-                result.stdout = utils.parseOutput(result.stdout, inputFilename);
-                result.stderr = utils.parseOutput(result.stderr, inputFilename);
-                return result;
-            });
-        }.bind(this));
+            result.inputFilename = inputFilename;
+            result.stdout = utils.parseOutput(result.stdout, inputFilename);
+            result.stderr = utils.parseOutput(result.stderr, inputFilename);
+            return result;
+        });
     };
 
     var preProcessBinaryAsmLines = function(asmLines) {

--- a/lib/map-file.js
+++ b/lib/map-file.js
@@ -23,7 +23,9 @@
 // POSSIBILITY OF SUCH DAMAGE.
 "use strict";
 
-var fs = require("fs");
+var fs = require("fs"),
+    utils = require("./utils"),
+    logger = require("./logger").logger;
 
 class MapFileReader {
     /**
@@ -35,21 +37,29 @@ class MapFileReader {
         this.mapFilename = mapFilename;
         this.preferredLoadAddress = 0x400000;
         this.segmentMultiplier = 0x1000;
+        this.segmentOffsets = [];
         this.segments = [];
+        this.isegments = [];
         this.namedAddresses = [];
         this.lineNumbers = [];
         this.entryPoint = "";
         
         this.regexVSLoadAddress = /\sPreferred load address is ([0-9a-f]*)/i;
 
+        this.regexDelphiCodeSegmentOffset = /^\s([0-9a-f]*):([0-9a-f]*)\s*([0-9a-f]*)H\s*(\.[a-z\$]*)\s*([A-Z]*)$/i;
+
         this.regexDelphiCodeSegment = /^\s([0-9a-f]*):([0-9a-f]*)\s*([0-9a-f]*)\s*C=CODE\s*S=.text\s*G=.*M=([\w\d]*)\s.*/i;
         this.regexVsCodeSegment = /^\s([0-9a-f]*):([0-9a-f]*)\s*([0-9a-f]*)H\s*\.text\$mn\s*CODE.*/i;
+
+        this.regexDelphiICodeSegment = /^\s([0-9a-f]*):([0-9a-f]*)\s*([0-9a-f]*)\s*C=ICODE\s*S=.itext\s*G=.*M=([\w\d]*)\s.*/i;
 
         this.regexDelphiNames = /^\s([0-9a-f]*):([0-9a-f]*)\s*([a-z0-9_@\.]*)$/i;
         this.regexVsNames = /^\s([0-9a-f]*):([0-9a-f]*)\s*([a-z0-9\?\$_@\.]*)\s*([0-9a-f]*)(\sf\si\s*|\sf\s*|\s*)([a-z0-9\-\._<>:]*)$/i;
 
         this.regexDelphiLineNumbersStart = /Line numbers for (.*)\(.*\) segment \.text/i;
         this.regexDelphiLineNumber = /^([0-9]*)\s([0-9a-f]*):([0-9a-f]*)/i;
+
+        this.regexDelphiLineNumbersStartIText = /Line numbers for (.*)\(.*\) segment \.itext/i;
     }
 
     Run() {
@@ -60,12 +70,84 @@ class MapFileReader {
 
     /**
      * 
+     * @param {string} segment 
+     * @returns {number} 
+     */
+    GetSegmentOffset(segment) {
+        if (this.segmentOffsets.length > 0) {
+            for (var idx = 0; idx < this.segmentOffsets.length; idx++) {
+                var info = this.segmentOffsets[idx];
+                if (info.segment === segment) {
+                    return info.addressInt;
+                }
+            }
+        }
+
+        // default
+        return this.preferredLoadAddress + parseInt(segment, 16) * this.segmentMultiplier;
+    }
+
+    /**
+     * 
+     * @param {string} segment 
+     * @param {number} address 
+     */
+    SetSegmentOffset(segment, address) {
+        var info = false;
+        var idx = 0;
+
+        for (idx = 0; idx < this.segments.length; idx++) {
+            info = this.segments[idx];
+            if (info.segment === segment) {
+                this.segments[idx].addressInt = address;
+                this.segments[idx].address = address.toString(16);
+            }
+        }
+
+        if (this.segmentOffsets.length > 0) {
+            for (idx = 0; idx < this.segmentOffsets.length; idx++) {
+                info = this.segmentOffsets[idx];
+                if (info.segment === segment) {
+                    this.segmentOffsets[idx].addressInt = address;
+                    this.segmentOffsets[idx].address = address.toString(16);
+                    return;
+                }
+            }
+        }
+
+        // else, add it
+        this.segmentOffsets.push({
+            "segment": segment,
+            "addressInt": address,
+            "address": address.toString(16),
+            "segmentLength": 0
+        });
+    }
+
+    /**
+     * 
      * @param {string} unitName 
      * @returns {(Object|boolean)} 
      */
     GetSegmentInfoByUnitName(unitName) {
         for (var idx = 0; idx < this.segments.length; idx++) {
             var info = this.segments[idx];
+            if (info.unitName === unitName) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} unitName 
+     * @returns {(Object|boolean)} 
+     */
+    GetICodeSegmentInfoByUnitName(unitName) {
+        for (var idx = 0; idx < this.isegments.length; idx++) {
+            var info = this.isegments[idx];
             if (info.unitName === unitName) {
                 return info;
             }
@@ -99,7 +181,7 @@ class MapFileReader {
             var info = this.segments[idx];
             if (!segment && (info.addressInt === address)) {
                 return info;
-            } else if ((info.segment === segment) && (info.addressInt === address)) {
+            } else if ((info.segment === segment) && (info.addressWithoutOffset === address)) {
                 return info;
             }
         }
@@ -109,14 +191,16 @@ class MapFileReader {
 
     /**
      * Get Segment info for the segment where the given address is in
-     * @param {string} segment 
+     * @param {(string|boolean)} segment 
      * @param {number} address 
      * @returns {(Object|boolean)} 
      */
     GetSegmentInfoAddressIsIn(segment, address) {
         for (var idx = 0; idx < this.segments.length; idx++) {
             var info = this.segments[idx];
-            if ((segment === info.segment) && (address >= info.addressInt) && (address < (info.addressInt + info.segmentLength))) {
+            if (!segment && (address >= info.addressInt) && (address < (info.addressInt + info.segmentLength))) {
+                return info;
+            } else if ((segment === info.segment) && (address >= info.addressWithoutOffset) && (address < (info.addressWithoutOffset + info.segmentLength))) {
                 return info;
             }
         }
@@ -143,23 +227,6 @@ class MapFileReader {
 
     /**
      * 
-     * @param {string} segment 
-     * @param {number} address 
-     * @returns {(Object|boolean)} 
-     */
-    GetSegmentInfoForAddressWithoutOffset(segment, address) {
-        for (var idx = 0; idx < this.segments.length; idx++) {
-            var info = this.segments[idx];
-            if ((segment === info.segment) && (address === info.addressWithoutOffset)) {
-                return info;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * 
      * @param {(string|boolean)} segment 
      * @param {number} address 
      * @returns {(Object|boolean)} 
@@ -169,7 +236,7 @@ class MapFileReader {
             var lineInfo = this.lineNumbers[idx];
             if (!segment && (lineInfo.addressInt === address)) {
                 return lineInfo;
-            } else if ((segment === lineInfo.segment) && (lineInfo.addressInt === address)) {
+            } else if ((segment === lineInfo.segment) && (lineInfo.addressWithoutOffset === address)) {
                 return lineInfo;
             }
         }
@@ -188,7 +255,7 @@ class MapFileReader {
             var info = this.namedAddresses[idx];
             if (!segment && (info.addressInt === address)) {
                 return info;
-            } else if ((segment === info.segment) && (info.addressInt === address)) {
+            } else if ((segment === info.segment) && (info.addressWithoutOffset === address)) {
                 return info;
             }
         }
@@ -223,46 +290,69 @@ class MapFileReader {
         }
     }
 
+    AddressToObject(segment, address) {
+        var addressWithoutOffset = parseInt(address, 16);
+        var addressWithOffset = this.GetSegmentOffset(segment) + addressWithoutOffset;
+
+        return {
+            "segment": segment,
+            "addressWithoutOffset": addressWithoutOffset,
+            "addressInt": addressWithOffset,
+            "address": addressWithOffset.toString(16)
+        };
+    }
+
     /**
      * Tries to match the given line to code segment information
+     *  Matches in order:
+     *   1. segment offset info
+     *   2. code segment delphi map
+     *   3. icode segment delphi map
+     *   4. code segment vs map
      * @param {string} line 
      */
     TryReadingCodeSegmentInfo(line) {
-        var addressWithoutOffset = false;
-        var addressWithOffset = false;
-        var segmentStr = false;
+        var codesegmentObject = false;
 
-        var matches = line.match(this.regexDelphiCodeSegment);
-        if (matches) {
-            segmentStr = matches[1];
-            addressWithoutOffset = parseInt(matches[2], 16);
-            addressWithOffset = (parseInt(segmentStr, 16) * this.segmentMultiplier) + addressWithoutOffset + this.preferredLoadAddress;
-            
-            this.segments.push({
-                "id": this.segments.length + 1,
-                "segment": segmentStr,
-                "addressWithoutOffset": addressWithoutOffset,
-                "addressInt": addressWithOffset,
-                "address": addressWithOffset.toString(16),
-                "segmentLength": parseInt(matches[3], 16),
-                "unitName": matches[4]
-            });
-        }
-
-        matches = line.match(this.regexVsCodeSegment);
-        if (matches) {
-            addressWithoutOffset = parseInt(matches[2], 16);
-            addressWithOffset = addressWithoutOffset + this.preferredLoadAddress;
-            
-            this.segments.push({
-                "id": this.segments.length + 1,
+        var matches = line.match(this.regexDelphiCodeSegmentOffset);
+        if (matches && !matches[4].includes('$') && (parseInt(matches[2], 16) >= this.preferredLoadAddress)) {
+            var addressWithOffset = parseInt(matches[2], 16);
+            this.segmentOffsets.push({
                 "segment": matches[1],
-                "addressWithoutOffset": addressWithoutOffset,
                 "addressInt": addressWithOffset,
                 "address": addressWithOffset.toString(16),
-                "segmentLength": parseInt(matches[3], 16),
-                "unitName": false
+                "segmentLength": parseInt(matches[3], 16)
             });
+        } else {
+            matches = line.match(this.regexDelphiCodeSegment);
+            if (matches) {
+                codesegmentObject = this.AddressToObject(matches[1], matches[2]);
+                codesegmentObject.id = this.segments.length + 1;
+                codesegmentObject.segmentLength = parseInt(matches[3], 16);
+                codesegmentObject.unitName = matches[4];
+
+                this.segments.push(codesegmentObject);
+            } else {
+                matches = line.match(this.regexDelphiICodeSegment);
+                if (matches) {
+                    codesegmentObject = this.AddressToObject(matches[1], matches[2]);
+                    codesegmentObject.id = this.isegments.length + 1;
+                    codesegmentObject.segmentLength = parseInt(matches[3], 16);
+                    codesegmentObject.unitName = matches[4];
+
+                    this.isegments.push(codesegmentObject);
+                } else {
+                    matches = line.match(this.regexVsCodeSegment);
+                    if (matches) {
+                        codesegmentObject = this.AddressToObject(matches[1], matches[2]);
+                        codesegmentObject.id = this.segments.length + 1;
+                        codesegmentObject.segmentLength = parseInt(matches[3], 16);
+                        codesegmentObject.unitName = false;
+
+                        this.segments.push(codesegmentObject);
+                    }
+                }
+            }
         }
     }
 
@@ -271,42 +361,33 @@ class MapFileReader {
      * @param {string} line 
      */
     TryReadingNamedAddress(line) {
-        var addressWithoutOffset = false;
-        var addressWithOffset = false;
-        var segmentStr = false;
+        var symbolObject = false;
 
         var matches = line.match(this.regexDelphiNames);
         if (matches) {
-            addressWithoutOffset = parseInt(matches[2], 16);
-            segmentStr = matches[1];
-            addressWithOffset = (parseInt(segmentStr, 16) * this.segmentMultiplier) + addressWithoutOffset + this.preferredLoadAddress;
-
             if (!this.GetSymbolInfoByName(matches[3])) {
-                this.namedAddresses.push({
-                    "segment": segmentStr,
-                    "addressWithoutOffset": addressWithoutOffset,
-                    "addressInt": addressWithOffset,
-                    "address": addressWithOffset.toString(16),
-                    "displayName": matches[3]
-                });
+                symbolObject = this.AddressToObject(matches[1], matches[2]);
+                symbolObject.displayName = matches[3];
+
+                this.namedAddresses.push(symbolObject);
             }
         }
 
         matches = line.match(this.regexVsNames);
         if (matches && (matches.length >= 7) && (matches[4] !== "")) {
-            segmentStr = matches[1];
-            addressWithoutOffset = parseInt(matches[2], 16);
-            addressWithOffset = parseInt(matches[4], 16);
-
-            this.namedAddresses.push({
-                "segment": segmentStr,
-                "addressWithoutOffset": addressWithoutOffset,
+            var addressWithOffset = parseInt(matches[4], 16);
+            symbolObject = {
+                "segment": matches[1],
+                "addressWithoutOffset": parseInt(matches[2], 16),
                 "addressInt": addressWithOffset,
                 "address": addressWithOffset.toString(16),
                 "displayName": matches[3]
-            });
+            };
+            this.namedAddresses.push(symbolObject);
 
-            var segment = this.GetSegmentInfoAddressWithoutOffsetIsIn(segmentStr, addressWithoutOffset);
+            this.SetSegmentOffset(symbolObject.segment, symbolObject.addressInt - symbolObject.addressWithoutOffset);
+
+            var segment = this.GetSegmentInfoAddressWithoutOffsetIsIn(symbolObject.segment, symbolObject.addressWithoutOffset);
             if (segment && !segment.unitName) {
                 segment.unitName = matches[6];
             }
@@ -314,7 +395,7 @@ class MapFileReader {
     }
 
     /**
-     * 
+     * Retreives line number references from supplied Map line
      * @param {string} line 
      * @returns {boolean}
      */
@@ -325,17 +406,10 @@ class MapFileReader {
         for (var refIdx = 0; refIdx < references.length; refIdx++) {
             var matches = references[refIdx].match(this.regexDelphiLineNumber);
             if (matches) {
-                var segmentStr = matches[2];
-                var addressWithoutOffset = parseInt(matches[3], 16);
-                var addressWithOffset = (parseInt(segmentStr, 16) * this.segmentMultiplier) + addressWithoutOffset + this.preferredLoadAddress;
-                
-                this.lineNumbers.push({
-                    "segment": segmentStr,
-                    "addressWithoutOffset": addressWithoutOffset,
-                    "addressInt": addressWithOffset,
-                    "address": addressWithOffset.toString(16),
-                    "lineNumber": parseInt(matches[1], 10)
-                });
+                var lineObject = this.AddressToObject(matches[2], matches[3]);
+                lineObject.lineNumber = parseInt(matches[1], 10);
+
+                this.lineNumbers.push(lineObject);
 
                 hasLineNumbers = true;
             }
@@ -344,10 +418,12 @@ class MapFileReader {
         return hasLineNumbers;
     }
 
-    LoadMap() {
-        var self = this;
-        var data = fs.readFileSync(this.mapFilename);
-        var mapLines = data.toString().split("\r\n");
+    /**
+     * Retreives information from Map file contents
+     * @param {string} contents 
+     */
+    LoadMapFromString(contents) {
+        var mapLines = utils.splitLines(contents);
         
         var readLineNumbersMode = false;
         var lineNumbersForUnit = "";
@@ -357,24 +433,30 @@ class MapFileReader {
             var line = mapLines[lineIdx];
 
             if (!readLineNumbersMode) {
-                self.TryReadingPreferredAddress(line);
-                self.TryReadingCodeSegmentInfo(line);
-                self.TryReadingNamedAddress(line);
+                this.TryReadingPreferredAddress(line);
+                this.TryReadingCodeSegmentInfo(line);
+                this.TryReadingNamedAddress(line);
 
-                var matches = line.match(self.regexDelphiLineNumbersStart);
+                var matches = line.match(this.regexDelphiLineNumbersStart);
                 if (matches) {
                     readLineNumbersMode = true;
                     lineNumbersForUnit = matches[1];
                     lineIdx++;
                 }
             } else {
-                if (!self.TryReadingLineNumbers(line)) {
+                if (!this.TryReadingLineNumbers(line)) {
                     readLineNumbersMode = false;
                 }
             }
 
             lineIdx++;
         }
+    }
+
+    LoadMap() {
+        var data = fs.readFileSync(this.mapFilename);
+
+        this.LoadMapFromString(data.toString());
     }
 }
 

--- a/lib/map-file.js
+++ b/lib/map-file.js
@@ -1,0 +1,381 @@
+// Copyright (c) 2017, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+var fs = require("fs");
+
+class MapFileReader {
+    /**
+     * constructor
+     * @param {string} mapFilename 
+     * @param {function} callback 
+     */
+    constructor(mapFilename) {
+        this.mapFilename = mapFilename;
+        this.preferredLoadAddress = 0x400000;
+        this.segmentMultiplier = 0x1000;
+        this.segments = [];
+        this.namedAddresses = [];
+        this.lineNumbers = [];
+        this.entryPoint = "";
+        
+        this.regexVSLoadAddress = /\sPreferred load address is ([0-9a-f]*)/i;
+
+        this.regexDelphiCodeSegment = /^\s([0-9a-f]*):([0-9a-f]*)\s*([0-9a-f]*)\s*C=CODE\s*S=.text\s*G=.*M=([\w\d]*)\s.*/i;
+        this.regexVsCodeSegment = /^\s([0-9a-f]*):([0-9a-f]*)\s*([0-9a-f]*)H\s*\.text\$mn\s*CODE.*/i;
+
+        this.regexDelphiNames = /^\s([0-9a-f]*):([0-9a-f]*)\s*([a-z0-9_@\.]*)$/i;
+        this.regexVsNames = /^\s([0-9a-f]*):([0-9a-f]*)\s*([a-z0-9\?\$_@\.]*)\s*([0-9a-f]*)(\sf\si\s*|\sf\s*|\s*)([a-z0-9\-\._<>:]*)$/i;
+
+        this.regexDelphiLineNumbersStart = /Line numbers for (.*)\(.*\) segment \.text/i;
+        this.regexDelphiLineNumber = /^([0-9]*)\s([0-9a-f]*):([0-9a-f]*)/i;
+    }
+
+    Run() {
+        if (this.mapFilename) {
+            this.LoadMap();
+        }
+    }
+
+    /**
+     * 
+     * @param {string} unitName 
+     * @returns {(Object|boolean)} 
+     */
+    GetSegmentInfoByUnitName(unitName) {
+        for (var idx = 0; idx < this.segments.length; idx++) {
+            var info = this.segments[idx];
+            if (info.unitName === unitName) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} unitName 
+     * @returns {number} 
+     */
+    GetSegmentIdByUnitName(unitName) {
+        var info = this.GetSegmentInfoByUnitName(unitName);
+        if (info) {
+            return info.id;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Get Segment info for exact address
+     * @param {(string|boolean)} segment
+     * @param {number} address
+     * @returns {(Object|boolean)} 
+     */
+    GetSegmentInfoByStartingAddress(segment, address) {
+        for (var idx = 0; idx < this.segments.length; idx++) {
+            var info = this.segments[idx];
+            if (!segment && (info.addressInt === address)) {
+                return info;
+            } else if ((info.segment === segment) && (info.addressInt === address)) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get Segment info for the segment where the given address is in
+     * @param {string} segment 
+     * @param {number} address 
+     * @returns {(Object|boolean)} 
+     */
+    GetSegmentInfoAddressIsIn(segment, address) {
+        for (var idx = 0; idx < this.segments.length; idx++) {
+            var info = this.segments[idx];
+            if ((segment === info.segment) && (address >= info.addressInt) && (address < (info.addressInt + info.segmentLength))) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+    
+    /**
+     * Get Segment info for the segment where the given address is in
+     * @param {string} segment 
+     * @param {number} address 
+     * @returns {(Object|boolean)} 
+     */
+    GetSegmentInfoAddressWithoutOffsetIsIn(segment, address) {
+        for (var idx = 0; idx < this.segments.length; idx++) {
+            var info = this.segments[idx];
+            if ((segment === info.segment) && (address >= info.addressWithoutOffset) && (address < (info.addressWithoutOffset + info.segmentLength))) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} segment 
+     * @param {number} address 
+     * @returns {(Object|boolean)} 
+     */
+    GetSegmentInfoForAddressWithoutOffset(segment, address) {
+        for (var idx = 0; idx < this.segments.length; idx++) {
+            var info = this.segments[idx];
+            if ((segment === info.segment) && (address === info.addressWithoutOffset)) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {(string|boolean)} segment 
+     * @param {number} address 
+     * @returns {(Object|boolean)} 
+     */
+    GetLineInfoByAddress(segment, address) {
+        for (var idx = 0; idx < this.lineNumbers.length; idx++) {
+            var lineInfo = this.lineNumbers[idx];
+            if (!segment && (lineInfo.addressInt === address)) {
+                return lineInfo;
+            } else if ((segment === lineInfo.segment) && (lineInfo.addressInt === address)) {
+                return lineInfo;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} segment 
+     * @param {number} address 
+     * @returns {(Object|boolean)} 
+     */
+    GetSymbolAt(segment, address) {
+        for (var idx = 0; idx < this.namedAddresses.length; idx++) {
+            var info = this.namedAddresses[idx];
+            if (!segment && (info.addressInt === address)) {
+                return info;
+            } else if ((segment === info.segment) && (info.addressInt === address)) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} name 
+     * @returns {(Object|boolean)} 
+     */
+    GetSymbolInfoByName(name) {
+        for (var idx = 0; idx < this.namedAddresses.length; idx++) {
+            var info = this.namedAddresses[idx];
+            if (info.displayName === name) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} line 
+     */
+    TryReadingPreferredAddress(line) {
+        var matches = line.match(this.regexVSLoadAddress);
+        if (matches) {
+            this.preferredLoadAddress = parseInt(matches[1], 16);
+        }
+    }
+
+    /**
+     * Tries to match the given line to code segment information
+     * @param {string} line 
+     */
+    TryReadingCodeSegmentInfo(line) {
+        var addressWithoutOffset = false;
+        var addressWithOffset = false;
+        var segmentStr = false;
+
+        var matches = line.match(this.regexDelphiCodeSegment);
+        if (matches) {
+            segmentStr = matches[1];
+            addressWithoutOffset = parseInt(matches[2], 16);
+            addressWithOffset = (parseInt(segmentStr, 16) * this.segmentMultiplier) + addressWithoutOffset + this.preferredLoadAddress;
+            
+            this.segments.push({
+                "id": this.segments.length + 1,
+                "segment": segmentStr,
+                "addressWithoutOffset": addressWithoutOffset,
+                "addressInt": addressWithOffset,
+                "address": addressWithOffset.toString(16),
+                "segmentLength": parseInt(matches[3], 16),
+                "unitName": matches[4]
+            });
+        }
+
+        matches = line.match(this.regexVsCodeSegment);
+        if (matches) {
+            addressWithoutOffset = parseInt(matches[2], 16);
+            addressWithOffset = addressWithoutOffset + this.preferredLoadAddress;
+            
+            this.segments.push({
+                "id": this.segments.length + 1,
+                "segment": matches[1],
+                "addressWithoutOffset": addressWithoutOffset,
+                "addressInt": addressWithOffset,
+                "address": addressWithOffset.toString(16),
+                "segmentLength": parseInt(matches[3], 16),
+                "unitName": false
+            });
+        }
+    }
+
+    /**
+     * Try to match information about the address where a symbol is
+     * @param {string} line 
+     */
+    TryReadingNamedAddress(line) {
+        var addressWithoutOffset = false;
+        var addressWithOffset = false;
+        var segmentStr = false;
+
+        var matches = line.match(this.regexDelphiNames);
+        if (matches) {
+            addressWithoutOffset = parseInt(matches[2], 16);
+            segmentStr = matches[1];
+            addressWithOffset = (parseInt(segmentStr, 16) * this.segmentMultiplier) + addressWithoutOffset + this.preferredLoadAddress;
+
+            if (!this.GetSymbolInfoByName(matches[3])) {
+                this.namedAddresses.push({
+                    "segment": segmentStr,
+                    "addressWithoutOffset": addressWithoutOffset,
+                    "addressInt": addressWithOffset,
+                    "address": addressWithOffset.toString(16),
+                    "displayName": matches[3]
+                });
+            }
+        }
+
+        matches = line.match(this.regexVsNames);
+        if (matches && (matches.length >= 7) && (matches[4] !== "")) {
+            segmentStr = matches[1];
+            addressWithoutOffset = parseInt(matches[2], 16);
+            addressWithOffset = parseInt(matches[4], 16);
+
+            this.namedAddresses.push({
+                "segment": segmentStr,
+                "addressWithoutOffset": addressWithoutOffset,
+                "addressInt": addressWithOffset,
+                "address": addressWithOffset.toString(16),
+                "displayName": matches[3]
+            });
+
+            var segment = this.GetSegmentInfoAddressWithoutOffsetIsIn(segmentStr, addressWithoutOffset);
+            if (segment && !segment.unitName) {
+                segment.unitName = matches[6];
+            }
+        }
+    }
+
+    /**
+     * 
+     * @param {string} line 
+     * @returns {boolean}
+     */
+    TryReadingLineNumbers(line) {
+        var hasLineNumbers = false;
+
+        var references = line.split("    ");    // 4 spaces
+        for (var refIdx = 0; refIdx < references.length; refIdx++) {
+            var matches = references[refIdx].match(this.regexDelphiLineNumber);
+            if (matches) {
+                var segmentStr = matches[2];
+                var addressWithoutOffset = parseInt(matches[3], 16);
+                var addressWithOffset = (parseInt(segmentStr, 16) * this.segmentMultiplier) + addressWithoutOffset + this.preferredLoadAddress;
+                
+                this.lineNumbers.push({
+                    "segment": segmentStr,
+                    "addressWithoutOffset": addressWithoutOffset,
+                    "addressInt": addressWithOffset,
+                    "address": addressWithOffset.toString(16),
+                    "lineNumber": parseInt(matches[1], 10)
+                });
+
+                hasLineNumbers = true;
+            }
+        }
+
+        return hasLineNumbers;
+    }
+
+    LoadMap() {
+        var self = this;
+        var data = fs.readFileSync(this.mapFilename);
+        var mapLines = data.toString().split("\r\n");
+        
+        var readLineNumbersMode = false;
+        var lineNumbersForUnit = "";
+
+        var lineIdx = 0;
+        while (lineIdx < mapLines.length) {
+            var line = mapLines[lineIdx];
+
+            if (!readLineNumbersMode) {
+                self.TryReadingPreferredAddress(line);
+                self.TryReadingCodeSegmentInfo(line);
+                self.TryReadingNamedAddress(line);
+
+                var matches = line.match(self.regexDelphiLineNumbersStart);
+                if (matches) {
+                    readLineNumbersMode = true;
+                    lineNumbersForUnit = matches[1];
+                    lineIdx++;
+                }
+            } else {
+                if (!self.TryReadingLineNumbers(line)) {
+                    readLineNumbersMode = false;
+                }
+            }
+
+            lineIdx++;
+        }
+    }
+}
+
+exports.MapFileReader = MapFileReader;

--- a/lib/pe32-support.js
+++ b/lib/pe32-support.js
@@ -186,11 +186,14 @@ class PELabelReconstructor {
                     lineIdx++;
                 }
 
+                var namedAddr = false;
+                var labelLine = false;
+
                 var isReferenced = this.addressesToLabel.indexOf(addressStr);
                 if (isReferenced !== -1) {
-                    var labelLine = matches[1] + " <L" + addressStr + ">:";
+                    labelLine = matches[1] + " <L" + addressStr + ">:";
 
-                    var namedAddr = this.mapFileReader.GetSymbolAt(false, address);
+                    namedAddr = this.mapFileReader.GetSymbolAt(false, address);
                     if (namedAddr) {
                         if (currentSymbol) {
                             // note: this might be wrong, we simply don't know
@@ -209,7 +212,7 @@ class PELabelReconstructor {
                 } else {
                     // we might have missed the reference to this address, but if it's listed as a symbol, we should still label it
                     // todo: the call might be in <.itext>, should we include that part of the assembly?
-                    var namedAddr = this.mapFileReader.GetSymbolAt(false, address);
+                    namedAddr = this.mapFileReader.GetSymbolAt(false, address);
                     if (namedAddr) {
                         currentSymbol = namedAddr.displayName;
                         labelLine = matches[1] + " <" + namedAddr.displayName + ">:";

--- a/lib/pe32-support.js
+++ b/lib/pe32-support.js
@@ -177,13 +177,6 @@ class PELabelReconstructor {
                 var segmentInfo = this.mapFileReader.GetSegmentInfoByStartingAddress(false, address);
                 if (segmentInfo) {
                     currentSegment = segmentInfo;
-
-                    if (segmentInfo.unitName.startsWith("output")) {
-                        this.asmLines.splice(lineIdx, 0, " .file " + segmentInfo.id + " " + "\"<stdin>\"");
-                    } else {
-                        this.asmLines.splice(lineIdx, 0, " .file " + segmentInfo.id + " " + "\"" + segmentInfo.unitName + "\"");
-                    }
-                    lineIdx++;
                 }
 
                 var namedAddr = false;

--- a/lib/pe32-support.js
+++ b/lib/pe32-support.js
@@ -48,67 +48,56 @@ class PELabelReconstructor {
         this.mapFileReader = new MapFileReader(this.mapFilename);
         this.mapFileReader.Run();
 
-        var info = this.mapFileReader.GetSegmentInfoByUnitName("output");
-        if (info) {
-            this.DeleteLinesBeforeAddress(info.addressInt, info.segmentLength);
-        }
+        this.DeleteEverythingBut("output");
     
         this.CollectJumpsAndCalls();
         this.InsertLabels();
     }
 
+    DeleteEverythingBut(unitName) {
+        var idx, info;
+        for (idx = 0; idx < this.mapFileReader.segments.length; idx++) {
+            info = this.mapFileReader.segments[idx];
+            if (info.unitName !== unitName) {
+                this.DeleteLinesBetweenAddresses(info.addressInt, info.addressInt + info.segmentLength);
+            }
+        }
+
+        for (idx = 0; idx < this.mapFileReader.isegments.length; idx++) {
+            info = this.mapFileReader.isegments[idx];
+            if (info.unitName !== unitName) {
+                this.DeleteLinesBetweenAddresses(info.addressInt, info.addressInt + info.segmentLength);
+            }
+        }
+    }
+
     /**
      * 
-     * @param {number} address 
-     * @param {number} segmentLength 
+     * @param {number} beginAddress 
+     * @param {number} endAddress 
      */
-    DeleteLinesBeforeAddress(address, segmentLength) {
-        var startIdx = 0;
-
-        var matches = false;
-        var line = false;
-        var lineAddr = false;
+    DeleteLinesBetweenAddresses(beginAddress, endAddress) {
+        var startIdx = -1;
 
         var lineIdx = 0;
         while (lineIdx < this.asmLines.length) {
-            line = this.asmLines[lineIdx];
+            var line = this.asmLines[lineIdx];
 
-            if (line.endsWith("<CODE>:")) {
-                startIdx = lineIdx;
-            } else if (line.endsWith("<.text>:")) {
-                startIdx = lineIdx;
-            }
-
-            matches = line.match(this.addressRegex);
+            var matches = line.match(this.addressRegex);
             if (matches) {
-                lineAddr = parseInt(matches[1], 16);
-                if (lineAddr >= address) {
-                    this.asmLines.splice(startIdx, lineIdx - startIdx);
+                var lineAddr = parseInt(matches[1], 16);
+                if ((startIdx === -1) && (lineAddr >= beginAddress)) {
+                    startIdx = lineIdx;
+                    if (line.endsWith("<CODE>:") || line.endsWith("<.text>:") || line.endsWith("<.itext>:")) {
+                        startIdx++;
+                    }
+                } else if (lineAddr >= endAddress) {
+                    this.asmLines.splice(startIdx, lineIdx - startIdx - 1);
                     break;
                 }
             }
 
             lineIdx++;
-        }
-
-        if (segmentLength) {
-            var endAddress = address + segmentLength;
-
-            lineIdx = 0;
-            while (lineIdx < this.asmLines.length) {
-                line = this.asmLines[lineIdx];
-    
-                matches = line.match(this.addressRegex);
-                if (matches) {
-                    lineAddr = parseInt(matches[1], 16);
-                    if (lineAddr >= endAddress) {
-                        this.asmLines = this.asmLines.splice(0, lineIdx);
-                        break;
-                    }
-                }
-    
-                lineIdx++;
-            }
         }
     }
 

--- a/lib/pe32-support.js
+++ b/lib/pe32-support.js
@@ -1,0 +1,221 @@
+// Copyright (c) 2017, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+var MapFileReader = require('./map-file').MapFileReader,
+    logger = require('./logger').logger;
+
+class PELabelReconstructor {
+    /**
+     * 
+     * @param {Array} asmLines 
+     * @param {string} mapFilename 
+     * @param {boolean} dontLabelUnmappedAddresses 
+     * @param {function} callback 
+     */
+    constructor(asmLines, mapFilename, dontLabelUnmappedAddresses) {
+        this.asmLines = asmLines;
+        this.addressesToLabel = [];
+        this.dontLabelUnmappedAddresses = dontLabelUnmappedAddresses;
+
+        this.addressRegex = /^\s*([0-9a-z]*):/i;
+        this.mapFileReader = null;
+        this.mapFilename = mapFilename;
+    }
+
+    Run() {
+        this.mapFileReader = new MapFileReader(this.mapFilename);
+        this.mapFileReader.Run();
+
+        var info = this.mapFileReader.GetSegmentInfoByUnitName("output");
+        if (info) {
+            this.DeleteLinesBeforeAddress(info.addressInt, info.segmentLength);
+        }
+    
+        this.CollectJumpsAndCalls();
+        this.InsertLabels();
+    }
+
+    /**
+     * 
+     * @param {number} address 
+     * @param {number} segmentLength 
+     */
+    DeleteLinesBeforeAddress(address, segmentLength) {
+        var startIdx = 0;
+
+        var matches = false;
+        var line = false;
+        var lineAddr = false;
+
+        var lineIdx = 0;
+        while (lineIdx < this.asmLines.length) {
+            line = this.asmLines[lineIdx];
+
+            if (line.endsWith("<CODE>:")) {
+                startIdx = lineIdx;
+            }
+
+            matches = line.match(this.addressRegex);
+            if (matches) {
+                lineAddr = parseInt(matches[1], 16);
+                if (lineAddr >= address) {
+                    this.asmLines.splice(startIdx, lineIdx - startIdx);
+                    break;
+                }
+            }
+
+            lineIdx++;
+        }
+
+        if (segmentLength) {
+            var endAddress = address + segmentLength;
+
+            lineIdx = 0;
+            while (lineIdx < this.asmLines.length) {
+                line = this.asmLines[lineIdx];
+    
+                matches = line.match(this.addressRegex);
+                if (matches) {
+                    lineAddr = parseInt(matches[1], 16);
+                    if (lineAddr >= endAddress) {
+                        this.asmLines = this.asmLines.splice(0, lineIdx);
+                        break;
+                    }
+                }
+    
+                lineIdx++;
+            }
+        }
+    }
+
+    CollectJumpsAndCalls() {
+        var jumpRegex = /(\sj[a-z]*)(\s*)0x([0-9a-f]*)/i;
+        var callRegex = /(\scall)(\s*)0x([0-9a-f]*)/i;
+
+        for (var lineIdx = 0; lineIdx < this.asmLines.length; lineIdx++) {
+            var line = this.asmLines[lineIdx];
+
+            var namedAddr = false;
+            var labelName = false;
+            var address = false;
+
+            var matches = line.match(jumpRegex);
+            if (matches) {
+                address = matches[3];
+                if (!address.includes('+') && !address.includes('-')) {
+                    labelName = "L" + address;
+                    namedAddr = this.mapFileReader.GetSymbolAt(false, parseInt(address, 16));
+                    if (namedAddr) {
+                        labelName = namedAddr.displayName;
+                    }
+
+                    if (!this.dontLabelUnmappedAddresses || namedAddr) {
+                        this.addressesToLabel.push(address);
+                        this.asmLines[lineIdx] = line.replace(jumpRegex, " " + matches[1] + matches[2] + labelName);
+                    }
+                }
+            }
+
+            matches = line.match(callRegex);
+            if (matches && !matches[3].includes('+') && !matches[3].includes('-')) {
+                address = matches[3];
+                if (!address.includes('+') && !address.includes('-')) {
+                    labelName = "L" + address;
+                    namedAddr = this.mapFileReader.GetSymbolAt(false, parseInt(address, 16));
+                    if (namedAddr) {
+                        labelName = namedAddr.displayName;
+                    }
+
+                    if (!this.dontLabelUnmappedAddresses || namedAddr) {
+                        this.addressesToLabel.push(address);
+                        this.asmLines[lineIdx] = line.replace(callRegex, " " + matches[1] + matches[2] + labelName);
+                    }
+                }
+            }
+        }
+    }
+
+    InsertLabels() {
+        var sourceFileId = this.mapFileReader.GetSegmentIdByUnitName("output");
+
+        var currentSegment = false;
+        var currentSymbol = false;
+
+        var lineIdx = 0;
+        while (lineIdx < this.asmLines.length) {
+            var line = this.asmLines[lineIdx];
+
+            var matches = line.match(this.addressRegex);
+            if (matches) {
+                var addressStr = matches[1];
+                var address = parseInt(addressStr, 16);
+
+                var segmentInfo = this.mapFileReader.GetSegmentInfoByStartingAddress(false, address);
+                if (segmentInfo) {
+                    currentSegment = segmentInfo;
+
+                    if (segmentInfo.unitName.startsWith("output")) {
+                        this.asmLines.splice(lineIdx, 0, " .file " + segmentInfo.id + " " + "\"<stdin>\"");
+                    } else {
+                        this.asmLines.splice(lineIdx, 0, " .file " + segmentInfo.id + " " + "\"" + segmentInfo.unitName + "\"");
+                    }
+                    lineIdx++;
+                }
+
+                var isReferenced = this.addressesToLabel.indexOf(addressStr);
+                if (isReferenced !== -1) {
+                    var labelLine = matches[1] + " <L" + addressStr + ">:";
+
+                    var namedAddr = this.mapFileReader.GetSymbolAt(false, address);
+                    if (namedAddr) {
+                        if (currentSymbol) {
+                            // note: this might be wrong, we simply don't know
+                            // this.asmLines.splice(lineIdx, 0, "  " + addressStr + " .cfi_endproc");
+                            // lineIdx++;
+                        }
+                        
+                        currentSymbol = namedAddr.displayName;
+                        labelLine = matches[1] + " <" + namedAddr.displayName + ">:";
+                    }
+                    
+                    if (!this.dontLabelUnmappedAddresses || namedAddr) {
+                        this.asmLines.splice(lineIdx, 0, labelLine);
+                        lineIdx++;
+                    }
+                }
+
+                var lineInfo = this.mapFileReader.GetLineInfoByAddress(false, address);
+                if (lineInfo && currentSegment.unitName.startsWith("output")) {
+                    this.asmLines.splice(lineIdx, 0, "/" + sourceFileId + ":" + lineInfo.lineNumber);
+                    lineIdx++;
+                }
+            }
+            
+            lineIdx++;
+        }
+    }
+}
+
+exports.labelReconstructor = PELabelReconstructor;

--- a/lib/pe32-support.js
+++ b/lib/pe32-support.js
@@ -75,6 +75,8 @@ class PELabelReconstructor {
 
             if (line.endsWith("<CODE>:")) {
                 startIdx = lineIdx;
+            } else if (line.endsWith("<.text>:")) {
+                startIdx = lineIdx;
             }
 
             matches = line.match(this.addressRegex);
@@ -201,6 +203,17 @@ class PELabelReconstructor {
                     }
                     
                     if (!this.dontLabelUnmappedAddresses || namedAddr) {
+                        this.asmLines.splice(lineIdx, 0, labelLine);
+                        lineIdx++;
+                    }
+                } else {
+                    // we might have missed the reference to this address, but if it's listed as a symbol, we should still label it
+                    // todo: the call might be in <.itext>, should we include that part of the assembly?
+                    var namedAddr = this.mapFileReader.GetSymbolAt(false, address);
+                    if (namedAddr) {
+                        currentSymbol = namedAddr.displayName;
+                        labelLine = matches[1] + " <" + namedAddr.displayName + ">:";
+
                         this.asmLines.splice(lineIdx, 0, labelLine);
                         lineIdx++;
                     }

--- a/test/map-file-tests.js
+++ b/test/map-file-tests.js
@@ -1,0 +1,155 @@
+// Copyright (c) 2017, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+var chai = require('chai');
+var should = chai.should();
+var assert = chai.assert;
+var MapFileReader = require('../lib/map-file').MapFileReader;
+var logger = require('../lib/logger').logger;
+
+describe('Setup', function () {
+    it('VS-map preferred load address', function () {
+        var reader = new MapFileReader();
+        reader.preferredLoadAddress.should.equal(0x400000, "default load address");
+
+        reader.TryReadingPreferredAddress(" Preferred load address is 00400000");
+        reader.preferredLoadAddress.should.equal(0x400000);
+        
+        reader.TryReadingPreferredAddress(" Preferred load address is 00410000");
+        reader.preferredLoadAddress.should.equal(0x410000);
+    });
+});
+
+describe('Code Segments', function () {
+    it('One normal Delphi-Map segment', function () {
+        var reader = new MapFileReader();
+        reader.TryReadingCodeSegmentInfo(" 0001:00002838 00000080 C=CODE     S=.text    G=(none)   M=output   ACBP=A9");
+        reader.segments.length.should.equal(1);
+
+        var info = reader.GetSegmentInfoByStartingAddress("0001", reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x2838);
+        info.unitName.should.equal("output");
+
+        var info = reader.GetSegmentInfoByStartingAddress(false, reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x2838);
+        info.unitName.should.equal("output");
+
+        var info = reader.GetSegmentInfoByStartingAddress("0001", "2838");
+        assert(info === false, "Address should not be a Start for any segment");
+
+        var info = reader.GetSegmentInfoAddressIsIn("0001", reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x2838 + 0x10);
+        info.unitName.should.equal("output");
+
+        var info = reader.GetSegmentInfoAddressIsIn("0001", reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x2838 + 0x80 + 1);
+        assert(info === false, "Address should not be in any segment");
+    });
+
+    it('One normal VS-Map segment', function () {
+        var reader = new MapFileReader();
+        reader.TryReadingCodeSegmentInfo(" 0001:00002838 00000080H .text$mn                CODE");
+        reader.segments.length.should.equal(1);
+
+        var info = reader.GetSegmentInfoByStartingAddress("0001", 0x402838);
+        info.addressInt.should.equal(reader.preferredLoadAddress + 0x2838);
+
+        var info = reader.GetSegmentInfoByStartingAddress("0001", 0x2838);
+        assert(info === false, "Address should not be a Start for any segment");
+
+        var info = reader.GetSegmentInfoAddressIsIn("0001", reader.preferredLoadAddress + 0x2838 + 0x10);
+        info.addressInt.should.equal(reader.preferredLoadAddress + 0x2838);
+        
+        var info = reader.GetSegmentInfoAddressIsIn("0001", reader.preferredLoadAddress + 0x2838 + 0x80 + 1);
+        assert(info === false);
+    });
+
+    it('Repair VS-Map code segment info', function () {
+        var reader = new MapFileReader();
+        reader.TryReadingCodeSegmentInfo(" 0002:00000000 00004c73H .text$mn                CODE");
+        reader.TryReadingNamedAddress(" 0002:000007f0       _main                      004117f0 f   ConsoleApplication1.obj");
+
+        var info = reader.GetSegmentInfoByStartingAddress("0002", reader.preferredLoadAddress + 0);
+        info.unitName.should.equal("ConsoleApplication1.obj");
+    });
+});
+
+describe('Symbol info', function () {
+    it('Delphi-Map symbol test', function () {
+        var reader = new MapFileReader();
+        reader.TryReadingNamedAddress(" 0001:00002838       Square");
+        reader.namedAddresses.length.should.equal(1);
+        
+        var info = reader.GetSymbolAt("0001", reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x2838);
+        assert(info !== false, "Symbol Square should have been returned");
+        info.displayName.should.equal("Square");
+    });
+
+    it('VS-Map symbol test', function () {
+        var reader = new MapFileReader();
+        reader.TryReadingNamedAddress(" 0002:000006b0       ??$__vcrt_va_start_verify_argument_type@QBD@@YAXXZ 004116b0 f i ConsoleApplication1.obj");
+        reader.namedAddresses.length.should.equal(1);
+        
+        var info = reader.GetSymbolAt("0002", 0x4116b0);
+        assert(info !== false, "Symbol start_verify_argument should have been returned");
+        info.displayName.should.equal("??$__vcrt_va_start_verify_argument_type@QBD@@YAXXZ");
+    });
+
+    it('Delphi-Map Duplication prevention', function () {
+        var reader = new MapFileReader();
+        reader.TryReadingNamedAddress(" 0001:00002838       Square");
+        reader.namedAddresses.length.should.equal(1);
+        
+        reader.TryReadingNamedAddress(" 0001:00002838       Square");
+        reader.namedAddresses.length.should.equal(1);
+    });
+});
+
+describe('Delphi-Map Line number info', function () {
+    it('No line', function () {
+        var reader = new MapFileReader();
+        assert(reader.TryReadingLineNumbers("") === false);
+    });
+
+    it('One line', function () {
+        var reader = new MapFileReader();
+        assert(reader.TryReadingLineNumbers("    17 0001:000028A4") === true);
+
+        var lineInfo = reader.GetLineInfoByAddress("0001", reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x28A4);
+        lineInfo.lineNumber.should.equal(17);
+    });
+
+    it('Multiple lines', function () {
+        var reader = new MapFileReader();
+        assert(reader.TryReadingLineNumbers("    12 0001:00002838    13 0001:0000283B    14 0001:00002854    15 0001:00002858") === true);
+
+        var lineInfo = reader.GetLineInfoByAddress("0001", reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x2838);
+        lineInfo.lineNumber.should.equal(12);
+
+        var lineInfo = reader.GetLineInfoByAddress("0001", reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x2858);
+        lineInfo.lineNumber.should.equal(15);
+
+        var lineInfo = reader.GetLineInfoByAddress("0001", reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x2854);
+        lineInfo.lineNumber.should.equal(14);
+
+        var lineInfo = reader.GetLineInfoByAddress("0001", reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x283B);
+        lineInfo.lineNumber.should.equal(13);
+    });
+});

--- a/test/map-file-tests.js
+++ b/test/map-file-tests.js
@@ -63,6 +63,12 @@ describe('Code Segments', function () {
         assert(info === false, "Address should not be in any segment");
     });
 
+    it('Not include this segment', function () {
+        var reader = new MapFileReader();
+        reader.TryReadingCodeSegmentInfo(" 0002:000000B0 00000023 C=ICODE    S=.itext   G=(none)   M=output   ACBP=A9");
+        reader.segments.length.should.equal(0);
+    });
+
     it('One normal VS-Map segment', function () {
         var reader = new MapFileReader();
         reader.TryReadingCodeSegmentInfo(" 0001:00002838 00000080H .text$mn                CODE");
@@ -100,6 +106,16 @@ describe('Symbol info', function () {
         var info = reader.GetSymbolAt("0001", reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x2838);
         assert(info !== false, "Symbol Square should have been returned");
         info.displayName.should.equal("Square");
+    });
+
+    it('Delphi-Map D2009 symbol test', function () {
+        var reader = new MapFileReader();
+        reader.TryReadingNamedAddress(" 0001:00002C4C       output.MaxArray");
+        reader.namedAddresses.length.should.equal(1);
+
+        var info = reader.GetSymbolAt("0001", reader.preferredLoadAddress + (1 * reader.segmentMultiplier) + 0x2C4C);
+        assert(info !== false, "Symbol MaxArray should have been returned");
+        info.displayName.should.equal("output.MaxArray");
     });
 
     it('VS-Map symbol test', function () {

--- a/test/maps/minimal-delphi.map
+++ b/test/maps/minimal-delphi.map
@@ -1,0 +1,66 @@
+
+ Start         Length     Name                   Class
+ 0001:00401000 00002D08H .text                   CODE
+ 0002:00404000 000000F0H .itext                  ICODE
+ 0003:00405000 000007ACH .data                   DATA
+ 0004:00406000 0000318CH .bss                    BSS
+ 0005:00000000 00000008H .tls                    TLS
+
+
+Detailed map of segments
+
+ 0001:00000000 00002B43 C=CODE     S=.text    G=(none)   M=System   ACBP=A9
+ 0001:00002B44 00000105 C=CODE     S=.text    G=(none)   M=SysInit  ACBP=A9
+ 0001:00002C4C 0000006A C=CODE     S=.text    G=(none)   M=output   ACBP=A9
+ 0001:00002CB8 00000050 C=CODE     S=.text    G=(none)   M=prog     ACBP=A9
+ 0002:00000000 000000AE C=ICODE    S=.itext   G=(none)   M=System   ACBP=A9
+ 0002:000000B0 00000020 C=ICODE    S=.itext   G=(none)   M=output   ACBP=A9
+ 0002:000000D0 0000001D C=ICODE    S=.itext   G=(none)   M=prog     ACBP=A9
+
+
+  Address             Publics by Name
+
+ 0004:00002B38       output..1
+ 0004:00002B3C       output.A
+ 0004:00002E64       output.B
+ 0001:00002C88       output.Finalization
+ 0001:00002C4C       output.MaxArray
+ 0002:000000B0       output.output
+ 0001:00002CB8       prog.Finalization
+ 0002:000000D0       prog.prog
+ 0001:00002BBC       SysInit.@GetTls
+ 0001:00002ADC       System.Finalization
+
+
+  Address             Publics by Value
+
+ 0001:000025B4       System.FinalizeUnits
+ 0001:00002C4C       output.MaxArray
+ 0001:00002C88       output.Finalization
+ 0001:00002CB8       prog.Finalization
+ 0002:000000B0       output.output
+ 0002:000000D0       prog.prog
+ 0004:00002B38       output..1
+ 0004:00002B3C       output.A
+ 0004:00002E64       output.B
+
+
+Line numbers for output(Z:\tmp\compiler-explorer-compiler1171110-10390-19q384o\output.pas) segment .text
+
+    12 0001:00002C4C    13 0001:00002C57    15 0001:00002C61    16 0001:00002C6B
+    17 0001:00002C75    13 0001:00002C7B    18 0001:00002C7E
+
+Line numbers for output(Z:\tmp\compiler-explorer-compiler1171110-10390-19q384o\output.pas) segment .itext
+
+    23 0002:000000B0    24 0002:000000B9    25 0002:000000CF
+
+Line numbers for prog(Z:\tmp\compiler-explorer-compiler1171110-10390-19q384o\prog.dpr) segment .itext
+
+     1 0002:000000D0     1 0002:000000E8
+
+Bound resource files
+
+C:\users\partouf\Temp\dtfaa23.tmp
+
+
+Program entry point at 0002:000000D0

--- a/test/maps/minimal-vs15.map
+++ b/test/maps/minimal-vs15.map
@@ -1,0 +1,371 @@
+ ConsoleApplication1
+
+ Timestamp is 5a2b9e20 (Sat Dec  9 09:26:08 2017)
+
+ Preferred load address is 00400000
+
+ Start         Length     Name                   Class
+ 0001:00000000 00010000H .textbss                DATA
+ 0002:00000000 00004c73H .text$mn                CODE
+ 0003:00000000 00000104H .CRT$XCA                DATA
+ 0003:00000104 00000104H .CRT$XCAA               DATA
+ 0003:00000208 00000104H .CRT$XCZ                DATA
+ 0003:0000030c 00000104H .CRT$XIA                DATA
+ 0003:00000410 00000104H .CRT$XIAA               DATA
+ 0003:00000514 00000104H .CRT$XIAC               DATA
+ 0003:00000618 00000104H .CRT$XIZ                DATA
+ 0003:0000071c 00000104H .CRT$XPA                DATA
+ 0003:00000820 00000104H .CRT$XPZ                DATA
+ 0003:00000924 00000104H .CRT$XTA                DATA
+ 0003:00000a28 00000108H .CRT$XTZ                DATA
+ 0003:00000b30 00000b9cH .rdata                  DATA
+ 0003:000016cc 0000019cH .rdata$zzzdbg           DATA
+ 0003:00001868 00000104H .rtc$IAA                DATA
+ 0003:0000196c 00000104H .rtc$IMZ                DATA
+ 0003:00001a70 00000104H .rtc$IZZ                DATA
+ 0003:00001b74 00000104H .rtc$TAA                DATA
+ 0003:00001c78 00000104H .rtc$TMZ                DATA
+ 0003:00001d7c 00000104H .rtc$TZZ                DATA
+ 0003:00001e80 0000018dH .xdata$x                DATA
+ 0003:0000200d 00000000H .edata                  DATA
+ 0004:00000000 00000138H .data                   DATA
+ 0004:00000138 00000454H .bss                    DATA
+ 0005:00000000 000001b4H .idata$5                DATA
+ 0005:000001b4 0000003cH .idata$2                DATA
+ 0005:000001f0 00000014H .idata$3                DATA
+ 0005:00000204 000001b4H .idata$4                DATA
+ 0005:000003b8 000006b2H .idata$6                DATA
+ 0006:00000000 0000013aH .gfids$y                DATA
+ 0007:00000000 00000104H .00cfg                  DATA
+ 0008:00000000 00000170H .rsrc$01                DATA
+ 0008:00000170 000002ccH .rsrc$02                DATA
+
+  Address         Publics by Value              Rva+Base       Lib:Object
+
+ 0000:00000000       ___guard_longjmp_count     00000000     <absolute>
+ 0000:00000000       ___guard_longjmp_table     00000000     <absolute>
+ 0000:00000000       ___safe_se_handler_count   00000000     <absolute>
+ 0000:00000000       ___guard_fids_count        00000000     <absolute>
+ 0000:00000000       ___guard_iat_table         00000000     <absolute>
+ 0000:00000000       ___dynamic_value_reloc_table 00000000     <absolute>
+ 0000:00000000       ___guard_iat_count         00000000     <absolute>
+ 0000:00000000       ___safe_se_handler_table   00000000     <absolute>
+ 0000:00000000       ___guard_fids_table        00000000     <absolute>
+ 0000:00000100       ___guard_flags             00000100     <absolute>
+ 0000:00000000       ___ImageBase               00400000     <linker-defined>
+ 0001:00000000       __enc$textbss$begin        00401000     <linker-defined>
+ 0001:00010000       __enc$textbss$end          00411000     <linker-defined>
+ 0002:000006b0       ??$__vcrt_va_start_verify_argument_type@QBD@@YAXXZ 004116b0 f i ConsoleApplication1.obj
+ 0002:000006e0       ?Hello@@YAXXZ              004116e0 f   ConsoleApplication1.obj
+ 0002:00000730       ___local_stdio_printf_options 00411730 f i ConsoleApplication1.obj
+ 0002:00000770       __vfprintf_l               00411770 f i ConsoleApplication1.obj
+ 0002:000007f0       _main                      004117f0 f   ConsoleApplication1.obj
+ 0002:00000840       _printf                    00411840 f i ConsoleApplication1.obj
+ 0002:000008d0       @_RTC_AllocaHelper@12      004118d0 f   MSVCRTD:_stack_.obj
+ 0002:00000910       @_RTC_CheckStackVars2@12   00411910 f   MSVCRTD:_stack_.obj
+ 0002:00000a20       @_RTC_CheckStackVars@8     00411a20 f   MSVCRTD:_stack_.obj
+ 0002:00000a90       __RTC_CheckEsp             00411a90 f   MSVCRTD:_stack_.obj
+ 0002:00000ad0       __CRT_RTC_INIT             00411ad0 f   MSVCRTD:_init_.obj
+ 0002:00000ae0       __CRT_RTC_INITW            00411ae0 f   MSVCRTD:_init_.obj
+ 0002:00000af0       __RTC_InitBase             00411af0 f   MSVCRTD:_init_.obj
+ 0002:00000b30       __RTC_Shutdown             00411b30 f   MSVCRTD:_init_.obj
+ 0002:00000f20       ?configure_argv@__scrt_narrow_argv_policy@@SAHXZ 00411f20 f i MSVCRTD:exe_main.obj
+ 0002:00000f40       ?get_app_type@__scrt_main_policy@@SA?AW4_crt_app_type@@XZ 00411f40 f i MSVCRTD:exe_main.obj
+ 0002:00000f90       _mainCRTStartup            00411f90 f   MSVCRTD:exe_main.obj
+ 0002:00001140       ?_RTC_AllocaFailure@@YAXPAXPAU_RTC_ALLOCA_NODE@@H@Z 00412140 f   MSVCRTD:_error_.obj
+ 0002:000012b0       ?_RTC_Failure@@YAXPAXH@Z   004122b0 f   MSVCRTD:_error_.obj
+ 0002:00001320       ?_RTC_StackFailure@@YAXPAXPBD@Z 00412320 f   MSVCRTD:_error_.obj
+ 0002:000017a0       __RTC_UninitUse            004127a0 f   MSVCRTD:_error_.obj
+ 0002:000018d0       __vsprintf_s_l             004128d0 f i MSVCRTD:_error_.obj
+ 0002:00001910       _sprintf_s                 00412910 f i MSVCRTD:_error_.obj
+ 0002:00001940       ?_RTC_GetErrorFunc@@YAP6AHHPBDH00ZZPBX@Z 00412940 f   MSVCRTD:_userapi_.obj
+ 0002:00001950       ?_RTC_GetErrorFuncW@@YAP6AHHPB_WH00ZZPBX@Z 00412950 f   MSVCRTD:_userapi_.obj
+ 0002:00001960       __RTC_GetErrDesc           00412960 f   MSVCRTD:_userapi_.obj
+ 0002:00001980       __RTC_NumErrors            00412980 f   MSVCRTD:_userapi_.obj
+ 0002:00001990       __RTC_SetErrorFunc         00412990 f   MSVCRTD:_userapi_.obj
+ 0002:000019c0       __RTC_SetErrorFuncW        004129c0 f   MSVCRTD:_userapi_.obj
+ 0002:000019f0       __RTC_SetErrorType         004129f0 f   MSVCRTD:_userapi_.obj
+ 0002:00001a20       ??$__crt_fast_decode_pointer@PAP6AXXZ@@YAPAP6AXXZQAP6AXXZ@Z 00412a20 f i MSVCRTD:utility.obj
+ 0002:00001a50       ??$__crt_fast_encode_pointer@PAP6AXXZ@@YAPAP6AXXZQAP6AXXZ@Z 00412a50 f i MSVCRTD:utility.obj
+ 0002:00001a90       ?__crt_rotate_pointer_value@@YAIIH@Z 00412a90 f i MSVCRTD:utility.obj
+ 0002:00001be0       _NtCurrentTeb              00412be0 f i MSVCRTD:utility.obj
+ 0002:00001bf0       ___scrt_acquire_startup_lock 00412bf0 f   MSVCRTD:utility.obj
+ 0002:00001c50       ___scrt_dllmain_after_initialize_c 00412c50 f   MSVCRTD:utility.obj
+ 0002:00001c90       ___scrt_dllmain_before_initialize_c 00412c90 f   MSVCRTD:utility.obj
+ 0002:00001cc0       ___scrt_dllmain_crt_thread_attach 00412cc0 f   MSVCRTD:utility.obj
+ 0002:00001d00       ___scrt_dllmain_crt_thread_detach 00412d00 f   MSVCRTD:utility.obj
+ 0002:00001d20       ___scrt_dllmain_exception_filter 00412d20 f   MSVCRTD:utility.obj
+ 0002:00001d80       ___scrt_dllmain_uninitialize_c 00412d80 f   MSVCRTD:utility.obj
+ 0002:00001dc0       ___scrt_dllmain_uninitialize_critical 00412dc0 f   MSVCRTD:utility.obj
+ 0002:00001de0       ___scrt_initialize_crt     00412de0 f   MSVCRTD:utility.obj
+ 0002:00001e40       ___scrt_initialize_onexit_tables 00412e40 f   MSVCRTD:utility.obj
+ 0002:00001f40       ___scrt_is_nonwritable_in_current_image 00412f40 f   MSVCRTD:utility.obj
+ 0002:000020c0       ___scrt_release_startup_lock 004130c0 f   MSVCRTD:utility.obj
+ 0002:000020f0       ___scrt_uninitialize_crt   004130f0 f   MSVCRTD:utility.obj
+ 0002:00002140       __onexit                   00413140 f   MSVCRTD:utility.obj
+ 0002:000021d0       _at_quick_exit             004131d0 f   MSVCRTD:utility.obj
+ 0002:00002230       _atexit                    00413230 f   MSVCRTD:utility.obj
+ 0002:00002270       ___security_init_cookie    00413270 f   MSVCRTD:gs_support.obj
+ 0002:00002390       __matherr                  00413390 f   MSVCRTD:matherr.obj
+ 0002:000023a0       __get_startup_argv_mode    004133a0 f   MSVCRTD:argv_mode.obj
+ 0002:000023b0       __get_startup_commit_mode  004133b0 f   MSVCRTD:commit_mode.obj
+ 0002:000023c0       __get_startup_file_mode    004133c0 f   MSVCRTD:file_mode.obj
+ 0002:000023d0       __get_startup_new_mode     004133d0 f   MSVCRTD:new_mode.obj
+ 0002:000023e0       __get_startup_thread_locale_mode 004133e0 f   MSVCRTD:thread_locale.obj
+ 0002:000023f0       ?__scrt_initialize_type_info@@YAXXZ 004133f0 f   MSVCRTD:tncleanup.obj
+ 0002:00002410       ?__scrt_uninitialize_type_info@@YAXXZ 00413410 f   MSVCRTD:tncleanup.obj
+ 0002:00002430       __should_initialize_environment 00413430 f   MSVCRTD:env_mode.obj
+ 0002:00002440       __initialize_default_precision 00413440 f   MSVCRTD:default_precision.obj
+ 0002:00002470       __initialize_invalid_parameter_handler 00413470 f   MSVCRTD:invalid_parameter_handler.obj
+ 0002:00002480       __initialize_denormal_control 00413480 f   MSVCRTD:denormal_control.obj
+ 0002:00002490       ___local_stdio_scanf_options 00413490 f i MSVCRTD:default_local_stdio_options.obj
+ 0002:000024a0       ___scrt_initialize_default_local_stdio_options 004134a0 f   MSVCRTD:default_local_stdio_options.obj
+ 0002:000024f0       ___scrt_is_user_matherr_present 004134f0 f   MSVCRTD:matherr_detection.obj
+ 0002:00002520       ___scrt_get_dyn_tls_init_callback 00413520 f   MSVCRTD:dyn_tls_init.obj
+ 0002:00002530       ___scrt_get_dyn_tls_dtor_callback 00413530 f   MSVCRTD:dyn_tls_dtor.obj
+ 0002:00002540       ___scrt_fastfail           00413540 f   MSVCRTD:utility_desktop.obj
+ 0002:000026d0       ___scrt_get_show_window_mode 004136d0 f   MSVCRTD:utility_desktop.obj
+ 0002:00002720       ___scrt_initialize_winrt   00413720 f   MSVCRTD:utility_desktop.obj
+ 0002:00002730       ___scrt_is_managed_app     00413730 f   MSVCRTD:utility_desktop.obj
+ 0002:000027e0       ___scrt_set_unhandled_exception_filter 004137e0 f   MSVCRTD:utility_desktop.obj
+ 0002:00002800       ___scrt_unhandled_exception_filter@4 00413800 f   MSVCRTD:utility_desktop.obj
+ 0002:00002880       __crt_debugger_hook        00413880 f   MSVCRTD:utility_desktop.obj
+ 0002:000028a0       __RTC_Initialize           004138a0 f   MSVCRTD:_initsect_.obj
+ 0002:000028e0       __RTC_Terminate            004138e0 f   MSVCRTD:_initsect_.obj
+ 0002:00002920       @_guard_check_icall@4      00413920 f i MSVCRTD:checkcfg.obj
+ 0002:00002940       __except_handler4          00413940 f   MSVCRTD:_chandler4gs_.obj
+ 0002:00002f30       ?_RTC_GetSrcLine@@YAHPAEPA_WKPAH1K@Z 00413f30 f   MSVCRTD:_pdblkup_.obj
+ 0002:00003360       @__security_check_cookie@4 00414360 f   MSVCRTD:_secchk_.obj
+ 0002:00003380       ___isa_available_init      00414380 f   MSVCRTD:_cpu_disp_.obj
+ 0002:00003710       ___scrt_is_ucrt_dll_in_use 00414710 f   MSVCRTD:ucrt_detection.obj
+ 0002:00003740       @_guard_check_icall_nop@4  00414740 f i MSVCRTD:guard_support.obj
+ 0002:00003750       __guard_icall_checks_enforced 00414750 f i MSVCRTD:guard_support.obj
+ 0002:00003780       ___raise_securityfailure   00414780 f   MSVCRTD:gs_report.obj
+ 0002:000037c0       ___report_gsfailure        004147c0 f   MSVCRTD:gs_report.obj
+ 0002:00003910       ___report_rangecheckfailure 00414910 f   MSVCRTD:gs_report.obj
+ 0002:00003920       ___report_securityfailure  00414920 f   MSVCRTD:gs_report.obj
+ 0002:00003a30       ___report_securityfailureEx 00414a30 f   MSVCRTD:gs_report.obj
+ 0002:00003b9e       ___std_type_info_destroy_list 00414b9e f   vcruntimed:VCRUNTIME140D.dll
+ 0002:00003ba4       _memset                    00414ba4 f   vcruntimed:VCRUNTIME140D.dll
+ 0002:00003baa       __except_handler4_common   00414baa f   vcruntimed:VCRUNTIME140D.dll
+ 0002:00003bb0       ___vcrt_GetModuleFileNameW 00414bb0 f   vcruntimed:VCRUNTIME140D.dll
+ 0002:00003bb6       ___vcrt_GetModuleHandleW   00414bb6 f   vcruntimed:VCRUNTIME140D.dll
+ 0002:00003bbc       ___vcrt_LoadLibraryExW     00414bbc f   vcruntimed:VCRUNTIME140D.dll
+ 0002:00003bc2       ___acrt_iob_func           00414bc2 f   ucrtd:ucrtbased.dll
+ 0002:00003bc8       ___stdio_common_vfprintf   00414bc8 f   ucrtd:ucrtbased.dll
+ 0002:00003bce       __CrtDbgReport             00414bce f   ucrtd:ucrtbased.dll
+ 0002:00003bd4       __CrtDbgReportW            00414bd4 f   ucrtd:ucrtbased.dll
+ 0002:00003bda       __seh_filter_exe           00414bda f   ucrtd:ucrtbased.dll
+ 0002:00003be0       __set_app_type             00414be0 f   ucrtd:ucrtbased.dll
+ 0002:00003be6       ___setusermatherr          00414be6 f   ucrtd:ucrtbased.dll
+ 0002:00003bec       __configure_narrow_argv    00414bec f   ucrtd:ucrtbased.dll
+ 0002:00003bf2       __initialize_narrow_environment 00414bf2 f   ucrtd:ucrtbased.dll
+ 0002:00003bf8       __get_initial_narrow_environment 00414bf8 f   ucrtd:ucrtbased.dll
+ 0002:00003bfe       __initterm                 00414bfe f   ucrtd:ucrtbased.dll
+ 0002:00003c04       __initterm_e               00414c04 f   ucrtd:ucrtbased.dll
+ 0002:00003c0a       _exit                      00414c0a f   ucrtd:ucrtbased.dll
+ 0002:00003c10       __exit                     00414c10 f   ucrtd:ucrtbased.dll
+ 0002:00003c16       __set_fmode                00414c16 f   ucrtd:ucrtbased.dll
+ 0002:00003c1c       ___p___argc                00414c1c f   ucrtd:ucrtbased.dll
+ 0002:00003c22       ___p___argv                00414c22 f   ucrtd:ucrtbased.dll
+ 0002:00003c28       __cexit                    00414c28 f   ucrtd:ucrtbased.dll
+ 0002:00003c2e       __c_exit                   00414c2e f   ucrtd:ucrtbased.dll
+ 0002:00003c34       __register_thread_local_exe_atexit_callback 00414c34 f   ucrtd:ucrtbased.dll
+ 0002:00003c3a       __configthreadlocale       00414c3a f   ucrtd:ucrtbased.dll
+ 0002:00003c40       __set_new_mode             00414c40 f   ucrtd:ucrtbased.dll
+ 0002:00003c46       ___p__commode              00414c46 f   ucrtd:ucrtbased.dll
+ 0002:00003c4c       ___stdio_common_vsprintf_s 00414c4c f   ucrtd:ucrtbased.dll
+ 0002:00003c52       __seh_filter_dll           00414c52 f   ucrtd:ucrtbased.dll
+ 0002:00003c58       __initialize_onexit_table  00414c58 f   ucrtd:ucrtbased.dll
+ 0002:00003c5e       __register_onexit_function 00414c5e f   ucrtd:ucrtbased.dll
+ 0002:00003c64       __execute_onexit_table     00414c64 f   ucrtd:ucrtbased.dll
+ 0002:00003c6a       __crt_atexit               00414c6a f   ucrtd:ucrtbased.dll
+ 0002:00003c70       __crt_at_quick_exit        00414c70 f   ucrtd:ucrtbased.dll
+ 0002:00003c76       __controlfp_s              00414c76 f   ucrtd:ucrtbased.dll
+ 0002:00003c7c       _terminate                 00414c7c f   ucrtd:ucrtbased.dll
+ 0002:00003c82       __wmakepath_s              00414c82 f   ucrtd:ucrtbased.dll
+ 0002:00003c88       __wsplitpath_s             00414c88 f   ucrtd:ucrtbased.dll
+ 0002:00003c8e       _wcscpy_s                  00414c8e f   ucrtd:ucrtbased.dll
+ 0002:00003c94       _IsDebuggerPresent@0       00414c94 f   kernel32:KERNEL32.dll
+ 0002:00003c9a       _RaiseException@16         00414c9a f   kernel32:KERNEL32.dll
+ 0002:00003ca0       _MultiByteToWideChar@24    00414ca0 f   kernel32:KERNEL32.dll
+ 0002:00003ca6       _WideCharToMultiByte@32    00414ca6 f   kernel32:KERNEL32.dll
+ 0002:00003cac       _QueryPerformanceCounter@4 00414cac f   kernel32:KERNEL32.dll
+ 0002:00003cb2       _GetCurrentProcessId@0     00414cb2 f   kernel32:KERNEL32.dll
+ 0002:00003cb8       _GetCurrentThreadId@0      00414cb8 f   kernel32:KERNEL32.dll
+ 0002:00003cbe       _GetSystemTimeAsFileTime@4 00414cbe f   kernel32:KERNEL32.dll
+ 0002:00003cc4       _InitializeSListHead@4     00414cc4 f   kernel32:KERNEL32.dll
+ 0002:00003cca       _UnhandledExceptionFilter@4 00414cca f   kernel32:KERNEL32.dll
+ 0002:00003cd0       _SetUnhandledExceptionFilter@4 00414cd0 f   kernel32:KERNEL32.dll
+ 0002:00003cd6       _GetStartupInfoW@4         00414cd6 f   kernel32:KERNEL32.dll
+ 0002:00003cdc       _IsProcessorFeaturePresent@4 00414cdc f   kernel32:KERNEL32.dll
+ 0002:00003ce2       _GetModuleHandleW@4        00414ce2 f   kernel32:KERNEL32.dll
+ 0002:00003ce8       _GetLastError@0            00414ce8 f   kernel32:KERNEL32.dll
+ 0002:00003cee       _HeapAlloc@12              00414cee f   kernel32:KERNEL32.dll
+ 0002:00003cf4       _HeapFree@12               00414cf4 f   kernel32:KERNEL32.dll
+ 0002:00003cfa       _GetProcessHeap@0          00414cfa f   kernel32:KERNEL32.dll
+ 0002:00003d00       _VirtualQuery@12           00414d00 f   kernel32:KERNEL32.dll
+ 0002:00003d06       _FreeLibrary@4             00414d06 f   kernel32:KERNEL32.dll
+ 0002:00003d0c       _GetProcAddress@8          00414d0c f   kernel32:KERNEL32.dll
+ 0002:00003d12       _GetCurrentProcess@0       00414d12 f   kernel32:KERNEL32.dll
+ 0002:00003d18       _TerminateProcess@8        00414d18 f   kernel32:KERNEL32.dll
+ 0002:00003d20       ___vcrt_initialize         00414d20 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d20       ___acrt_initialize         00414d20 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d20       ___scrt_stub_for_acrt_initialize 00414d20 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d30       ___scrt_stub_for_acrt_thread_attach 00414d30 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d30       ___vcrt_thread_attach      00414d30 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d30       ___acrt_thread_attach      00414d30 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d40       ___vcrt_thread_detach      00414d40 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d40       ___acrt_thread_detach      00414d40 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d40       ___scrt_stub_for_acrt_thread_detach 00414d40 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d50       ___vcrt_uninitialize       00414d50 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d50       ___acrt_uninitialize       00414d50 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d50       ___scrt_stub_for_acrt_uninitialize 00414d50 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d60       ___vcrt_uninitialize_critical 00414d60 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d60       ___scrt_stub_for_acrt_uninitialize_critical 00414d60 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d60       ___acrt_uninitialize_critical 00414d60 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d70       ___scrt_stub_for_is_c_termination_complete 00414d70 f   MSVCRTD:ucrt_stubs.obj
+ 0002:00003d70       __is_c_termination_complete 00414d70 f   MSVCRTD:ucrt_stubs.obj
+ 0003:00000000       ___xc_a                    00416000     MSVCRTD:initializers.obj
+ 0003:00000208       ___xc_z                    00416208     MSVCRTD:initializers.obj
+ 0003:0000030c       ___xi_a                    0041630c     MSVCRTD:initializers.obj
+ 0003:00000618       ___xi_z                    00416618     MSVCRTD:initializers.obj
+ 0003:0000071c       ___xp_a                    0041671c     MSVCRTD:initializers.obj
+ 0003:00000820       ___xp_z                    00416820     MSVCRTD:initializers.obj
+ 0003:00000924       ___xt_a                    00416924     MSVCRTD:initializers.obj
+ 0003:00000a28       ___xt_z                    00416a28     MSVCRTD:initializers.obj
+ 0003:00000b30       ??_C@_04OFFCAMCD@Test?$AA@ 00416b30     ConsoleApplication1.obj
+ 0003:00000bf8       ??_C@_0NN@NGPKDKPD@The?5value?5of?5ESP?5was?5not?5properl@ 00416bf8     MSVCRTD:_error_.obj
+ 0003:00000d08       ??_C@_0BBN@GPMLNJCF@A?5cast?5to?5a?5smaller?5data?5type?5ha@ 00416d08     MSVCRTD:_error_.obj
+ 0003:00000e60       ??_C@_0BN@FFOINMNJ@Stack?5memory?5was?5corrupted?6?$AN?$AA@ 00416e60     MSVCRTD:_error_.obj
+ 0003:00000e84       ??_C@_0DG@HKJMLLLP@A?5local?5variable?5was?5used?5before@ 00416e84     MSVCRTD:_error_.obj
+ 0003:00000ec4       ??_C@_0CM@NGINOKPC@Stack?5memory?5around?5_alloca?5was?5@ 00416ec4     MSVCRTD:_error_.obj
+ 0003:00000ef8       ??_C@_0BO@GNIAFIKK@Unknown?5Runtime?5Check?5Error?6?$AN?$AA@ 00416ef8     MSVCRTD:_error_.obj
+ 0003:00000f20       ??_C@_1GM@OLMCBDMB@?$AAR?$AAu?$AAn?$AAt?$AAi?$AAm?$AAe?$AA?5?$AAC?$AAh?$AAe?$AAc?$AAk?$AA?5?$AAE?$AAr?$AAr?$AAo?$AAr?$AA?4?$AA?6?$AA?$AN?$AA?5?$AAU?$AAn?$AAa?$AAb?$AAl?$AAe?$AA?5?$AAt?$AAo@ 00416f20     MSVCRTD:_error_.obj
+ 0003:00000fa8       ??_C@_1EA@NFKNIFJP@?$AAR?$AAu?$AAn?$AA?9?$AAT?$AAi?$AAm?$AAe?$AA?5?$AAC?$AAh?$AAe?$AAc?$AAk?$AA?5?$AAF?$AAa?$AAi?$AAl?$AAu?$AAr?$AAe?$AA?5?$AA?$CD?$AA?$CF?$AAd?$AA?5?$AA?9?$AA?5?$AA?$CF?$AAs?$AA?$AA@ 00416fa8     MSVCRTD:_error_.obj
+ 0003:00000ff4       ??_C@_0BB@PFFGGCJP@Unknown?5Filename?$AA@ 00416ff4     MSVCRTD:_error_.obj
+ 0003:00001008       ??_C@_0BE@GNBOBNCK@Unknown?5Module?5Name?$AA@ 00417008     MSVCRTD:_error_.obj
+ 0003:00001020       ??_C@_0CA@IODNCDPG@Run?9Time?5Check?5Failure?5?$CD?$CFd?5?9?5?$CFs?$AA@ 00417020     MSVCRTD:_error_.obj
+ 0003:00001048       ??_C@_0CG@IAFNJNEE@Stack?5corrupted?5near?5unknown?5var@ 00417048     MSVCRTD:_error_.obj
+ 0003:00001078       ??_C@_05MKKEDADM@?$CF?42X?5?$AA@ 00417078     MSVCRTD:_error_.obj
+ 0003:00001080       ??_C@_0EJ@LJKNEOLN@Stack?5area?5around?5_alloca?5memory@ 00417080     MSVCRTD:_error_.obj
+ 0003:000010d8       ??_C@_08OMAHNMHJ@?6Data?3?5?$DM?$AA@ 004170d8     MSVCRTD:_error_.obj
+ 0003:000010e4       ??_C@_0CK@DKGBICFE@?6Allocation?5number?5within?5this?5f@ 004170e4     MSVCRTD:_error_.obj
+ 0003:00001118       ??_C@_07DFDJCKFN@?6Size?3?5?$AA@ 00417118     MSVCRTD:_error_.obj
+ 0003:00001124       ??_C@_0N@MHFFIMFG@?6Address?3?50x?$AA@ 00417124     MSVCRTD:_error_.obj
+ 0003:00001138       ??_C@_0EI@CLEPFNGI@Stack?5area?5around?5_alloca?5memory@ 00417138     MSVCRTD:_error_.obj
+ 0003:00001190       ??_C@_0BC@HHMKLAND@?$CFs?$CFs?$CFp?$CFs?$CFzd?$CFs?$CFd?$CFs?$AA@ 00417190     MSVCRTD:_error_.obj
+ 0003:000011a8       ??_C@_01EEMJAFIK@?6?$AA@   004171a8     MSVCRTD:_error_.obj
+ 0003:000011ac       ??_C@_02LLMPMKNF@?$DO?5?$AA@ 004171ac     MSVCRTD:_error_.obj
+ 0003:000011b0       ??_C@_08KJEDNCKC@?$CFs?$CFs?$CFs?$CFs?$AA@ 004171b0     MSVCRTD:_error_.obj
+ 0003:000011bc       ??_C@_0DE@OHJBPMBP@A?5variable?5is?5being?5used?5without@ 004171bc     MSVCRTD:_error_.obj
+ 0003:00001214       ??_C@_0BJ@HEGAHDFO@Stack?5pointer?5corruption?$AA@ 00417214     MSVCRTD:_userapi_.obj
+ 0003:00001234       ??_C@_0CK@FEGOIOPB@Cast?5to?5smaller?5type?5causing?5los@ 00417234     MSVCRTD:_userapi_.obj
+ 0003:00001268       ??_C@_0BI@CIGMDCBH@Stack?5memory?5corruption?$AA@ 00417268     MSVCRTD:_userapi_.obj
+ 0003:00001284       ??_C@_0CK@CNLNOEPB@Local?5variable?5used?5before?5initi@ 00417284     MSVCRTD:_userapi_.obj
+ 0003:000012b8       ??_C@_0BP@OGBCLIBO@Stack?5around?5_alloca?5corrupted?$AA@ 004172b8     MSVCRTD:_userapi_.obj
+ 0003:00001338       ??_C@_1EI@MLPKHBGE@?$AAa?$AAp?$AAi?$AA?9?$AAm?$AAs?$AA?9?$AAw?$AAi?$AAn?$AA?9?$AAc?$AAo?$AAr?$AAe?$AA?9?$AAr?$AAe?$AAg?$AAi?$AAs?$AAt?$AAr?$AAy?$AA?9?$AAl?$AA1?$AA?9?$AA1?$AA?9?$AA0?$AA?4@ 00417338     MSVCRTD:_pdblkup_.obj
+ 0003:00001390       ??_C@_1BK@JHLNAEJL@?$AAa?$AAd?$AAv?$AAa?$AAp?$AAi?$AA3?$AA2?$AA?4?$AAd?$AAl?$AAl?$AA?$AA@ 00417390     MSVCRTD:_pdblkup_.obj
+ 0003:000013b0       ??_C@_0O@COHOBMLB@RegOpenKeyExW?$AA@ 004173b0     MSVCRTD:_pdblkup_.obj
+ 0003:000013c0       ??_C@_0BB@GLNAEDBD@RegQueryValueExW?$AA@ 004173c0     MSVCRTD:_pdblkup_.obj
+ 0003:000013d4       ??_C@_0M@HLOHPNFA@RegCloseKey?$AA@ 004173d4     MSVCRTD:_pdblkup_.obj
+ 0003:000013e8       ??_C@_1HE@EBEAGLFB@?$AAS?$AAO?$AAF?$AAT?$AAW?$AAA?$AAR?$AAE?$AA?2?$AAW?$AAo?$AAw?$AA6?$AA4?$AA3?$AA2?$AAN?$AAo?$AAd?$AAe?$AA?2?$AAM?$AAi?$AAc?$AAr?$AAo?$AAs?$AAo?$AAf?$AAt?$AA?2?$AAV@ 004173e8     MSVCRTD:_pdblkup_.obj
+ 0003:00001474       ??_C@_1BG@EABPBLLF@?$AAP?$AAr?$AAo?$AAd?$AAu?$AAc?$AAt?$AAD?$AAi?$AAr?$AA?$AA@ 00417474     MSVCRTD:_pdblkup_.obj
+ 0003:000014b4       ??_C@_1BC@JINFINNJ@?$AAM?$AAS?$AAP?$AAD?$AAB?$AA1?$AA4?$AA0?$AA?$AA@ 004174b4     MSVCRTD:_pdblkup_.obj
+ 0003:000014cc       ??_C@_0BB@KCIACLNC@PDBOpenValidate5?$AA@ 004174cc     MSVCRTD:_pdblkup_.obj
+ 0003:000014e0       ??_C@_01KDCPPGHE@r?$AA@    004174e0     MSVCRTD:_pdblkup_.obj
+ 0003:00001528       __load_config_used         00417528     MSVCRTD:loadcfg.obj
+ 0003:00001868       ___rtc_iaa                 00417868     MSVCRTD:_initsect_.obj
+ 0003:00001a70       ___rtc_izz                 00417a70     MSVCRTD:_initsect_.obj
+ 0003:00001b74       ___rtc_taa                 00417b74     MSVCRTD:_initsect_.obj
+ 0003:00001d7c       ___rtc_tzz                 00417d7c     MSVCRTD:_initsect_.obj
+ 0004:00000000       ?_RTC_ErrorLevels@@3PAHA   00419000     MSVCRTD:_error_.obj
+ 0004:00000018       ___scrt_native_dllmain_reason 00419018     MSVCRTD:utility.obj
+ 0004:0000001c       ___scrt_default_matherr    0041901c     MSVCRTD:matherr.obj
+ 0004:00000020       ___security_cookie_complement 00419020     MSVCRTD:gs_cookie.obj
+ 0004:00000024       ___security_cookie         00419024     MSVCRTD:gs_cookie.obj
+ 0004:0000002c       ___isa_enabled             0041902c     MSVCRTD:_cpu_disp_.obj
+ 0004:00000030       ___scrt_ucrt_dll_is_in_use 00419030     MSVCRTD:ucrt_stubs.obj
+ 0004:00000138       ?_OptionsStorage@?1??__local_stdio_printf_options@@9@4_KA 00419138     ConsoleApplication1.obj
+ 0004:00000144       ___@@_PchSym_@00@UfhvihUkzgirxpUwlxfnvmghUtrgsfyUxlmhlovzkkorxzgrlmBUxlmhlovzkkorxzgrlmBUwvyftUhgwzucOlyq@58EB7FF75EFF052 00419144     stdafx.obj
+ 0004:00000158       ___scrt_current_native_startup_state 00419158     MSVCRTD:utility.obj
+ 0004:0000015c       ___scrt_native_startup_lock 0041915c     MSVCRTD:utility.obj
+ 0004:00000180       ?__type_info_root_node@@3U__type_info_node@@A 00419180     MSVCRTD:tncleanup.obj
+ 0004:00000190       ?_OptionsStorage@?1??__local_stdio_scanf_options@@9@4_KA 00419190     MSVCRTD:default_local_stdio_options.obj
+ 0004:0000019c       ___scrt_debugger_hook_flag 0041919c     MSVCRTD:utility_desktop.obj
+ 0004:000001a8       ___isa_available           004191a8     MSVCRTD:_cpu_disp_.obj
+ 0004:000001ac       ___favor                   004191ac     MSVCRTD:_cpu_disp_.obj
+ 0004:00000574       ___dyn_tls_dtor_callback   00419574     <common>
+ 0004:00000580       ___dyn_tls_init_callback   00419580     <common>
+ 0005:00000000       __imp__RaiseException@16   0041a000     kernel32:KERNEL32.dll
+ 0005:00000004       __imp__MultiByteToWideChar@24 0041a004     kernel32:KERNEL32.dll
+ 0005:00000008       __imp__WideCharToMultiByte@32 0041a008     kernel32:KERNEL32.dll
+ 0005:0000000c       __imp__QueryPerformanceCounter@4 0041a00c     kernel32:KERNEL32.dll
+ 0005:00000010       __imp__GetCurrentProcessId@0 0041a010     kernel32:KERNEL32.dll
+ 0005:00000014       __imp__GetCurrentThreadId@0 0041a014     kernel32:KERNEL32.dll
+ 0005:00000018       __imp__TerminateProcess@8  0041a018     kernel32:KERNEL32.dll
+ 0005:0000001c       __imp__GetCurrentProcess@0 0041a01c     kernel32:KERNEL32.dll
+ 0005:00000020       __imp__GetProcAddress@8    0041a020     kernel32:KERNEL32.dll
+ 0005:00000024       __imp__FreeLibrary@4       0041a024     kernel32:KERNEL32.dll
+ 0005:00000028       __imp__VirtualQuery@12     0041a028     kernel32:KERNEL32.dll
+ 0005:0000002c       __imp__GetProcessHeap@0    0041a02c     kernel32:KERNEL32.dll
+ 0005:00000030       __imp__HeapFree@12         0041a030     kernel32:KERNEL32.dll
+ 0005:00000034       __imp__HeapAlloc@12        0041a034     kernel32:KERNEL32.dll
+ 0005:00000038       __imp__GetLastError@0      0041a038     kernel32:KERNEL32.dll
+ 0005:0000003c       __imp__GetModuleHandleW@4  0041a03c     kernel32:KERNEL32.dll
+ 0005:00000040       __imp__IsProcessorFeaturePresent@4 0041a040     kernel32:KERNEL32.dll
+ 0005:00000044       __imp__GetStartupInfoW@4   0041a044     kernel32:KERNEL32.dll
+ 0005:00000048       __imp__SetUnhandledExceptionFilter@4 0041a048     kernel32:KERNEL32.dll
+ 0005:0000004c       __imp__UnhandledExceptionFilter@4 0041a04c     kernel32:KERNEL32.dll
+ 0005:00000050       __imp__InitializeSListHead@4 0041a050     kernel32:KERNEL32.dll
+ 0005:00000054       __imp__GetSystemTimeAsFileTime@4 0041a054     kernel32:KERNEL32.dll
+ 0005:00000058       __imp__IsDebuggerPresent@0 0041a058     kernel32:KERNEL32.dll
+ 0005:0000005c       \177KERNEL32_NULL_THUNK_DATA 0041a05c     kernel32:KERNEL32.dll
+ 0005:00000098       __imp____vcrt_GetModuleHandleW 0041a098     vcruntimed:VCRUNTIME140D.dll
+ 0005:0000009c       __imp____vcrt_GetModuleFileNameW 0041a09c     vcruntimed:VCRUNTIME140D.dll
+ 0005:000000a0       __imp___except_handler4_common 0041a0a0     vcruntimed:VCRUNTIME140D.dll
+ 0005:000000a4       __imp__memset              0041a0a4     vcruntimed:VCRUNTIME140D.dll
+ 0005:000000a8       __imp____vcrt_LoadLibraryExW 0041a0a8     vcruntimed:VCRUNTIME140D.dll
+ 0005:000000ac       __imp____std_type_info_destroy_list 0041a0ac     vcruntimed:VCRUNTIME140D.dll
+ 0005:000000b0       \177VCRUNTIME140D_NULL_THUNK_DATA 0041a0b0     vcruntimed:VCRUNTIME140D.dll
+ 0005:000000e0       __imp___seh_filter_dll     0041a0e0     ucrtd:ucrtbased.dll
+ 0005:000000e4       __imp___initialize_onexit_table 0041a0e4     ucrtd:ucrtbased.dll
+ 0005:000000e8       __imp____stdio_common_vsprintf_s 0041a0e8     ucrtd:ucrtbased.dll
+ 0005:000000ec       __imp___execute_onexit_table 0041a0ec     ucrtd:ucrtbased.dll
+ 0005:000000f0       __imp___crt_atexit         0041a0f0     ucrtd:ucrtbased.dll
+ 0005:000000f4       __imp___crt_at_quick_exit  0041a0f4     ucrtd:ucrtbased.dll
+ 0005:000000f8       __imp___controlfp_s        0041a0f8     ucrtd:ucrtbased.dll
+ 0005:000000fc       __imp__terminate           0041a0fc     ucrtd:ucrtbased.dll
+ 0005:00000100       __imp___wmakepath_s        0041a100     ucrtd:ucrtbased.dll
+ 0005:00000104       __imp___wsplitpath_s       0041a104     ucrtd:ucrtbased.dll
+ 0005:00000108       __imp__wcscpy_s            0041a108     ucrtd:ucrtbased.dll
+ 0005:0000010c       __imp____p__commode        0041a10c     ucrtd:ucrtbased.dll
+ 0005:00000110       __imp___set_new_mode       0041a110     ucrtd:ucrtbased.dll
+ 0005:00000114       __imp___configthreadlocale 0041a114     ucrtd:ucrtbased.dll
+ 0005:00000118       __imp___register_thread_local_exe_atexit_callback 0041a118     ucrtd:ucrtbased.dll
+ 0005:0000011c       __imp___c_exit             0041a11c     ucrtd:ucrtbased.dll
+ 0005:00000120       __imp___cexit              0041a120     ucrtd:ucrtbased.dll
+ 0005:00000124       __imp____p___argv          0041a124     ucrtd:ucrtbased.dll
+ 0005:00000128       __imp____p___argc          0041a128     ucrtd:ucrtbased.dll
+ 0005:0000012c       __imp___set_fmode          0041a12c     ucrtd:ucrtbased.dll
+ 0005:00000130       __imp___exit               0041a130     ucrtd:ucrtbased.dll
+ 0005:00000134       __imp__exit                0041a134     ucrtd:ucrtbased.dll
+ 0005:00000138       __imp___initterm_e         0041a138     ucrtd:ucrtbased.dll
+ 0005:0000013c       __imp___initterm           0041a13c     ucrtd:ucrtbased.dll
+ 0005:00000140       __imp___get_initial_narrow_environment 0041a140     ucrtd:ucrtbased.dll
+ 0005:00000144       __imp___initialize_narrow_environment 0041a144     ucrtd:ucrtbased.dll
+ 0005:00000148       __imp___configure_narrow_argv 0041a148     ucrtd:ucrtbased.dll
+ 0005:0000014c       __imp____setusermatherr    0041a14c     ucrtd:ucrtbased.dll
+ 0005:00000150       __imp___set_app_type       0041a150     ucrtd:ucrtbased.dll
+ 0005:00000154       __imp___seh_filter_exe     0041a154     ucrtd:ucrtbased.dll
+ 0005:00000158       __imp___CrtDbgReportW      0041a158     ucrtd:ucrtbased.dll
+ 0005:0000015c       __imp___CrtDbgReport       0041a15c     ucrtd:ucrtbased.dll
+ 0005:00000160       __imp____stdio_common_vfprintf 0041a160     ucrtd:ucrtbased.dll
+ 0005:00000164       __imp____acrt_iob_func     0041a164     ucrtd:ucrtbased.dll
+ 0005:00000168       __imp___register_onexit_function 0041a168     ucrtd:ucrtbased.dll
+ 0005:0000016c       \177ucrtbased_NULL_THUNK_DATA 0041a16c     ucrtd:ucrtbased.dll
+ 0005:000001b4       __IMPORT_DESCRIPTOR_VCRUNTIME140D 0041a1b4     vcruntimed:VCRUNTIME140D.dll
+ 0005:000001c8       __IMPORT_DESCRIPTOR_ucrtbased 0041a1c8     ucrtd:ucrtbased.dll
+ 0005:000001dc       __IMPORT_DESCRIPTOR_KERNEL32 0041a1dc     kernel32:KERNEL32.dll
+ 0005:000001f0       __NULL_IMPORT_DESCRIPTOR   0041a1f0     vcruntimed:VCRUNTIME140D.dll
+ 0007:00000000       ___guard_check_icall_fptr  0041c000     MSVCRTD:guard_support.obj

--- a/test/pe32-tests.js
+++ b/test/pe32-tests.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2017, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+var chai = require('chai');
+var should = chai.should();
+var assert = chai.assert;
+var LabelReconstructor = require('../lib/pe32-support').labelReconstructor;
+var logger = require('../lib/logger').logger;
+
+describe('Basic reconstructions', function () {
+    it('No lines', function () {
+        var lines = [];
+        var reconstructor = new LabelReconstructor(lines, false, false);
+        reconstructor.asmLines.length.should.equal(0);
+    });
+
+    // todo: more tests pe32-support labelReconstructor
+});


### PR DESCRIPTION
Work in progress - but so far I can read Windows .exe objdumps and match the functions and lines if there's a .map file.

Currently just tested with binaries and maps generated by Delphi 7, but planning to try and support MSVC binaries and maps as well.

Delphi 7 binary with labels and line number matching:
![FPC vs Delphi comparison](https://i.imgur.com/ZYT52c6.png)


Todo:
- [x] Basic MAP support Windows
- [x] Basic MAP support Delphi
- [ ] Setup so that binary mode is always enabled and can't be disabled
- [ ] Make a local properties that supports all compilers
- [ ] Write examples with generics that compile on both fpc and delphi
- [ ] Delphi 5
- [ ] Delphi 6
- [x] Delphi 7
- [ ] Delphi 2007
- [x] Delphi 2009
- [x] Delphi XE
- [ ] Delphi XE2
- [ ] Delphi XE3
- [ ] Delphi XE4
- [ ] Delphi XE5
- [ ] Delphi XE6
- [ ] Delphi XE7
- [ ] Delphi XE8
- [ ] Delphi 10 Seattle
- [ ] Delphi 10.1 Berlin
- [ ] Delphi 10.2 Tokyo
- [ ] Ask terms/permission from Embarcadero to use some compilers on godbolt.org
