### PR TITLE
Generalize PATH for spaces in PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NODE_DIR?=/opt/compiler-explorer/node
-NPM:=$(shell env PATH=$(NODE_DIR)/bin:$(PATH) which npm)
-NODE:=$(shell env PATH=$(NODE_DIR)/bin:$(PATH) which node || env PATH=$(NODE_DIR)/bin:$(PATH) which nodejs)
+NPM:= $(shell env PATH="$(NODE_DIR)/bin:$$PATH" which npm)
+NODE:= $(shell env PATH="$(NODE_DIR)/bin:$$PATH" which node || env PATH="$(NODE_DIR)/bin:$$PATH" which nodejs)
 default: run
 
 NODE_VERSION_USED:=8


### PR DESCRIPTION
I discovered an issue with commit 43c16a on WSL. Changes to the makefile used $(PATH). This doesn't do well on filesystems that allow spaces or parentheses (like Windows...)

This should be equivalent and additionally should improve the state of the world on Linux in case anyone is foolish enough to use a path with spaces in it. 
