### PR TITLE
Hide execute button when execute is disabled on all compilers

### DIFF
--- a/app.js
+++ b/app.js
@@ -219,9 +219,9 @@ function ClientOptionsHandler(fileSources) {
         return {name: source.name, urlpart: source.urlpart};
     }), "name");
 
-    var supportsBinary = compilerPropsAT(languages, res => !!res, "supportsBinary", true);
-    var supportsExecutePerLanguage = compilerPropsAT(languages, (res, lang) => supportsBinary[lang.id] && !!res, "supportsExecute", true);
-    var supportsExecute = Object.values(supportsExecutePerLanguage).some((value) => value);
+    const supportsBinary = compilerPropsAT(languages, res => !!res, "supportsBinary", true);
+    const supportsExecutePerLanguage = compilerPropsAT(languages, (res, lang) => supportsBinary[lang.id] && !!res, "supportsExecute", true);
+    const supportsExecute = Object.values(supportsExecutePerLanguage).some((value) => value);
     var libs = {};
 
     var baseLibs = compilerPropsA(languages, "libs");

--- a/app.js
+++ b/app.js
@@ -220,7 +220,8 @@ function ClientOptionsHandler(fileSources) {
     }), "name");
 
     var supportsBinary = compilerPropsAT(languages, res => !!res, "supportsBinary", true);
-    var supportsExecute = supportsBinary && !!compilerPropsAT(languages, (res, lang) => supportsBinary[lang.id] && !!res, "supportsExecute", true);
+    var supportsExecutePerLanguage = compilerPropsAT(languages, (res, lang) => supportsBinary[lang.id] && !!res, "supportsExecute", true);
+    var supportsExecute = Object.values(supportsExecutePerLanguage).some((value) => value);
     var libs = {};
 
     var baseLibs = compilerPropsA(languages, "libs");


### PR DESCRIPTION
The !! returned true even if all the properties were false

Fixes #722