### PR TITLE
Don't attempt to use the default language from the client's local storage if it no longer exists

### DIFF
--- a/static/editor.js
+++ b/static/editor.js
@@ -8,9 +8,9 @@
 //     * Redistributions of source code must retain the above copyright notice,
 //       this list of conditions and the following disclaimer.
 //     * Redistributions in binary form must reproduce the above copyright
-//       notice, this list of conditions and the following disclaimer in the 
+//       notice, this list of conditions and the following disclaimer in the
 //       documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -76,7 +76,10 @@ define(function (require) {
         if (langKeys.length <= 1) {
             this.languageBtn.prop("disabled", true);
         }
-        this.currentLanguage = languages[this.settings.defaultLanguage || langKeys[0]];
+        this.currentLanguage = languages[langKeys[0]];
+        if (this.settings.defaultLanguage && languages[this.settings.defaultLanguage]) {
+            this.currentLanguage = languages[this.settings.defaultLanguage];
+        }
         if (state.lang && languages[state.lang]) {
             this.currentLanguage = languages[state.lang];
         } else if (this.settings.newEditorLastLang && hub.lastOpenedLangId && languages[hub.lastOpenedLangId]) {


### PR DESCRIPTION
To reproduce: 
Run as a single language eg `make EXTRA_ARGS="--language=pascal"`
Open CE in a browser
Stop CE and run it with a different language eg `make EXTRA_ARGS="--language=c++"`
Reload CE in the browser and it attempt to read the now missing pascal language info to create the editor.