### PR TITLE
Make API match the documentation

### DIFF
--- a/app.js
+++ b/app.js
@@ -541,6 +541,7 @@ Promise.all([findCompilers(), aws.initConfig(awsProps)])
             prevCompilers = compilers;
             clientOptionsHandler.setCompilers(compilers);
             apiHandler.setCompilers(compilers);
+            apiHandler.setLanguages(languages);
         }
 
         onCompilerChange(compilers);

--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -30,33 +30,68 @@ const express = require('express'),
 class ApiHandler {
     constructor(compileHandler) {
         this.compilers = [];
+        this.languages = [];
         this.handle = express.Router();
         this.handle.use((req, res, next) => {
             res.header("Access-Control-Allow-Origin", "*");
             res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
             next();
         });
-        this.handle.get('/compilers', (req, res) => {
-            if (req.accepts(['text', 'json']) === 'json') {
-                res.set('Content-Type', 'application/json');
-                res.end(JSON.stringify(this.compilers));
-            } else {
-                res.set('Content-Type', 'text/plain');
-                const title = 'Compiler Name';
-                const maxLength = _.max(_.pluck(_.pluck(this.compilers, 'id').concat([title]), 'length'));
-                res.write(utils.padRight(title, maxLength) + ' | Description\n');
-                res.end(
-                    this.compilers.map(compiler => utils.padRight(compiler.id, maxLength) + ' | ' + compiler.name)
-                        .join("\n"));
-            }
-        });
+        this.handle.get('/compilers', this.handleCompilers.bind(this));
+        this.handle.get('/compilers/:language', this.handleCompilers.bind(this));
+        this.handle.get('/languages', this.handleLanguages.bind(this));
         const asmDocsHandler = new AsmDocsApi.Handler();
         this.handle.get('/asm/:opcode', asmDocsHandler.handle.bind(asmDocsHandler));
         this.handle.post('/compiler/:compiler/compile', compileHandler.handle.bind(compileHandler));
     }
 
+    handleLanguages(req, res) {
+        const availableLanguageIds = _.uniq(_.pluck(this.compilers, 'lang'));
+        const availableLanguages = availableLanguageIds.map(function(val) {
+            return this.languages[val];
+        }.bind(this));
+
+        if (req.accepts(['text', 'json']) === 'json') {
+            res.set('Content-Type', 'application/json');
+            res.end(JSON.stringify(availableLanguages));
+        } else {
+            res.set('Content-Type', 'text/plain');
+            const title = 'Id';
+            const maxLength = _.max(_.pluck(_.pluck(availableLanguages, 'id').concat([title]), 'length'));
+            res.write(utils.padRight(title, maxLength) + ' | Name\n');
+            res.end(availableLanguages.map(lang => utils.padRight(lang.id, maxLength) + ' | ' + lang.name)
+                .join("\n"));
+        }
+    }
+
+    handleCompilers(req, res) {
+        let filteredCompilers = this.compilers;
+        if (req.params.language) {
+            filteredCompilers = this.compilers.filter((val) => {
+                return val.lang === req.params.language;
+            });
+        }
+
+        if (req.accepts(['text', 'json']) === 'json') {
+            res.set('Content-Type', 'application/json');
+            res.end(JSON.stringify(filteredCompilers));
+        } else {
+            res.set('Content-Type', 'text/plain');
+            const title = 'Compiler Name';
+            const maxLength = _.max(_.pluck(_.pluck(filteredCompilers, 'id').concat([title]), 'length'));
+            res.write(utils.padRight(title, maxLength) + ' | Description\n');
+            res.end(
+                filteredCompilers.map(compiler => utils.padRight(compiler.id, maxLength) + ' | ' + compiler.name)
+                    .join("\n"));
+        }
+    }
+
     setCompilers(compilers) {
         this.compilers = compilers;
+    }
+
+    setLanguages(languages) {
+        this.languages = languages;
     }
 }
 

