### PR TITLE
Quiet warnings in library headers by setting include paths with -isystem on compilers that support it

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -237,6 +237,7 @@ compiler.mips564el.name=MIPS64 gcc 5.4 (el)
 group.cl.compilers=&cl19
 group.cl.needsMulti=false
 group.cl.compilerType=Wine-CL
+group.cl.includeFlag=/I
 group.cl.versionFlag=/?
 group.cl.versionRe=^Microsoft \(R\) C/C\+\+.*$
 group.cl.demangler=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64/undname.exe

--- a/etc/config/c++.amazon.win32.properties
+++ b/etc/config/c++.amazon.win32.properties
@@ -2,9 +2,11 @@
 compilers=cl19:cl19_32
 compiler.cl19.name=x86 msvc 19 (64 bit)
 compiler.cl19.exe=etc\scripts\cl19_amd.bat
+compiler.cl19.includeFlag=/I
 compiler.cl19.versionFlag=/?
 compiler.cl19_32.name=x86 msvc 19 (32 bit)
 compiler.cl19_32.exe=etc\scripts\cl19_x86.bat
+compiler.cl19_32.includeFlag=/I
 compiler.cl19_32.versionFlag=/?
 postProcess=
 binaryHideFuncRe=^(_.*|(de)?register_tm_clones|call_gmon_start|frame_dummy)$

--- a/etc/config/c++.danger.properties
+++ b/etc/config/c++.danger.properties
@@ -22,6 +22,7 @@ compiler.avrg454.name=AVR gcc 4.5.4
 group.cl.compilers=&cl19
 group.cl.needsMulti=false
 group.cl.compilerType=Wine-CL
+group.cl.includeFlag=/I
 group.cl.versionFlag=/?
 group.cl.versionRe=^Microsoft \(R\) C/C\+\+.*$
 group.cl19.compilers=cl19_64:cl19_32:cl19_arm

--- a/etc/config/c++.defaults.properties
+++ b/etc/config/c++.defaults.properties
@@ -23,6 +23,7 @@ libs=
 group.cl.compilers=&cl19
 group.cl.needsMulti=false
 group.cl.compilerType=WSL-CL
+group.cl.includeFlag=/I
 group.cl.versionFlag=/?
 group.cl.versionRe=^Microsoft \(R\) C/C\+\+.*$
 #group.cl19.compilers=cl19_64:cl19_32:cl19_arm

--- a/etc/config/c++.lud-mgodbolt01.properties
+++ b/etc/config/c++.lud-mgodbolt01.properties
@@ -23,6 +23,7 @@ compiler.clang39.name=Clang 3.9
 
 group.windows.compilers=&cl19
 group.windows.compilerType=Wine-CL
+group.windows.includeFlag=/I
 group.windows.needsMulti=false
 group.windows.versionFlag=/?
 group.windows.versionRe=^Microsoft \(R\) C/C\+\+.*$

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -491,11 +491,12 @@ Compiler.prototype.compile = function () {
         },
         filters: this.getEffectiveFilters()
     };
+    var includeFlag = (this.compiler && this.compiler.includeFlag) || '-isystem';
     _.each(this.availableLibs[this.currentLangId], function (lib) {
         _.each(lib.versions, function (version) {
             if (version.used) {
                 _.each(version.path, function (path) {
-                    options.userArguments += ' -I' + path;
+                    options.userArguments += ' ' + includeFlag + path;
                 });
             }
         });


### PR DESCRIPTION
When using libraries with compiler explorer, numerous warnings are often raised in library headers. For example, this snippet, when compiled with clang `-Weverything`
```c++
#include <boost/locale.hpp>
template std::string boost::locale::conv::utf_to_utf(const char[], method_type);
```
[raises over 11000 warnings, all within Boost header files, before the process is killed.](https://godbolt.org/g/gtq1ih)

This is a semi-contrived example but not unusual.

Except for certain niche use cases (e.g. auditing the library for quality) raising warnings inside the library headers is unlikely to be desirable behavior for users.

Fortunately, there is a simple solution, setting search paths for library headers with the [`-isystem`](https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html) flag instead of `-I`. Compilers that support this flag, which includes all versions of all compilers currently on godbolt.org except MSVC,[1] will not raise warnings inside directories specified by `-isystem`.

This pull request makes `-isystem` the default flag used to set library header search paths, and adds an optional property `includeFlag` to compilers to override this default (currently only necessary with MSVC).

With this change, the above snippet (and all library headers) should compile without warnings. I have not written automated tests yet, but would appreciate any guidance WRT what you'd want me to test. Thanks! :)

[1] The Intel compiler supports `-isystem` on Unix but not on Windows.