### PR TITLE
[WIP] Add Embarcadero C++ compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&clang:&cl:&cross:&ellcc:&zapcc
+compilers=&gcc86:&icc:&clang:&cl:&cross:&ellcc:&zapcc:&bcc
 defaultCompiler=g72
 demangler=/opt/compiler-explorer/gcc-7.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-7.2.0/bin/objdump
@@ -223,6 +223,18 @@ compiler.cl19_32.exe=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/a
 compiler.cl19_32.name=x86 MSVC 19 2017 RTW
 compiler.cl19_arm.exe=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64_arm/cl.exe
 compiler.cl19_arm.name=ARM MSVC 2017 RTW
+
+################################
+# Embaradero BCC32C
+group.bcc.compilers=bcc101
+group.bcc.needsMulti=false
+group.bcc.versionFlag=--version
+group.bcc.versionRe=^Embarcadero C\+\+.*$
+group.bcc.compilerType=Wine-BCC
+group.bcc.supportsBinary=false
+group.bcc.demangler=
+compiler.bcc101.exe=/opt/compiler-explorer/BCC101/bin/bcc32c.exe
+compiler.bcc101.name=x86 BCC32C 10.1
 
 #################################
 # ELLCC

--- a/lib/asm.js
+++ b/lib/asm.js
@@ -31,9 +31,9 @@ function AsmParser(compilerProps) {
     var fileFind = /^\s*\.file\s+(\d+)\s+"([^"]+)"(\s+"([^"]+)")?.*/;
     var hasOpcodeRe = /^\s*[a-zA-Z]/;
     var definesFunction = /^\s*\.type.*,\s*[@%]function$/;
-    var definesGlobal = /^\s*\.globa?l\s*([.a-zA-Z_][a-zA-Z0-9$_.]*)/;
-    var labelDef = /^([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
-    const indentedLabelDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
+    var definesGlobal = /^\s*\.globa?l\s*([.a-zA-Z_@][a-zA-Z0-9$_.]*)/;
+    var labelDef = /^([.a-zA-Z_$@][a-zA-Z0-9$_.]*):/;
+    const indentedLabelDef = /^\s*([.a-zA-Z_$@][a-zA-Z0-9$_.]*):/;
     var assignmentDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]+)\s*=/;
     var directive = /^\s*\..*$/;
     const startAppBlock = /\s*\#APP.*/;
@@ -172,7 +172,7 @@ function AsmParser(compilerProps) {
         var files = parseFiles(asmLines);
         var prevLabel = "";
 
-        var commentOnly = /^\s*(((#|@|\/\/).*)|(\/\*.*\*\/))$/;
+        var commentOnly = /^(\s*((#|\/\/).*)|(\s*\/\*.*\*\/)|(\s+@.*))$/;
         var sourceTag = /^\s*\.loc\s+(\d+)\s+(\d+).*/;
         var sourceStab = /^\s*\.stabn\s+(\d+),0,(\d+),.*/;
         const stdInLooking = /.*<stdin>|^-$|example\.[^/]+$|<source>/;

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -666,4 +666,21 @@ Compile.prototype.getDefaultFilters = function () {
     };
 };
 
+Compile.prototype.setupForWine = function () {
+    if ((process.platform === "linux") || (process.platform === "darwin")) {
+        const wine = this.env.ceProps("wine");
+        const origExec = this.exec;
+        this.exec = function (command, args, options) {
+            if (command.toLowerCase().endsWith(".exe")) {
+                args.unshift(command);
+                command = wine;
+            }
+            return origExec(command, args, options);
+        };
+        this.filename = function (fn) {
+            return 'Z:' + fn;
+        };
+    }
+};
+
 module.exports = Compile;

--- a/lib/compilers/Wine-BCC.js
+++ b/lib/compilers/Wine-BCC.js
@@ -26,7 +26,7 @@ const
     Compile = require('../base-compiler'),
     path = require('path');
 
-function compileCl(info, env) {
+function compileBCC(info, env) {
     var compile = new Compile(info, env);
     if ((process.platform === "linux") || (process.platform === "darwin")) {
         var wine = env.ceProps("wine");
@@ -62,4 +62,4 @@ function compileCl(info, env) {
     }
 }
 
-module.exports = compileCl;
+module.exports = compileBCC;

--- a/lib/compilers/Wine-BCC.js
+++ b/lib/compilers/Wine-BCC.js
@@ -28,7 +28,6 @@ const
 
 function compileCl(info, env) {
     var compile = new Compile(info, env);
-    info.supportsFiltersInBinary = true;
     if ((process.platform === "linux") || (process.platform === "darwin")) {
         var wine = env.ceProps("wine");
         var origExec = compile.exec;

--- a/lib/compilers/Wine-BCC.js
+++ b/lib/compilers/Wine-BCC.js
@@ -28,20 +28,7 @@ const
 
 function compileBCC(info, env) {
     var compile = new Compile(info, env);
-    if ((process.platform === "linux") || (process.platform === "darwin")) {
-        var wine = env.ceProps("wine");
-        var origExec = compile.exec;
-        compile.exec = function (command, args, options) {
-            if (command.toLowerCase().endsWith(".exe")) {
-                args.unshift(command);
-                command = wine;
-            }
-            return origExec(command, args, options);
-        };
-        compile.filename = function (fn) {
-            return 'Z:' + fn;
-        };
-    }
+    compile.setupForWine();
 
     compile.optionsForFilter = function (filters, outputFilename, userOptions) {
         let options = [

--- a/lib/compilers/Wine-BCC.js
+++ b/lib/compilers/Wine-BCC.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2012-2018, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const
+    Compile = require('../base-compiler'),
+    path = require('path');
+
+function compileCl(info, env) {
+    var compile = new Compile(info, env);
+    info.supportsFiltersInBinary = true;
+    if ((process.platform === "linux") || (process.platform === "darwin")) {
+        var wine = env.ceProps("wine");
+        var origExec = compile.exec;
+        compile.exec = function (command, args, options) {
+            if (command.toLowerCase().endsWith(".exe")) {
+                args.unshift(command);
+                command = wine;
+            }
+            return origExec(command, args, options);
+        };
+        compile.filename = function (fn) {
+            return 'Z:' + fn;
+        };
+    }
+
+    compile.optionsForFilter = function (filters, outputFilename, userOptions) {
+        let options = [
+            '-o' + this.filename(outputFilename),
+            '-n' + this.filename(path.dirname(outputFilename)),
+            '-v'
+        ];
+        if (!filters.binary) options = options.concat('-S');
+        return options;
+    };
+
+    if (info.unitTestMode) {
+        compile.initialise();
+
+        return compile;
+    } else {
+        return compile.initialise();
+    }
+}
+
+module.exports = compileCl;

--- a/lib/compilers/Wine-CL.js
+++ b/lib/compilers/Wine-CL.js
@@ -30,20 +30,8 @@ function compileCl(info, env) {
     var compile = new Compile(info, env);
     compile.asm = new asm.AsmParser(compile.compilerProps);
     info.supportsFiltersInBinary = true;
-    if ((process.platform === "linux") || (process.platform === "darwin")) {
-        var wine = env.ceProps("wine");
-        var origExec = compile.exec;
-        compile.exec = function (command, args, options) {
-            if (command.toLowerCase().endsWith(".exe")) {
-                args.unshift(command);
-                command = wine;
-            }
-            return origExec(command, args, options);
-        };
-        compile.filename = function (fn) {
-            return 'Z:' + fn;
-        };
-    }
+    compile.setupForWine();
+    
     compile.supportsObjdump = function () {
         return false;
     };


### PR DESCRIPTION
Before anything else; I read the license for this compiler and I don't think it's allowed to be used for CE. (PDF here: https://www.dropbox.com/s/ncxh6i3fi2ck37u/Embarcadero%20Freeware%20Software%20License%20Agreement.pdf?dl=0)

Link to compiler download: https://www.embarcadero.com/free-tools/ccompiler

But I figured out how to add this Windows compiler to CE without breaking too much other stuff.

Things that don't work:
- Binary mode, there's a lot of issues with the supplied linker and most "fixes" are questionable
- Demangling, they seem to be using a custom kind of mangling, could be figured out at a later time
