### PR TITLE
Fix crash on startup when a library's `listedVersions` is a single number

### DIFF
--- a/app.js
+++ b/app.js
@@ -255,7 +255,7 @@ function ClientOptionsHandler(fileSources) {
                     url: compilerPropsL(lang, libBaseName + '.url')
                 };
                 libs[lang][lib].versions = {};
-                const listedVersions = compilerPropsL(lang, libBaseName + '.versions');
+                const listedVersions = `${compilerPropsL(lang, libBaseName + '.versions')}`;
                 if (listedVersions) {
                     _.each(listedVersions.split(':'), version => {
                         const libVersionName = libBaseName + `.versions.${version}`;


### PR DESCRIPTION
Closes #828

As mentioned in the issue, this is a minimal change to prevent this specific crash; I suspect more code is relying on the assumption that `compilerPropsL` and/or other functions always return a `string`.