### PR TITLE
Pascal: Always use output.pas as filename, otherwise things will break.

### DIFF
--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -32,6 +32,7 @@ var Compile = require('../base-compiler'),
 function compileFPC(info, env) {
     var demangler = new PascalDemangler();
     var compiler = new Compile(info, env);
+    compiler.compileFilename = "output.pas";
     compiler.supportsOptOutput = false;
 
     var originalExecBinary = compiler.execBinary;
@@ -63,10 +64,16 @@ function compileFPC(info, env) {
         return options;
     };
 
+    compiler.getOutputFilename = function (dirPath, outputFilebase) {
+        return path.join(dirPath, path.basename(this.compileFilename, this.langInfo.extensions[0]) + ".s");
+    };
+
     var saveDummyProjectFile = function (filename) {
+        const unitName = path.basename(compiler.compileFilename, compiler.langInfo.extensions[0]);
+
         fs.writeFileSync(filename,
             "program prog; " +
-            "uses output in 'output.pas'; " +
+            "uses " + unitName + " in '" + compiler.compileFilename + "'; " +
             "begin " +
             "end.", function() {});
     };
@@ -100,7 +107,7 @@ function compileFPC(info, env) {
 
             if (!isNaN(valueInBrackets)) {
                 return "  .loc 1 " + valueInBrackets + " 0";
-            } else if (valueInBrackets.includes("output.pas")) {
+            } else if (valueInBrackets.includes(compiler.compileFilename)) {
                 return "  .file 1 \"<stdin>\"";
             } else {
                 return false;
@@ -181,7 +188,11 @@ function compileFPC(info, env) {
         originalExecBinary(executable, result, maxSize);
     };
 
-    return compiler.initialise();
+    if (info.unitTestMode) {
+        compiler.initialise();
+        return compiler;
+    } else
+        return compiler.initialise();
 }
 
 module.exports = compileFPC;

--- a/test/pascal-tests.js
+++ b/test/pascal-tests.js
@@ -24,7 +24,31 @@
 
 var should = require('chai').should();
 var PascalDemangler = require('../lib/pascal-support').demangler;
+var PascalCompiler = require('../lib/compilers/pascal');
+var logger = require('../lib/logger').logger;
 
+var CompilationEnvironment = require('../lib/compilation-env').CompilationEnvironment;
+
+var props = function (key, deflt) {
+    return deflt;
+};
+
+describe('Basic compiler setup', function () {
+    var ce = new CompilationEnvironment(props);
+    var info = {
+        "exe": null,
+        "remote": true,
+        "unitTestMode": true
+    };
+
+    ce.compilerPropsL = function (lang, property, defaultValue) {
+        return "";
+    };
+
+    var compiler = new PascalCompiler(info, ce, "pascal");
+
+    compiler.getOutputFilename("/tmp/", "output.pas").should.equal("/tmp/output.s");
+});
 
 describe('Pascal signature composer function', function () {
     var demangler = new PascalDemangler();

--- a/test/pascal-tests.js
+++ b/test/pascal-tests.js
@@ -34,18 +34,19 @@ var props = function (key, deflt) {
 };
 
 describe('Basic compiler setup', function () {
-    var ce = new CompilationEnvironment(props);
-    var info = {
+    const ce = new CompilationEnvironment(props);
+    const info = {
         "exe": null,
         "remote": true,
-        "unitTestMode": true
+        "unitTestMode": true,
+        "lang": "pascal"
     };
 
     ce.compilerPropsL = function (lang, property, defaultValue) {
         return "";
     };
 
-    var compiler = new PascalCompiler(info, ce, "pascal");
+    const compiler = new PascalCompiler(info, ce, info.lang);
 
     compiler.getOutputFilename("/tmp/", "output.pas").should.equal("/tmp/output.s");
 });


### PR DESCRIPTION
Tried to make it flexible but ran into trouble in pascal-support.js so I just force compileFilename back to being output.pas