### PR TITLE
Label indentation fixes when using inline assembly

### DIFF
--- a/lib/asm.js
+++ b/lib/asm.js
@@ -240,7 +240,6 @@ function AsmParser(compilerProps) {
                     prevLabel = match;
                 }
             }
-
             if (!match && filters.directives) {
                 // Check for directives only if it wasn't a label; the regexp would
                 // otherwise misinterpret labels as directives.

--- a/lib/asm.js
+++ b/lib/asm.js
@@ -92,7 +92,6 @@ function AsmParser(compilerProps) {
             var match = line.match(labelDef);
             if (match)
                 currentLabel = match[1];
-
             match = line.match(definesGlobal);
             if (match) {
                 labelsUsed[match[1]] = true;
@@ -230,7 +229,6 @@ function AsmParser(compilerProps) {
                 line = fixLabelIndentation(line);
 
             match = line.match(labelDef);
-
             if (!match) match = line.match(assignmentDef);
             if (match) {
                 // It's a label definition.

--- a/lib/asm.js
+++ b/lib/asm.js
@@ -69,7 +69,7 @@ function AsmParser(compilerProps) {
         var labelsUsed = {};
         var weakUsages = {};
         var currentLabel = "";
-        var inCustomAssembly = 0;
+        let inCustomAssembly = 0;
 
         // Scan through looking for definite label usages (ones used by opcodes),
         // and ones that are weakly used: that is, their use is conditional on another label.
@@ -179,7 +179,7 @@ function AsmParser(compilerProps) {
         var endBlock = /\.(cfi_endproc|data|text|section)/;
         let source = null;
 
-        var inCustomAssembly = 0;
+        let inCustomAssembly = 0;
         asmLines.forEach(function (line) {
             let match;
             if (line.trim() === "") {

--- a/lib/asm.js
+++ b/lib/asm.js
@@ -33,8 +33,11 @@ function AsmParser(compilerProps) {
     var definesFunction = /^\s*\.type.*,\s*[@%]function$/;
     var definesGlobal = /^\s*\.globa?l\s*([.a-zA-Z_][a-zA-Z0-9$_.]*)/;
     var labelDef = /^([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
+    var indentedLabelDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
     var assignmentDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]+)\s*=/;
     var directive = /^\s*\..*$/;
+    var startAppBlock = /.*\#APP.*/;
+    var endAppBlock = /.*\#NO_APP.*/;
 
     function hasOpcode(line) {
         // Remove any leading label definition...
@@ -64,6 +67,7 @@ function AsmParser(compilerProps) {
         var labelsUsed = {};
         var weakUsages = {};
         var currentLabel = "";
+        var inCustomAssembly = false;
 
         // Scan through looking for definite label usages (ones used by opcodes),
         // and ones that are weakly used: that is, their use is conditional on another label.
@@ -74,9 +78,25 @@ function AsmParser(compilerProps) {
         // In this case, the '.baz' is used by an opcode, and so is strongly used.
         // The '.foo' is weakly used by .baz.
         asmLines.forEach(function (line) {
+            if (line.match(startAppBlock)) {
+                inCustomAssembly = true;
+            } else if (line.match(endAppBlock)) {
+                inCustomAssembly = false;
+            }
+
             var match = line.match(labelDef);
             if (match)
                 currentLabel = match[1];
+
+            if (!match && inCustomAssembly) {
+                // inline assembly labels in gcc might be indented inconsistently with other labels
+                match = line.match(indentedLabelDef);
+                if (match) {
+                    currentLabel = match[1];
+                    line = line.replace(/^\s+/, "");
+                }
+            }
+
             match = line.match(definesGlobal);
             if (match) {
                 labelsUsed[match[1]] = true;
@@ -163,8 +183,6 @@ function AsmParser(compilerProps) {
         const stdInLooking = /.*<stdin>|^-$|example\.[^/]+$|<source>/;
         var endBlock = /\.(cfi_endproc|data|text|section)/;
         let source = null;
-        var startAppBlock = /.*\#APP.*/;
-        var endAppBlock = /.*\#NO_APP.*/;
 
         var inCustomAssembly = false;
         asmLines.forEach(function (line) {
@@ -213,6 +231,13 @@ function AsmParser(compilerProps) {
             if (filters.commentOnly && line.match(commentOnly)) return;
 
             match = line.match(labelDef);
+            if (!match && inCustomAssembly) {
+                // inline assembly labels in gcc might be indented inconsistently with other labels
+                match = line.match(indentedLabelDef);
+                if (match) {
+                    line = line.replace(/^\s+/, "");
+                }
+            }
             if (!match) match = line.match(assignmentDef);
             if (match) {
                 // It's a label definition.
@@ -224,6 +249,7 @@ function AsmParser(compilerProps) {
                     prevLabel = match;
                 }
             }
+
             if (!match && filters.directives) {
                 // Check for directives only if it wasn't a label; the regexp would
                 // otherwise misinterpret labels as directives.

--- a/lib/asm.js
+++ b/lib/asm.js
@@ -36,10 +36,10 @@ function AsmParser(compilerProps) {
     const indentedLabelDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
     var assignmentDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]+)\s*=/;
     var directive = /^\s*\..*$/;
-    const startAppBlock = /.*\#APP.*/;
-    const endAppBlock = /.*\#NO_APP.*/;
-    const startAsmNesting = /.*\# Begin ASM.*/;
-    const endAsmNesting = /.*\# End ASM.*/;
+    const startAppBlock = /\s*\#APP.*/;
+    const endAppBlock = /\s*\#NO_APP.*/;
+    const startAsmNesting = /\s*\# Begin ASM.*/;
+    const endAsmNesting = /\s*\# End ASM.*/;
 
     function hasOpcode(line) {
         // Remove any leading label definition...

--- a/lib/asm.js
+++ b/lib/asm.js
@@ -33,11 +33,13 @@ function AsmParser(compilerProps) {
     var definesFunction = /^\s*\.type.*,\s*[@%]function$/;
     var definesGlobal = /^\s*\.globa?l\s*([.a-zA-Z_][a-zA-Z0-9$_.]*)/;
     var labelDef = /^([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
-    var indentedLabelDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
+    const indentedLabelDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
     var assignmentDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]+)\s*=/;
     var directive = /^\s*\..*$/;
-    var startAppBlock = /.*\#APP.*/;
-    var endAppBlock = /.*\#NO_APP.*/;
+    const startAppBlock = /.*\#APP.*/;
+    const endAppBlock = /.*\#NO_APP.*/;
+    const startAsmNesting = /.*\# Begin ASM.*/;
+    const endAsmNesting = /.*\# End ASM.*/;
 
     function hasOpcode(line) {
         // Remove any leading label definition...
@@ -67,7 +69,7 @@ function AsmParser(compilerProps) {
         var labelsUsed = {};
         var weakUsages = {};
         var currentLabel = "";
-        var inCustomAssembly = false;
+        var inCustomAssembly = 0;
 
         // Scan through looking for definite label usages (ones used by opcodes),
         // and ones that are weakly used: that is, their use is conditional on another label.
@@ -78,24 +80,18 @@ function AsmParser(compilerProps) {
         // In this case, the '.baz' is used by an opcode, and so is strongly used.
         // The '.foo' is weakly used by .baz.
         asmLines.forEach(function (line) {
-            if (line.match(startAppBlock)) {
-                inCustomAssembly = true;
-            } else if (line.match(endAppBlock)) {
-                inCustomAssembly = false;
+            if (line.match(startAppBlock) || line.match(startAsmNesting)) {
+                inCustomAssembly++;
+            } else if (line.match(endAppBlock) || line.match(endAsmNesting)) {
+                inCustomAssembly--;
             }
+
+            if (inCustomAssembly > 0)
+                line = fixLabelIndentation(line);
 
             var match = line.match(labelDef);
             if (match)
                 currentLabel = match[1];
-
-            if (!match && inCustomAssembly) {
-                // inline assembly labels in gcc might be indented inconsistently with other labels
-                match = line.match(indentedLabelDef);
-                if (match) {
-                    currentLabel = match[1];
-                    line = line.replace(/^\s+/, "");
-                }
-            }
 
             match = line.match(definesGlobal);
             if (match) {
@@ -184,7 +180,7 @@ function AsmParser(compilerProps) {
         var endBlock = /\.(cfi_endproc|data|text|section)/;
         let source = null;
 
-        var inCustomAssembly = false;
+        var inCustomAssembly = 0;
         asmLines.forEach(function (line) {
             let match;
             if (line.trim() === "") {
@@ -192,10 +188,10 @@ function AsmParser(compilerProps) {
                 return;
             }
 
-            if (line.match(startAppBlock)) {
-                inCustomAssembly = true;
-            } else if (line.match(endAppBlock)) {
-                inCustomAssembly = false;
+            if (line.match(startAppBlock) || line.match(startAsmNesting)) {
+                inCustomAssembly++;
+            } else if (line.match(endAppBlock) || line.match(endAsmNesting)) {
+                inCustomAssembly--;
             }
 
             if (!!(match = line.match(sourceTag))) {
@@ -230,14 +226,11 @@ function AsmParser(compilerProps) {
 
             if (filters.commentOnly && line.match(commentOnly)) return;
 
+            if (inCustomAssembly > 0)
+                line = fixLabelIndentation(line);
+
             match = line.match(labelDef);
-            if (!match && inCustomAssembly) {
-                // inline assembly labels in gcc might be indented inconsistently with other labels
-                match = line.match(indentedLabelDef);
-                if (match) {
-                    line = line.replace(/^\s+/, "");
-                }
-            }
+
             if (!match) match = line.match(assignmentDef);
             if (match) {
                 // It's a label definition.
@@ -264,6 +257,15 @@ function AsmParser(compilerProps) {
             result.push({text: filterAsmLine(line, filters), source: hasOpcode(line) ? source : null});
         });
         return result;
+    }
+
+    function fixLabelIndentation(line) {
+        const match = line.match(indentedLabelDef);
+        if (match) {
+            return line.replace(/^\s+/, "");
+        } else {
+            return line;
+        }
     }
 
     var binaryHideFuncRe = null;

--- a/lib/asm.js
+++ b/lib/asm.js
@@ -163,12 +163,23 @@ function AsmParser(compilerProps) {
         const stdInLooking = /.*<stdin>|^-$|example\.[^/]+$|<source>/;
         var endBlock = /\.(cfi_endproc|data|text|section)/;
         let source = null;
+        var startAppBlock = /.*\#APP.*/;
+        var endAppBlock = /.*\#NO_APP.*/;
+
+        var inCustomAssembly = false;
         asmLines.forEach(function (line) {
             let match;
             if (line.trim() === "") {
                 result.push({text: "", source: null});
                 return;
             }
+
+            if (line.match(startAppBlock)) {
+                inCustomAssembly = true;
+            } else if (line.match(endAppBlock)) {
+                inCustomAssembly = false;
+            }
+
             if (!!(match = line.match(sourceTag))) {
                 const file = files[parseInt(match[1])];
                 const sourceLine = parseInt(match[2]);

--- a/test/cases/bug-577_clang.asm
+++ b/test/cases/bug-577_clang.asm
@@ -1,0 +1,196 @@
+	.text
+	.file	"example.cpp"
+	.globl	_Z6squarei
+	.p2align	4, 0x90
+	.type	_Z6squarei,@function
+_Z6squarei:                             # @_Z6squarei
+.Lfunc_begin0:
+	.file	1 "" "example.cpp"
+	.loc	1 2 0                   # example.cpp:2:0
+	.cfi_startproc
+# BB#0:
+	pushq	%rbp
+.Lcfi0:
+	.cfi_def_cfa_offset 16
+.Lcfi1:
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+.Lcfi2:
+	.cfi_def_cfa_register %rbp
+	movl	%edi, -4(%rbp)
+.Ltmp0:
+	.loc	1 3 5 prologue_end      # example.cpp:3:5
+	#APP
+label:
+	#NO_APP
+	.loc	1 4 12                  # example.cpp:4:12
+	movl	-4(%rbp), %edi
+	.loc	1 4 16 is_stmt 0        # example.cpp:4:16
+	imull	-4(%rbp), %edi
+	.loc	1 4 5                   # example.cpp:4:5
+	movl	%edi, %eax
+	popq	%rbp
+	retq
+.Ltmp1:
+.Lfunc_end0:
+	.size	_Z6squarei, .Lfunc_end0-_Z6squarei
+	.cfi_endproc
+
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"clang version 4.0.0-1ubuntu1 (tags/RELEASE_400/rc1)" # string offset=0
+.Linfo_string1:
+	.asciz	"example.cpp" # string offset=52
+.Linfo_string2:
+	.asciz	"/home/partouf/compiler-explorer" # string offset=122
+.Linfo_string3:
+	.asciz	"_Z6squarei"            # string offset=154
+.Linfo_string4:
+	.asciz	"square"                # string offset=165
+.Linfo_string5:
+	.asciz	"int"                   # string offset=172
+.Linfo_string6:
+	.asciz	"num"                   # string offset=176
+	.section	.debug_loc,"",@progbits
+	.section	.debug_abbrev,"",@progbits
+.Lsection_abbrev:
+	.byte	1                       # Abbreviation Code
+	.byte	17                      # DW_TAG_compile_unit
+	.byte	1                       # DW_CHILDREN_yes
+	.byte	37                      # DW_AT_producer
+	.byte	14                      # DW_FORM_strp
+	.byte	19                      # DW_AT_language
+	.byte	5                       # DW_FORM_data2
+	.byte	3                       # DW_AT_name
+	.byte	14                      # DW_FORM_strp
+	.byte	16                      # DW_AT_stmt_list
+	.byte	23                      # DW_FORM_sec_offset
+	.byte	27                      # DW_AT_comp_dir
+	.byte	14                      # DW_FORM_strp
+	.byte	17                      # DW_AT_low_pc
+	.byte	1                       # DW_FORM_addr
+	.byte	18                      # DW_AT_high_pc
+	.byte	6                       # DW_FORM_data4
+	.byte	0                       # EOM(1)
+	.byte	0                       # EOM(2)
+	.byte	2                       # Abbreviation Code
+	.byte	46                      # DW_TAG_subprogram
+	.byte	1                       # DW_CHILDREN_yes
+	.byte	17                      # DW_AT_low_pc
+	.byte	1                       # DW_FORM_addr
+	.byte	18                      # DW_AT_high_pc
+	.byte	6                       # DW_FORM_data4
+	.byte	64                      # DW_AT_frame_base
+	.byte	24                      # DW_FORM_exprloc
+	.byte	110                     # DW_AT_linkage_name
+	.byte	14                      # DW_FORM_strp
+	.byte	3                       # DW_AT_name
+	.byte	14                      # DW_FORM_strp
+	.byte	58                      # DW_AT_decl_file
+	.byte	11                      # DW_FORM_data1
+	.byte	59                      # DW_AT_decl_line
+	.byte	11                      # DW_FORM_data1
+	.byte	73                      # DW_AT_type
+	.byte	19                      # DW_FORM_ref4
+	.byte	63                      # DW_AT_external
+	.byte	25                      # DW_FORM_flag_present
+	.byte	0                       # EOM(1)
+	.byte	0                       # EOM(2)
+	.byte	3                       # Abbreviation Code
+	.byte	5                       # DW_TAG_formal_parameter
+	.byte	0                       # DW_CHILDREN_no
+	.byte	2                       # DW_AT_location
+	.byte	24                      # DW_FORM_exprloc
+	.byte	3                       # DW_AT_name
+	.byte	14                      # DW_FORM_strp
+	.byte	58                      # DW_AT_decl_file
+	.byte	11                      # DW_FORM_data1
+	.byte	59                      # DW_AT_decl_line
+	.byte	11                      # DW_FORM_data1
+	.byte	73                      # DW_AT_type
+	.byte	19                      # DW_FORM_ref4
+	.byte	0                       # EOM(1)
+	.byte	0                       # EOM(2)
+	.byte	4                       # Abbreviation Code
+	.byte	36                      # DW_TAG_base_type
+	.byte	0                       # DW_CHILDREN_no
+	.byte	3                       # DW_AT_name
+	.byte	14                      # DW_FORM_strp
+	.byte	62                      # DW_AT_encoding
+	.byte	11                      # DW_FORM_data1
+	.byte	11                      # DW_AT_byte_size
+	.byte	11                      # DW_FORM_data1
+	.byte	0                       # EOM(1)
+	.byte	0                       # EOM(2)
+	.byte	0                       # EOM(3)
+	.section	.debug_info,"",@progbits
+.Lsection_info:
+.Lcu_begin0:
+	.long	90                      # Length of Unit
+	.short	4                       # DWARF version number
+	.long	.Lsection_abbrev        # Offset Into Abbrev. Section
+	.byte	8                       # Address Size (in bytes)
+	.byte	1                       # Abbrev [1] 0xb:0x53 DW_TAG_compile_unit
+	.long	.Linfo_string0          # DW_AT_producer
+	.short	4                       # DW_AT_language
+	.long	.Linfo_string1          # DW_AT_name
+	.long	.Lline_table_start0     # DW_AT_stmt_list
+	.long	.Linfo_string2          # DW_AT_comp_dir
+	.quad	.Lfunc_begin0           # DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0 # DW_AT_high_pc
+	.byte	2                       # Abbrev [2] 0x2a:0x2c DW_TAG_subprogram
+	.quad	.Lfunc_begin0           # DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0 # DW_AT_high_pc
+	.byte	1                       # DW_AT_frame_base
+	.byte	86
+	.long	.Linfo_string3          # DW_AT_linkage_name
+	.long	.Linfo_string4          # DW_AT_name
+	.byte	1                       # DW_AT_decl_file
+	.byte	2                       # DW_AT_decl_line
+	.long	86                      # DW_AT_type
+                                        # DW_AT_external
+	.byte	3                       # Abbrev [3] 0x47:0xe DW_TAG_formal_parameter
+	.byte	2                       # DW_AT_location
+	.byte	145
+	.byte	124
+	.long	.Linfo_string6          # DW_AT_name
+	.byte	1                       # DW_AT_decl_file
+	.byte	2                       # DW_AT_decl_line
+	.long	86                      # DW_AT_type
+	.byte	0                       # End Of Children Mark
+	.byte	4                       # Abbrev [4] 0x56:0x7 DW_TAG_base_type
+	.long	.Linfo_string5          # DW_AT_name
+	.byte	5                       # DW_AT_encoding
+	.byte	4                       # DW_AT_byte_size
+	.byte	0                       # End Of Children Mark
+	.section	.debug_ranges,"",@progbits
+.Ldebug_range:
+	.section	.debug_macinfo,"",@progbits
+.Ldebug_macinfo:
+.Lcu_macro_begin0:
+	.byte	0                       # End Of Macro List Mark
+	.section	.debug_pubnames,"",@progbits
+	.long	.LpubNames_end0-.LpubNames_begin0 # Length of Public Names Info
+.LpubNames_begin0:
+	.short	2                       # DWARF Version
+	.long	.Lcu_begin0             # Offset of Compilation Unit Info
+	.long	94                      # Compilation Unit Length
+	.long	42                      # DIE offset
+	.asciz	"square"                # External Name
+	.long	0                       # End Mark
+.LpubNames_end0:
+	.section	.debug_pubtypes,"",@progbits
+	.long	.LpubTypes_end0-.LpubTypes_begin0 # Length of Public Types Info
+.LpubTypes_begin0:
+	.short	2                       # DWARF Version
+	.long	.Lcu_begin0             # Offset of Compilation Unit Info
+	.long	94                      # Compilation Unit Length
+	.long	86                      # DIE offset
+	.asciz	"int"                   # External Name
+	.long	0                       # End Mark
+.LpubTypes_end0:
+
+	.ident	"clang version 4.0.0-1ubuntu1 (tags/RELEASE_400/rc1)"
+	.section	".note.GNU-stack","",@progbits
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:

--- a/test/cases/bug-577_clang.asm.directives
+++ b/test/cases/bug-577_clang.asm.directives
@@ -1,0 +1,41 @@
+_Z6squarei:                             # @_Z6squarei
+.Lfunc_begin0:
+# BB#0:
+        pushq   %rbp
+.Lcfi0:
+.Lcfi1:
+        movq    %rsp, %rbp
+.Lcfi2:
+        movl    %edi, -4(%rbp)
+.Ltmp0:
+        #APP
+label:
+        #NO_APP
+        movl    -4(%rbp), %edi
+        imull   -4(%rbp), %edi
+        movl    %edi, %eax
+        popq    %rbp
+        retq
+.Ltmp1:
+.Lfunc_end0:
+
+.Linfo_string0:
+.Linfo_string1:
+.Linfo_string2:
+.Linfo_string3:
+.Linfo_string4:
+.Linfo_string5:
+.Linfo_string6:
+.Lsection_abbrev:
+.Lsection_info:
+.Lcu_begin0:
+                                        # DW_AT_external
+.Ldebug_range:
+.Ldebug_macinfo:
+.Lcu_macro_begin0:
+.LpubNames_begin0:
+.LpubNames_end0:
+.LpubTypes_begin0:
+.LpubTypes_end0:
+
+.Lline_table_start0:

--- a/test/cases/bug-577_clang.asm.directives.labels
+++ b/test/cases/bug-577_clang.asm.directives.labels
@@ -1,0 +1,16 @@
+_Z6squarei:                             # @_Z6squarei
+# BB#0:
+        pushq   %rbp
+        movq    %rsp, %rbp
+        movl    %edi, -4(%rbp)
+        #APP
+label:
+        #NO_APP
+        movl    -4(%rbp), %edi
+        imull   -4(%rbp), %edi
+        movl    %edi, %eax
+        popq    %rbp
+        retq
+
+                                        # DW_AT_external
+

--- a/test/cases/bug-577_clang.asm.directives.labels
+++ b/test/cases/bug-577_clang.asm.directives.labels
@@ -4,7 +4,6 @@ _Z6squarei:                             # @_Z6squarei
         movq    %rsp, %rbp
         movl    %edi, -4(%rbp)
         #APP
-label:
         #NO_APP
         movl    -4(%rbp), %edi
         imull   -4(%rbp), %edi

--- a/test/cases/bug-577_gcc.asm
+++ b/test/cases/bug-577_gcc.asm
@@ -1,0 +1,170 @@
+	.file	"example.cpp"
+	.intel_syntax noprefix
+	.text
+.Ltext0:
+	.globl	_Z6squarei
+	.type	_Z6squarei, @function
+_Z6squarei:
+.LFB0:
+	.file 1 "example.cpp"
+	.loc 1 2 0
+	.cfi_startproc
+	push	rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset 6, -16
+	mov	rbp, rsp
+	.cfi_def_cfa_register 6
+	mov	DWORD PTR -4[rbp], edi
+	.loc 1 3 0
+#APP
+# 3 "example.cpp" 1
+	label:
+# 0 "" 2
+	.loc 1 4 0
+#NO_APP
+	mov	eax, DWORD PTR -4[rbp]
+	imul	eax, DWORD PTR -4[rbp]
+	.loc 1 5 0
+	pop	rbp
+	.cfi_def_cfa 7, 8
+	ret
+	.cfi_endproc
+.LFE0:
+	.size	_Z6squarei, .-_Z6squarei
+.Letext0:
+	.section	.debug_info,"",@progbits
+.Ldebug_info0:
+	.long	0x61
+	.value	0x4
+	.long	.Ldebug_abbrev0
+	.byte	0x8
+	.uleb128 0x1
+	.long	.LASF0
+	.byte	0x4
+	.long	.LASF1
+	.quad	.Ltext0
+	.quad	.Letext0-.Ltext0
+	.long	.Ldebug_line0
+	.uleb128 0x2
+	.long	.LASF2
+	.byte	0x1
+	.byte	0x2
+	.long	.LASF3
+	.long	0x5d
+	.quad	.LFB0
+	.quad	.LFE0-.LFB0
+	.uleb128 0x1
+	.byte	0x9c
+	.long	0x5d
+	.uleb128 0x3
+	.string	"num"
+	.byte	0x1
+	.byte	0x2
+	.long	0x5d
+	.uleb128 0x2
+	.byte	0x91
+	.sleb128 -20
+	.byte	0
+	.uleb128 0x4
+	.byte	0x4
+	.byte	0x5
+	.string	"int"
+	.byte	0
+	.section	.debug_abbrev,"",@progbits
+.Ldebug_abbrev0:
+	.uleb128 0x1
+	.uleb128 0x11
+	.byte	0x1
+	.uleb128 0x25
+	.uleb128 0xe
+	.uleb128 0x13
+	.uleb128 0xb
+	.uleb128 0x3
+	.uleb128 0xe
+	.uleb128 0x11
+	.uleb128 0x1
+	.uleb128 0x12
+	.uleb128 0x7
+	.uleb128 0x10
+	.uleb128 0x17
+	.byte	0
+	.byte	0
+	.uleb128 0x2
+	.uleb128 0x2e
+	.byte	0x1
+	.uleb128 0x3f
+	.uleb128 0x19
+	.uleb128 0x3
+	.uleb128 0xe
+	.uleb128 0x3a
+	.uleb128 0xb
+	.uleb128 0x3b
+	.uleb128 0xb
+	.uleb128 0x6e
+	.uleb128 0xe
+	.uleb128 0x49
+	.uleb128 0x13
+	.uleb128 0x11
+	.uleb128 0x1
+	.uleb128 0x12
+	.uleb128 0x7
+	.uleb128 0x40
+	.uleb128 0x18
+	.uleb128 0x2117
+	.uleb128 0x19
+	.uleb128 0x1
+	.uleb128 0x13
+	.byte	0
+	.byte	0
+	.uleb128 0x3
+	.uleb128 0x5
+	.byte	0
+	.uleb128 0x3
+	.uleb128 0x8
+	.uleb128 0x3a
+	.uleb128 0xb
+	.uleb128 0x3b
+	.uleb128 0xb
+	.uleb128 0x49
+	.uleb128 0x13
+	.uleb128 0x2
+	.uleb128 0x18
+	.byte	0
+	.byte	0
+	.uleb128 0x4
+	.uleb128 0x24
+	.byte	0
+	.uleb128 0xb
+	.uleb128 0xb
+	.uleb128 0x3e
+	.uleb128 0xb
+	.uleb128 0x3
+	.uleb128 0x8
+	.byte	0
+	.byte	0
+	.byte	0
+	.section	.debug_aranges,"",@progbits
+	.long	0x2c
+	.value	0x2
+	.long	.Ldebug_info0
+	.byte	0x8
+	.byte	0
+	.value	0
+	.value	0
+	.quad	.Ltext0
+	.quad	.Letext0-.Ltext0
+	.quad	0
+	.quad	0
+	.section	.debug_line,"",@progbits
+.Ldebug_line0:
+	.section	.debug_str,"MS",@progbits,1
+.LASF1:
+	.string	"example.cpp"
+.LASF3:
+	.string	"_Z6squarei"
+.LASF2:
+	.string	"square"
+.LASF0:
+	.string	"GNU C++14 6.3.0 20170406 -masm=intel -mtune=generic -march=x86-64 -g -fstack-protector-strong"
+	.ident	"GCC: (Ubuntu 6.3.0-12ubuntu2) 6.3.0 20170406"
+	.section	.note.GNU-stack,"",@progbits

--- a/test/cases/bug-577_gcc.asm.directives
+++ b/test/cases/bug-577_gcc.asm.directives
@@ -1,12 +1,24 @@
+.Ltext0:
 _Z6squarei:
+.LFB0:
         push    rbp
         mov     rbp, rsp
         mov     DWORD PTR -4[rbp], edi
 #APP
 # 3 "example.cpp" 1
+label:
 # 0 "" 2
 #NO_APP
         mov     eax, DWORD PTR -4[rbp]
         imul    eax, DWORD PTR -4[rbp]
         pop     rbp
         ret
+.LFE0:
+.Letext0:
+.Ldebug_info0:
+.Ldebug_abbrev0:
+.Ldebug_line0:
+.LASF1:
+.LASF3:
+.LASF2:
+.LASF0:

--- a/test/cases/bug-577_gcc.asm.directives.labels
+++ b/test/cases/bug-577_gcc.asm.directives.labels
@@ -1,0 +1,13 @@
+_Z6squarei:
+        push    rbp
+        mov     rbp, rsp
+        mov     DWORD PTR -4[rbp], edi
+#APP
+# 3 "example.cpp" 1
+        label:
+# 0 "" 2
+#NO_APP
+        mov     eax, DWORD PTR -4[rbp]
+        imul    eax, DWORD PTR -4[rbp]
+        pop     rbp
+        ret

--- a/test/cases/bug-577_gcc.asm.directives.labels
+++ b/test/cases/bug-577_gcc.asm.directives.labels
@@ -4,7 +4,7 @@ _Z6squarei:
         mov     DWORD PTR -4[rbp], edi
 #APP
 # 3 "example.cpp" 1
-        label:
+label:
 # 0 "" 2
 #NO_APP
         mov     eax, DWORD PTR -4[rbp]

--- a/test/cases/bug-577_icc.asm
+++ b/test/cases/bug-577_icc.asm
@@ -1,0 +1,314 @@
+        .section .text
+.LNDBG_TX:
+# mark_description "Intel(R) C Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 18.0.0.128 Build 20170811";
+# mark_description "-g -o /tmp/compiler-explorer-compiler1171120-54-1t2ppc6.m4k6/output.s -masm=intel -S -gxx-name=/opt/compiler";
+# mark_description "-explorer/gcc-6.3.0/bin/g++";
+        .intel_syntax noprefix
+        .file "example.cpp"
+        .text
+..TXTST0:
+.L_2__routine_start__Z6squarei_0:
+# -- Begin  _Z6squarei
+        .text
+# mark_begin;
+
+        .globl _Z6squarei
+# --- square(int)
+_Z6squarei:
+# parameter 1(num): edi
+..B1.1:                         # Preds ..B1.0
+                                # Execution count [0.00e+00]
+        .cfi_startproc
+        .cfi_personality 0x3,__gxx_personality_v0
+..___tag_value__Z6squarei.2:
+..L3:
+                                                          #2.21
+..LN0:
+        .file   1 "/tmp/compiler-explorer-compiler1171120-54-1t2ppc6.m4k6/example.cpp"
+        .loc    1  2  is_stmt 1
+        push      rbp                                           #2.21
+        .cfi_def_cfa_offset 16
+..LN1:
+        mov       rbp, rsp                                      #2.21
+        .cfi_def_cfa 6, 16
+        .cfi_offset 6, -16
+..LN2:
+        sub       rsp, 16                                       #2.21
+..LN3:
+        mov       DWORD PTR [-16+rbp], edi                      #2.21
+..LN4:
+                                # LOE rbx rbp rsp r12 r13 r14 r15 rip
+..B1.5:                         # Preds ..B1.1
+                                # Execution count [0.00e+00]
+# Begin ASM
+..LN5:
+        .loc    1  3  prologue_end  is_stmt 1
+# Begin ASM
+        label:
+# End ASM                                                       #3.0
+..LN6:
+# End ASM
+                                # LOE rbx rbp rsp r12 r13 r14 r15 rip
+..B1.4:                         # Preds ..B1.5
+                                # Execution count [0.00e+00]
+..LN7:
+        .loc    1  4  is_stmt 1
+        mov       eax, DWORD PTR [-16+rbp]                      #4.18
+..LN8:
+        imul      eax, DWORD PTR [-16+rbp]                      #4.18
+..LN9:
+        .loc    1  4  epilogue_begin  is_stmt 1
+        leave                                                   #4.18
+        .cfi_restore 6
+..LN10:
+        ret                                                     #4.18
+..LN11:
+                                # LOE
+..LN12:
+        .cfi_endproc
+# mark_end;
+        .type   _Z6squarei,@function
+        .size   _Z6squarei,.-_Z6squarei
+..LN_Z6squarei.13:
+.LN_Z6squarei:
+        .data
+# -- End  _Z6squarei
+        .data
+        .section .note.GNU-stack, ""
+// -- Begin DWARF2 SEGMENT .debug_info
+        .section .debug_info
+.debug_info_seg:
+        .align 1
+        .4byte 0x00000074
+        .2byte 0x0004
+        .4byte .debug_abbrev_seg
+        .byte 0x08
+//      DW_TAG_compile_unit:
+        .byte 0x01
+//      DW_AT_comp_dir:
+        .4byte .debug_str
+//      DW_AT_name:
+        .4byte .debug_str+0x13
+//      DW_AT_producer:
+        .4byte .debug_str+0x56
+        .4byte .debug_str+0xc2
+//      DW_AT_language:
+        .byte 0x04
+//      DW_AT_use_UTF8:
+        .byte 0x01
+//      DW_AT_low_pc:
+        .8byte ..LN0
+//      DW_AT_high_pc:
+        .8byte ..LN_Z6squarei.13-..LN0
+//      DW_AT_stmt_list:
+        .4byte .debug_line_seg
+//      DW_TAG_namespace:
+        .byte 0x02
+//      DW_AT_name:
+        .4byte 0x00647473
+//      DW_TAG_namespace:
+        .byte 0x03
+//      DW_AT_name:
+        .4byte .debug_str+0x14a
+//      DW_TAG_namespace:
+        .byte 0x03
+//      DW_AT_name:
+        .4byte .debug_str+0x154
+//      DW_TAG_base_type:
+        .byte 0x04
+//      DW_AT_byte_size:
+        .byte 0x04
+//      DW_AT_encoding:
+        .byte 0x05
+//      DW_AT_name:
+        .4byte 0x00746e69
+//      DW_TAG_subprogram:
+        .byte 0x05
+//      DW_AT_decl_line:
+        .byte 0x02
+//      DW_AT_decl_file:
+        .byte 0x01
+//      DW_AT_type:
+        .4byte 0x00000041
+//      DW_AT_name:
+        .4byte .debug_str+0x15f
+        .4byte .debug_str+0x166
+//      DW_AT_low_pc:
+        .8byte ..L3
+//      DW_AT_high_pc:
+        .8byte ..LN_Z6squarei.13-..L3
+//      DW_AT_external:
+        .byte 0x01
+//      DW_TAG_formal_parameter:
+        .byte 0x06
+//      DW_AT_decl_line:
+        .byte 0x02
+//      DW_AT_decl_file:
+        .byte 0x01
+//      DW_AT_type:
+        .4byte 0x00000041
+//      DW_AT_name:
+        .4byte 0x006d756e
+//      DW_AT_location:
+        .2byte 0x7602
+        .byte 0x70
+        .byte 0x00
+        .byte 0x00
+// -- Begin DWARF2 SEGMENT .debug_line
+        .section .debug_line
+.debug_line_seg:
+        .align 1
+// -- Begin DWARF2 SEGMENT .debug_abbrev
+        .section .debug_abbrev
+.debug_abbrev_seg:
+        .align 1
+        .byte 0x01
+        .byte 0x11
+        .byte 0x01
+        .byte 0x1b
+        .byte 0x0e
+        .byte 0x03
+        .byte 0x0e
+        .byte 0x25
+        .byte 0x0e
+        .2byte 0x7681
+        .byte 0x0e
+        .byte 0x13
+        .byte 0x0b
+        .byte 0x53
+        .byte 0x0c
+        .byte 0x11
+        .byte 0x01
+        .byte 0x12
+        .byte 0x07
+        .byte 0x10
+        .byte 0x17
+        .2byte 0x0000
+        .byte 0x02
+        .byte 0x39
+        .byte 0x00
+        .byte 0x03
+        .byte 0x08
+        .2byte 0x0000
+        .byte 0x03
+        .byte 0x39
+        .byte 0x00
+        .byte 0x03
+        .byte 0x0e
+        .2byte 0x0000
+        .byte 0x04
+        .byte 0x24
+        .byte 0x00
+        .byte 0x0b
+        .byte 0x0b
+        .byte 0x3e
+        .byte 0x0b
+        .byte 0x03
+        .byte 0x08
+        .2byte 0x0000
+        .byte 0x05
+        .byte 0x2e
+        .byte 0x01
+        .byte 0x3b
+        .byte 0x0b
+        .byte 0x3a
+        .byte 0x0b
+        .byte 0x49
+        .byte 0x13
+        .byte 0x03
+        .byte 0x0e
+        .2byte 0x4087
+        .byte 0x0e
+        .byte 0x11
+        .byte 0x01
+        .byte 0x12
+        .byte 0x07
+        .byte 0x3f
+        .byte 0x0c
+        .2byte 0x0000
+        .byte 0x06
+        .byte 0x05
+        .byte 0x00
+        .byte 0x3b
+        .byte 0x0b
+        .byte 0x3a
+        .byte 0x0b
+        .byte 0x49
+        .byte 0x13
+        .byte 0x03
+        .byte 0x08
+        .byte 0x02
+        .byte 0x18
+        .2byte 0x0000
+        .byte 0x00
+// -- Begin DWARF2 SEGMENT .debug_frame
+        .section .debug_frame
+.debug_frame_seg:
+        .align 1
+// -- Begin DWARF2 SEGMENT .debug_str
+        .section .debug_str,"MS",@progbits,1
+.debug_str_seg:
+        .align 1
+        .8byte 0x656c69706d6f632f
+        .8byte 0x726f6c7078652d72
+        .2byte 0x7265
+        .byte 0x00
+        .8byte 0x6d6f632f706d742f
+        .8byte 0x78652d72656c6970
+        .8byte 0x632d7265726f6c70
+        .8byte 0x3172656c69706d6f
+        .8byte 0x352d303231313731
+        .8byte 0x6370703274312d34
+        .8byte 0x652f366b346d2e36
+        .8byte 0x632e656c706d6178
+        .2byte 0x7070
+        .byte 0x00
+        .8byte 0x2952286c65746e49
+        .8byte 0x6c65746e49204320
+        .8byte 0x4320343620295228
+        .8byte 0x2072656c69706d6f
+        .8byte 0x6c70706120726f66
+        .8byte 0x736e6f6974616369
+        .8byte 0x676e696e6e757220
+        .8byte 0x65746e49206e6f20
+        .8byte 0x2c3436202952286c
+        .8byte 0x6e6f697372655620
+        .8byte 0x2e302e302e383120
+        .8byte 0x6c69754220383231
+        .8byte 0x3830373130322064
+        .4byte 0x000a3131
+        .8byte 0x742f206f2d20672d
+        .8byte 0x69706d6f632f706d
+        .8byte 0x6c7078652d72656c
+        .8byte 0x6d6f632d7265726f
+        .8byte 0x37313172656c6970
+        .8byte 0x2d34352d30323131
+        .8byte 0x2e36637070327431
+        .8byte 0x74756f2f366b346d
+        .8byte 0x6d2d20732e747570
+        .8byte 0x65746e693d6d7361
+        .8byte 0x78672d20532d206c
+        .8byte 0x2f3d656d616e2d78
+        .8byte 0x706d6f632f74706f
+        .8byte 0x7078652d72656c69
+        .8byte 0x63672f7265726f6c
+        .8byte 0x2f302e332e362d63
+        .8byte 0x002b2b672f6e6962
+        .8byte 0x78635f756e675f5f
+        .2byte 0x0078
+        .8byte 0x6962617878635f5f
+        .2byte 0x3176
+        .byte 0x00
+        .4byte 0x61757173
+        .2byte 0x6572
+        .byte 0x00
+        .8byte 0x7261757173365a5f
+        .2byte 0x6965
+        .byte 0x00
+// -- Begin DWARF2 SEGMENT .eh_frame
+        .section .eh_frame,"a",@progbits
+.eh_frame_seg:
+        .align 8
+        .section .text
+.LNDBG_TXe:
+# End

--- a/test/cases/bug-577_icc.asm.directives
+++ b/test/cases/bug-577_icc.asm.directives
@@ -1,0 +1,101 @@
+.LNDBG_TX:
+# mark_description "Intel(R) C Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 18.0.0.128 Build 20170811";
+# mark_description "-g -o /tmp/compiler-explorer-compiler1171120-54-1t2ppc6.m4k6/output.s -masm=intel -S -gxx-name=/opt/compiler";
+# mark_description "-explorer/gcc-6.3.0/bin/g++";
+..TXTST0:
+.L_2__routine_start__Z6squarei_0:
+# -- Begin  _Z6squarei
+# mark_begin;
+
+# --- square(int)
+_Z6squarei:
+# parameter 1(num): edi
+..B1.1:                         # Preds ..B1.0
+                                # Execution count [0.00e+00]
+..___tag_value__Z6squarei.2:
+..L3:
+                                                          #2.21
+..LN0:
+        push      rbp                                           #2.21
+..LN1:
+        mov       rbp, rsp                                      #2.21
+..LN2:
+        sub       rsp, 16                                       #2.21
+..LN3:
+        mov       DWORD PTR [-16+rbp], edi                      #2.21
+..LN4:
+                                # LOE rbx rbp rsp r12 r13 r14 r15 rip
+..B1.5:                         # Preds ..B1.1
+                                # Execution count [0.00e+00]
+# Begin ASM
+..LN5:
+# Begin ASM
+label:
+# End ASM                                                       #3.0
+..LN6:
+# End ASM
+                                # LOE rbx rbp rsp r12 r13 r14 r15 rip
+..B1.4:                         # Preds ..B1.5
+                                # Execution count [0.00e+00]
+..LN7:
+        mov       eax, DWORD PTR [-16+rbp]                      #4.18
+..LN8:
+        imul      eax, DWORD PTR [-16+rbp]                      #4.18
+..LN9:
+        leave                                                   #4.18
+..LN10:
+        ret                                                     #4.18
+..LN11:
+                                # LOE
+..LN12:
+# mark_end;
+..LN_Z6squarei.13:
+.LN_Z6squarei:
+# -- End  _Z6squarei
+// -- Begin DWARF2 SEGMENT .debug_info
+.debug_info_seg:
+//      DW_TAG_compile_unit:
+//      DW_AT_comp_dir:
+//      DW_AT_name:
+//      DW_AT_producer:
+//      DW_AT_language:
+//      DW_AT_use_UTF8:
+//      DW_AT_low_pc:
+//      DW_AT_high_pc:
+//      DW_AT_stmt_list:
+//      DW_TAG_namespace:
+//      DW_AT_name:
+//      DW_TAG_namespace:
+//      DW_AT_name:
+//      DW_TAG_namespace:
+//      DW_AT_name:
+//      DW_TAG_base_type:
+//      DW_AT_byte_size:
+//      DW_AT_encoding:
+//      DW_AT_name:
+//      DW_TAG_subprogram:
+//      DW_AT_decl_line:
+//      DW_AT_decl_file:
+//      DW_AT_type:
+//      DW_AT_name:
+//      DW_AT_low_pc:
+//      DW_AT_high_pc:
+//      DW_AT_external:
+//      DW_TAG_formal_parameter:
+//      DW_AT_decl_line:
+//      DW_AT_decl_file:
+//      DW_AT_type:
+//      DW_AT_name:
+//      DW_AT_location:
+// -- Begin DWARF2 SEGMENT .debug_line
+.debug_line_seg:
+// -- Begin DWARF2 SEGMENT .debug_abbrev
+.debug_abbrev_seg:
+// -- Begin DWARF2 SEGMENT .debug_frame
+.debug_frame_seg:
+// -- Begin DWARF2 SEGMENT .debug_str
+.debug_str_seg:
+// -- Begin DWARF2 SEGMENT .eh_frame
+.eh_frame_seg:
+.LNDBG_TXe:
+# End

--- a/test/cases/bug-577_icc.asm.directives.labels
+++ b/test/cases/bug-577_icc.asm.directives.labels
@@ -1,0 +1,70 @@
+# mark_description "Intel(R) C Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 18.0.0.128 Build 20170811";
+# mark_description "-g -o /tmp/compiler-explorer-compiler1171120-54-1t2ppc6.m4k6/output.s -masm=intel -S -gxx-name=/opt/compiler";
+# mark_description "-explorer/gcc-6.3.0/bin/g++";
+# -- Begin  _Z6squarei
+# mark_begin;
+
+# --- square(int)
+_Z6squarei:
+# parameter 1(num): edi
+                                # Execution count [0.00e+00]
+                                                          #2.21
+        push      rbp                                           #2.21
+        mov       rbp, rsp                                      #2.21
+        sub       rsp, 16                                       #2.21
+        mov       DWORD PTR [-16+rbp], edi                      #2.21
+                                # LOE rbx rbp rsp r12 r13 r14 r15 rip
+                                # Execution count [0.00e+00]
+# Begin ASM
+# Begin ASM
+# End ASM                                                       #3.0
+# End ASM
+                                # LOE rbx rbp rsp r12 r13 r14 r15 rip
+                                # Execution count [0.00e+00]
+        mov       eax, DWORD PTR [-16+rbp]                      #4.18
+        imul      eax, DWORD PTR [-16+rbp]                      #4.18
+        leave                                                   #4.18
+        ret                                                     #4.18
+                                # LOE
+# mark_end;
+# -- End  _Z6squarei
+// -- Begin DWARF2 SEGMENT .debug_info
+//      DW_TAG_compile_unit:
+//      DW_AT_comp_dir:
+//      DW_AT_name:
+//      DW_AT_producer:
+//      DW_AT_language:
+//      DW_AT_use_UTF8:
+//      DW_AT_low_pc:
+//      DW_AT_high_pc:
+//      DW_AT_stmt_list:
+//      DW_TAG_namespace:
+//      DW_AT_name:
+//      DW_TAG_namespace:
+//      DW_AT_name:
+//      DW_TAG_namespace:
+//      DW_AT_name:
+//      DW_TAG_base_type:
+//      DW_AT_byte_size:
+//      DW_AT_encoding:
+//      DW_AT_name:
+//      DW_TAG_subprogram:
+//      DW_AT_decl_line:
+//      DW_AT_decl_file:
+//      DW_AT_type:
+//      DW_AT_name:
+//      DW_AT_low_pc:
+//      DW_AT_high_pc:
+//      DW_AT_external:
+//      DW_TAG_formal_parameter:
+//      DW_AT_decl_line:
+//      DW_AT_decl_file:
+//      DW_AT_type:
+//      DW_AT_name:
+//      DW_AT_location:
+// -- Begin DWARF2 SEGMENT .debug_line
+// -- Begin DWARF2 SEGMENT .debug_abbrev
+// -- Begin DWARF2 SEGMENT .debug_frame
+// -- Begin DWARF2 SEGMENT .debug_str
+// -- Begin DWARF2 SEGMENT .eh_frame
+# End


### PR DESCRIPTION
Fixes label indentation and recognition for GCC and ICC. This will enable tracking and correctly handle hiding showing unused labels that were defined in inline assembly.

Included Clang output testcase for reference from example in #577 

Current situation where labels are shown incorrectly in GCC and ICC: https://godbolt.org/g/v5uvQL