--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -47,9 +47,7 @@ class ApiHandler {
 
     handleLanguages(req, res) {
         const availableLanguageIds = _.uniq(_.pluck(this.compilers, 'lang'));
-        const availableLanguages = availableLanguageIds.map(function(val) {
-            return this.languages[val];
-        }.bind(this));
+        const availableLanguages = availableLanguageIds.map(val => this.languages[val]);
 
         if (req.accepts(['text', 'json']) === 'json') {
             res.set('Content-Type', 'application/json');
@@ -67,9 +65,7 @@ class ApiHandler {
     handleCompilers(req, res) {
         let filteredCompilers = this.compilers;
         if (req.params.language) {
-            filteredCompilers = this.compilers.filter((val) => {
-                return val.lang === req.params.language;
-            });
+            filteredCompilers = this.compilers.filter((val) => val.lang === req.params.language);
         }
 
         if (req.accepts(['text', 'json']) === 'json') {

--- a/test/handlers/api-tests.js
+++ b/test/handlers/api-tests.js
@@ -26,6 +26,27 @@ const chai = require('chai'),
     ApiHandler = require('../../lib/handlers/api').Handler,
     express = require('express');
 
+const languages = {
+    'c++': {
+        id: 'c++',
+        name: 'C++',
+        monaco: 'cppp',
+        extensions: ['.cpp', '.cxx', '.h', '.hpp', '.hxx', '.c']
+    },
+    haskell: {
+        id: 'haskell',
+        name: 'Haskell',
+        monaco: 'haskell',
+        extensions: ['.hs', '.haskell']
+    },
+    pascal: {
+        id: 'pascal',
+        name: 'Pascal',
+        monaco: 'pascal',
+        extensions: ['.pas']
+    }
+};
+
 chai.use(require("chai-http"));
 chai.should();
 
@@ -37,10 +58,23 @@ describe('API handling', () => {
         }
     });
     app.use('/api', apiHandler.handle);
-    apiHandler.setCompilers([{
+    const compilers = [{
         id: "gcc900",
-        name: "GCC 9.0.0"
-    }]);
+        name: "GCC 9.0.0",
+        lang: "c++"
+    },
+    {
+        id: "fpc302",
+        name: "FPC 3.0.2",
+        lang: "pascal"
+    },
+    {
+        id: "clangtrunk",
+        name: "Clang trunk",
+        lang: "c++"
+    }];
+    apiHandler.setCompilers(compilers);
+    apiHandler.setLanguages(languages);
 
     it('should respond to plain text compiler requests', () => {
         return chai.request(app)
@@ -63,10 +97,7 @@ describe('API handling', () => {
             .then(res => {
                 res.should.have.status(200);
                 res.should.be.json;
-                res.body.should.deep.equals([{
-                    id: "gcc900",
-                    name: "GCC 9.0.0"
-                }]);
+                res.body.should.deep.equals(compilers);
             })
             .catch(function (err) {
                 throw err;
@@ -85,5 +116,46 @@ describe('API handling', () => {
                 throw err;
             });
     });
-    // TODO: more tests!
+
+    it('should respond to JSON compilers requests with c++ filter', () => {
+        return chai.request(app)
+            .get('/api/compilers/c++')
+            .set('Accept', 'application/json')
+            .then(res => {
+                res.should.have.status(200);
+                res.should.be.json;
+                res.body.should.deep.equals([compilers[0], compilers[2]]);
+            })
+            .catch(function (err) {
+                throw err;
+            });
+    });
+ 
+    it('should respond to JSON compilers requests with pascal filter', () => {
+        return chai.request(app)
+            .get('/api/compilers/pascal')
+            .set('Accept', 'application/json')
+            .then(res => {
+                res.should.have.status(200);
+                res.should.be.json;
+                res.body.should.deep.equals([compilers[1]]);
+            })
+            .catch(function (err) {
+                throw err;
+            });
+    });
+ 
+    it('should respond to JSON languages requests', () => {
+        return chai.request(app)
+            .get('/api/languages')
+            .set('Accept', 'application/json')
+            .then(res => {
+                res.should.have.status(200);
+                res.should.be.json;
+                res.body.should.deep.equals([languages['c++'], languages.pascal]);
+            })
+            .catch(function (err) {
+                throw err;
+            });
+    });
 });


### PR DESCRIPTION
I noticed the described API functions in the Readme didn't actually exist, so this adds /api/languages and /api/compilers/:language

But you could also delete them from the Readme