### PR TITLE
Fix for supportsBinary

### DIFF
--- a/static/compiler.js
+++ b/static/compiler.js
@@ -156,7 +156,7 @@ define(function (require) {
             .on('keyup', optionsChange);
 
         // Hide the binary option if the global options has it disabled.
-        this.domRoot.find('[data-bind=\'binary\']').toggle(options.supportsBinary);
+        this.domRoot.find('[data-bind=\'binary\']').toggle(options.supportsBinary[this.currentLangId]);
         this.domRoot.find('[data-bind=\'execute\']').toggle(options.supportsExecute);
 
         this.outputEditor = monaco.editor.create(this.domRoot.find('.monaco-placeholder')[0], {


### PR DESCRIPTION
supportsBinary on the clientside is an object with the languages, not a boolean like supportsExecute