### PR TITLE
Don't always use argumentparser

### DIFF
--- a/lib/compilers/WSL-CL.js
+++ b/lib/compilers/WSL-CL.js
@@ -68,11 +68,7 @@ function compileCl(info, env) {
         return false;
     };
 
-    compile.getArgumentParser = function () {
-        return function (compiler) {
-            return compiler;
-        }
-    };
+    compile.getArgumentParser = () => (compiler) => compiler;
 
     compile.postProcessAsm = function(result) {
         return RunCLDemangler(this, result);

--- a/lib/compilers/WSL-CL.js
+++ b/lib/compilers/WSL-CL.js
@@ -68,6 +68,12 @@ function compileCl(info, env) {
         return false;
     };
 
+    compile.getArgumentParser = function () {
+        return function (compiler) {
+            return compiler;
+        }
+    };
+
     compile.postProcessAsm = function(result) {
         return RunCLDemangler(this, result);
     };

--- a/lib/compilers/Wine-CL.js
+++ b/lib/compilers/Wine-CL.js
@@ -48,6 +48,12 @@ function compileCl(info, env) {
         return false;
     };
 
+    compile.getArgumentParser = function () {
+        return function (compiler) {
+            return compiler;
+        }
+    };
+
     compile.postProcessAsm = function(result) {
         return RunCLDemangler(this, result);
     };

--- a/lib/compilers/Wine-CL.js
+++ b/lib/compilers/Wine-CL.js
@@ -48,11 +48,7 @@ function compileCl(info, env) {
         return false;
     };
 
-    compile.getArgumentParser = function () {
-        return function (compiler) {
-            return compiler;
-        }
-    };
+    compile.getArgumentParser = () => (compiler) => compiler;
 
     compile.postProcessAsm = function(result) {
         return RunCLDemangler(this, result);

--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -188,6 +188,12 @@ function compileFPC(info, env) {
         originalExecBinary(executable, result, maxSize);
     };
 
+    compiler.getArgumentParser = function () {
+        return function (compiler) {
+            return compiler;
+        }
+    };
+
     if (info.unitTestMode) {
         compiler.initialise();
         return compiler;

--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -188,11 +188,7 @@ function compileFPC(info, env) {
         originalExecBinary(executable, result, maxSize);
     };
 
-    compiler.getArgumentParser = function () {
-        return function (compiler) {
-            return compiler;
-        }
-    };
+    compiler.getArgumentParser = () => (compiler) => compiler;
 
     if (info.unitTestMode) {
         compiler.initialise();


### PR DESCRIPTION
At least not on compilers we're certain to not have anything useful.

Wine compilers take forever with the default gcc argument parser
