### PR TITLE
Demangling for MSVC CL when using undname.exe

### DIFF
--- a/c-preload/compiler-wrapper
+++ b/c-preload/compiler-wrapper
@@ -9,6 +9,7 @@ export DENIED=/proc/self/cwd:/proc/self/root:/proc/self/exe
 # Wine configuration
 export DISPLAY=
 export WINEPREFIX=/tmp/wine
+export WINEDLLOVERRIDES="vcruntime140=n"
 mkdir -p /tmp/wine
 ALLOWED_FOR_READ=${ALLOWED_FOR_READ}:/usr/share/fonts:/etc/passwd
 

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -217,6 +217,7 @@ group.cl.needsMulti=false
 group.cl.compilerType=Wine-CL
 group.cl.versionFlag=/?
 group.cl.versionRe=^Microsoft \(R\) C/C\+\+.*$
+group.cl.demangler=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64/undname.exe
 group.cl19.compilers=cl19_64:cl19_32:cl19_arm
 group.cl19.options=/I/opt/compiler-explorer/windows/10.0.10240.0/ucrt/ /I/opt/compiler-explorer/windows/19.10.25017/lib/native/include/
 compiler.cl19_64.exe=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64/cl.exe

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -50,7 +50,7 @@ function RunCLDemangler(compiler, result) {
     
             var tmpFileAsArgument = compiler.filename(tmpfile);
 
-            return compiler.exec(demangler, [tmpFileAsArgument], {})
+            return compiler.exec(demangler, [tmpFileAsArgument], compiler.getDefaultExecOptions())
                 .then(function (demangleResult) {
                 fs.unlink(tmpfile, function() {
                     fs.remove(tmpDir, function() {});

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -48,7 +48,9 @@ function RunCLDemangler(compiler, result) {
             var tmpfile = path.join(tmpDir, "output.s");
             fs.writeFileSync(tmpfile, asmFileContent);
     
-            return compiler.exec(demangler, [tmpfile], {})
+            var tmpFileAsArgument = compiler.filename(tmpfile);
+
+            return compiler.exec(demangler, [tmpFileAsArgument], {})
                 .then(function (demangleResult) {
                 fs.unlink(tmpfile, function() {
                     fs.remove(tmpDir, function() {});

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -1,0 +1,68 @@
+// Copyright (c) 2017, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+"use strict";
+
+var fs = require('fs-extra'),
+    path = require('path'),
+    _ = require('underscore-node'),
+    utils = require('./utils');
+
+function OverwriteAsmLines(result, demangleOutput) {
+    var lines = utils.splitLines(demangleOutput);
+    for (var i = 0; i < result.asm.length; ++i)
+        result.asm[i].text = lines[i];
+    return result;
+}
+
+function RunCLDemangler(compiler, result) {
+    if (!result.okToCache) return result;
+    var demangler = compiler.compiler.demangler;
+    if (!demangler) return result;
+
+    var asmFileContent = _.pluck(result.asm, 'text').join("\n");
+
+    if (demangler.toLowerCase().endsWith("undname.exe")) {
+        return compiler.newTempDir().then(function (tmpDir) {
+            var tmpfile = path.join(tmpDir, "output.s");
+            fs.writeFileSync(tmpfile, asmFileContent);
+    
+            return compiler.exec(demangler, [tmpfile], {})
+                .then(function (demangleResult) {
+                fs.unlink(tmpfile, function() {
+                    fs.remove(tmpDir, function() {});
+                });
+    
+                return OverwriteAsmLines(result, demangleResult.stdout);
+            });
+        });
+    } else {
+        return compiler.exec(demangler, [], {input: asmFileContent})
+            .then(function (demangleResult) {
+                return OverwriteAsmLines(result, demangleResult.stdout);
+            });
+    }
+}
+
+exports.RunCLDemangler = RunCLDemangler;

--- a/lib/compilers/WSL-CL.js
+++ b/lib/compilers/WSL-CL.js
@@ -30,6 +30,7 @@
 
 var Compile = require('../base-compiler');
 var asm = require('../asm-cl');
+var RunCLDemangler = require('../cl-support').RunCLDemangler;
 
 function compileCl(info, env) {
     var compile = new Compile(info, env);
@@ -53,6 +54,11 @@ function compileCl(info, env) {
     compile.supportsObjdump = function () {
         return false;
     };
+
+    compile.postProcessAsm = function(result) {
+        return RunCLDemangler(this, result);
+    };
+
     compile.optionsForFilter = function (filters, outputFilename) {
         return [
             '/FAsc',

--- a/lib/compilers/Wine-CL.js
+++ b/lib/compilers/Wine-CL.js
@@ -24,10 +24,7 @@
 
 var Compile = require('../base-compiler');
 var asm = require('../asm-cl');
-var utils = require('../utils');
-var fs = require('fs-extra'),
-    path = require('path'),
-    _ = require('underscore-node');
+var RunCLDemangler = require('../cl-support').RunCLDemangler;
 
 function compileCl(info, env) {
     var compile = new Compile(info, env);
@@ -51,37 +48,8 @@ function compileCl(info, env) {
         return false;
     };
 
-    compile.postProcessAsm = function (result) {
-        if (!result.okToCache) return result;
-        var demangler = this.compiler.demangler;
-        if (!demangler) return result;
-
-        if (demangler.toLowerCase().endsWith("undname.exe")) {
-            return this.newTempDir().then(function (tmpDir) {
-                var tmpfile = path.join(tmpDir, "output.s");
-                fs.writeFileSync(tmpfile, _.pluck(result.asm, 'text').join("\r\n"));
-
-                return this.exec(demangler, [tmpfile], {})
-                    .then(_.bind(function (demangleResult) {
-                    fs.unlink(tmpfile, function() {
-                        fs.remove(tmpDir, function() {});
-                    });
-
-                    var lines = utils.splitLines(demangleResult.stdout);
-                    for (var i = 0; i < result.asm.length; ++i)
-                        result.asm[i].text = lines[i];
-                    return result;
-                }, this));
-            }.bind(this));
-        } else {
-            return this.exec(demangler, [], {input: _.pluck(result.asm, 'text').join("\n")})
-                .then(_.bind(function (demangleResult) {
-                    var lines = utils.splitLines(demangleResult.stdout);
-                    for (var i = 0; i < result.asm.length; ++i)
-                        result.asm[i].text = lines[i];
-                    return result;
-                }, this));
-        }
+    compile.postProcessAsm = function(result) {
+        return RunCLDemangler(this, result);
     };
 
     compile.optionsForFilter = function (filters, outputFilename, userOptions) {

--- a/lib/compilers/Wine-CL.js
+++ b/lib/compilers/Wine-CL.js
@@ -24,6 +24,10 @@
 
 var Compile = require('../base-compiler');
 var asm = require('../asm-cl');
+var utils = require('../utils');
+var fs = require('fs-extra'),
+    path = require('path'),
+    _ = require('underscore-node');
 
 function compileCl(info, env) {
     var compile = new Compile(info, env);
@@ -46,6 +50,40 @@ function compileCl(info, env) {
     compile.supportsObjdump = function () {
         return false;
     };
+
+    compile.postProcessAsm = function (result) {
+        if (!result.okToCache) return result;
+        var demangler = this.compiler.demangler;
+        if (!demangler) return result;
+
+        if (demangler.toLowerCase().endsWith("undname.exe")) {
+            return this.newTempDir().then(function (tmpDir) {
+                var tmpfile = path.join(tmpDir, "output.s");
+                fs.writeFileSync(tmpfile, _.pluck(result.asm, 'text').join("\r\n"));
+
+                return this.exec(demangler, [tmpfile], {})
+                    .then(_.bind(function (demangleResult) {
+                    fs.unlink(tmpfile, function() {
+                        fs.remove(tmpDir, function() {});
+                    });
+
+                    var lines = utils.splitLines(demangleResult.stdout);
+                    for (var i = 0; i < result.asm.length; ++i)
+                        result.asm[i].text = lines[i];
+                    return result;
+                }, this));
+            }.bind(this));
+        } else {
+            return this.exec(demangler, [], {input: _.pluck(result.asm, 'text').join("\n")})
+                .then(_.bind(function (demangleResult) {
+                    var lines = utils.splitLines(demangleResult.stdout);
+                    for (var i = 0; i < result.asm.length; ++i)
+                        result.asm[i].text = lines[i];
+                    return result;
+                }, this));
+        }
+    };
+
     compile.optionsForFilter = function (filters, outputFilename, userOptions) {
         return [
             '/FAsc',

--- a/test/win-path-tests.js
+++ b/test/win-path-tests.js
@@ -1,0 +1,68 @@
+// Copyright (c) 2017, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+var chai = require('chai');
+var should = chai.should();
+var assert = chai.assert;
+var WslCL = require('../lib/compilers/WSL-CL');
+var WineCL = require('../lib/compilers/Wine-CL');
+var logger = require('../lib/logger').logger;
+var CompilationEnvironment = require('../lib/compilation-env').CompilationEnvironment;
+
+describe('Paths', function () {
+    it('Linux -> Wine path', function () {
+        var info = {
+            "exe": null,
+            "remote": true
+        };
+        var envprops = function (key, deflt) {
+            return deflt;
+        };
+
+        var env = new CompilationEnvironment(envprops);
+        env.compilerProps = function () {};
+
+        var compiler = new WineCL(info, env);
+        
+        compiler._12.filename("/tmp/123456/output.s").should.equal("Z:/tmp/123456/output.s");
+    });
+
+    it('Linux -> Windows path', function () {
+        var info = {
+            "exe": null,
+            "remote": true
+        };
+        var envprops = function (key, deflt) {
+            return deflt;
+        };
+
+        var env = new CompilationEnvironment(envprops);
+        env.compilerProps = function () {};
+
+        var compiler = new WslCL(info, env);
+        
+        process.env.tmpDir = "/mnt/c/tmp";
+        compiler._12.filename("/mnt/c/tmp/123456/output.s").should.equal("c:/tmp/123456/output.s");
+    });
+});

--- a/test/win-path-tests.js
+++ b/test/win-path-tests.js
@@ -62,7 +62,7 @@ describe('Paths', function () {
 
         var compiler = new WslCL(info, env);
         
-        process.env.tmpDir = "/mnt/c/tmp";
+        process.env.winTmp = "/mnt/c/tmp";
         compiler._12.filename("/mnt/c/tmp/123456/output.s").should.equal("c:/tmp/123456/output.s");
     });
 });


### PR DESCRIPTION
Not too happy about this code, but it does work.

Is WSL-CL in use? Should probably change it for that one as well..

(As to setting undname as the demangler in the properties files, before that happens I should probably find out what .dll's undname needs and which ones should switch to native windows dll's instead of the Wine dll's)