### PR TITLE
explicitly specify editor's font to be monospace

### DIFF
--- a/static/compiler.js
+++ b/static/compiler.js
@@ -158,7 +158,7 @@ define(function (require) {
             scrollBeyondLastLine: false,
             readOnly: true,
             language: 'asm',
-            fontFamily: 'Fira Mono',
+            fontFamily: 'Fira Mono, monospace',
             glyphMargin: !options.embedded,
             fixedOverflowWidgets: true,
             minimap: {

--- a/static/diff.js
+++ b/static/diff.js
@@ -58,7 +58,7 @@ define(function (require) {
         this.compilers = {};
 
         this.outputEditor = monaco.editor.createDiffEditor(this.domRoot.find(".monaco-placeholder")[0], {
-            fontFamily: 'Fira Mono',
+            fontFamily: 'Fira Mono, monospace',
             scrollBeyondLastLine: false,
             readOnly: true,
             language: 'asm'

--- a/static/editor.js
+++ b/static/editor.js
@@ -86,7 +86,7 @@ define(function (require) {
         this.editor = monaco.editor.create(root[0], {
             scrollBeyondLastLine: false,
             language: this.currentLanguage.monaco,
-            fontFamily: 'Fira Mono',
+            fontFamily: 'Fira Mono, monospace',
             readOnly: !!options.readOnly || legacyReadOnly,
             glyphMargin: !options.embedded,
             quickSuggestions: false,


### PR DESCRIPTION
Currently the font of the editor is set to a specific monospace font without explicitly being marked as `monospace`. In the case where user use their own font settings to show the webpage based on whether a fontFamily is monospace or not, not explictly marking the fontFamily to be monospace would result in the content being rendered by a non-monospace font in user's settings. This patch is intended to fix this problem.