### PR TITLE
Added basic support for LLVM IR

### DIFF
--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -1,6 +1,9 @@
 compilers=&irclang:&llc:&opt
 defaultCompiler=llctrunk
 
+demangler=/opt/compiler-explorer/gcc-7.2.0/bin/c++filt
+objdumper=/opt/compiler-explorer/gcc-7.2.0/bin/objdump
+
 group.irclang.compilers=irclang500:irclangtrunk
 group.irclang.intelAsm=-masm=intel
 group.irclang.groupName=Clang x86-64
@@ -8,7 +11,7 @@ group.irclang.options=-x ir
 compiler.ircclang401.exe=/opt/compiler-explorer/clang-4.0.1/bin/clang++
 compiler.ircclang401.name=clang 4.0.1
 compiler.irclang500.exe=/opt/compiler-explorer/clang-5.0.0/bin/clang++
-compiler.irclang500.name=cang 5.0.0
+compiler.irclang500.name=clang 5.0.0
 compiler.irclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.irclangtrunk.name=clang (trunk)
 
@@ -29,8 +32,8 @@ group.opt.compilers=opt401:opt500:opttrunk
 group.opt.compilerType=opt
 group.opt.supportsBinary=false
 group.opt.supportsExecute=false
-group.llc.groupName=LLVM optimizer
-group.llc.versionRe=LLVM version .*
+group.opt.groupName=LLVM optimizer
+group.opt.versionRe=LLVM version .*
 compiler.opt401.exe=/opt/compiler-explorer/clang-4.0.1/bin/opt
 compiler.opt401.name=opt 4.0.1
 compiler.opt500.exe=/opt/compiler-explorer/clang-5.0.0/bin/opt

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -1,0 +1,39 @@
+compilers=&irclang:&llc:&opt
+defaultCompiler=llctrunk
+
+group.irclang.compilers=irclang500:irclangtrunk
+group.irclang.intelAsm=-masm=intel
+group.irclang.groupName=Clang x86-64
+group.irclang.options=-x ir
+compiler.ircclang401.exe=/opt/compiler-explorer/clang-4.0.1/bin/clang++
+compiler.ircclang401.name=clang 4.0.1
+compiler.irclang500.exe=/opt/compiler-explorer/clang-5.0.0/bin/clang++
+compiler.irclang500.name=cang 5.0.0
+compiler.irclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.irclangtrunk.name=clang (trunk)
+
+group.llc.compilers=llc401:llc500:llctrunk
+group.llc.compilerType=llc
+group.llc.supportsExecute=false
+group.llc.intelAsm=-masm=intel
+group.llc.groupName=LLVM Static Compiler
+group.llc.versionRe=LLVM version .*
+compiler.llc401.exe=/opt/compiler-explorer/clang-4.0.1/bin/llc
+compiler.llc401.name=llc 4.0.1
+compiler.llc500.exe=/opt/compiler-explorer/clang-5.0.0/bin/llc
+compiler.llc500.name=llc 5.0.0
+compiler.llctrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llc
+compiler.llctrunk.name=llc (trunk)
+
+group.opt.compilers=opt401:opt500:opttrunk
+group.opt.compilerType=opt
+group.opt.supportsBinary=false
+group.opt.supportsExecute=false
+group.llc.groupName=LLVM optimizer
+group.llc.versionRe=LLVM version .*
+compiler.opt401.exe=/opt/compiler-explorer/clang-4.0.1/bin/opt
+compiler.opt401.name=opt 4.0.1
+compiler.opt500.exe=/opt/compiler-explorer/clang-5.0.0/bin/opt
+compiler.opt500.name=opt 5.0.0
+compiler.opttrunk.exe=/opt/compiler-explorer/clang-trunk/bin/opt
+compiler.opttrunk.name=opt (trunk)

--- a/etc/config/llvm.default.properties
+++ b/etc/config/llvm.default.properties
@@ -1,0 +1,1 @@
+binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_start|frame_dummy|(_GLOBAL__sub_I_|\.plt).*|.*@plt(-0x[0-9a-f]+)?)$

--- a/etc/config/llvm.default.properties
+++ b/etc/config/llvm.default.properties
@@ -1,1 +1,28 @@
 binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_start|frame_dummy|(_GLOBAL__sub_I_|\.plt).*|.*@plt(-0x[0-9a-f]+)?)$
+objdumper=objdump
+demangler=c++filt
+
+compilers=irclang:llc:opt
+defaultCompiler=irclang
+
+compiler.irclang.intelAsm=-masm=intel
+compiler.irclang.groupName=Clang x86-64
+compiler.irclang.options=-x ir
+compiler.irclang.exe=/usr/bin/clang++
+compiler.irclang.name=clang 3.9.1
+
+compiler.llc.compilerType=llc
+compiler.llc.supportsExecute=false
+compiler.llc.intelAsm=-masm=intel
+compiler.llc.groupName=LLVM Static Compiler
+compiler.llc.versionRe=LLVM version .*
+compiler.llc.exe=/usr/bin/llc
+compiler.llc.name=llc
+
+compiler.opt.compilerType=opt
+compiler.opt.supportsBinary=false
+compiler.opt.supportsExecute=false
+compiler.opt.groupName=LLVM optimizer
+compiler.opt.versionRe=LLVM version .*
+compiler.opt.exe=/usr/bin/pot
+compiler.opt.name=opt

--- a/examples/llvm/default.ll
+++ b/examples/llvm/default.ll
@@ -1,0 +1,4 @@
+define i32 @square(i32) local_unnamed_addr #0 {
+  %2 = mul nsw i32 %0, %0
+  ret i32 %2
+}

--- a/lib/compilers/llc.js
+++ b/lib/compilers/llc.js
@@ -1,0 +1,41 @@
+// Copyright (c) 2012-2018, Matt Godbolt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const BaseCompiler = require('../base-compiler');
+
+class LLCCompiler extends BaseCompiler {
+    constructor(info, env) {
+        super(info, env);
+        this.compiler.supportsIntel = true;
+    }
+
+    optionsForFilter(filters, outputFilename) {
+        let options = ['-o', this.filename(outputFilename)];
+        if (filters.intel && !filters.binary) options = options.concat('-x86-asm-syntax=intel');
+        if (filters.binary) options = options.concat('-filetype=obj');
+        return options;
+    }
+}
+
+module.exports = LLCCompiler;

--- a/lib/compilers/llc.js
+++ b/lib/compilers/llc.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2018, Matt Godbolt
+// Copyright (c) 2018, Adrian Bibby Walther
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/lib/compilers/opt.js
+++ b/lib/compilers/opt.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2018, Matt Godbolt
+// Copyright (c) 2018, Adrian Bibby Walther
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,7 @@
 
 const BaseCompiler = require('../base-compiler');
 
-class OPTCompiler extends BaseCompiler {
+class OptCompiler extends BaseCompiler {
     constructor(info, env) {
         super(info, env);
     }
@@ -35,4 +35,4 @@ class OPTCompiler extends BaseCompiler {
     }
 }
 
-module.exports = OPTCompiler;
+module.exports = OptCompiler;

--- a/lib/compilers/opt.js
+++ b/lib/compilers/opt.js
@@ -1,0 +1,38 @@
+// Copyright (c) 2012-2018, Matt Godbolt
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const BaseCompiler = require('../base-compiler');
+
+class OPTCompiler extends BaseCompiler {
+    constructor(info, env) {
+        super(info, env);
+    }
+
+    optionsForFilter(filters, outputFilename) {
+        let options = ['-o', this.filename(outputFilename), '-S'];
+        return options;
+    }
+}
+
+module.exports = OPTCompiler;

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -80,7 +80,7 @@ class CompileHandler {
                 .then(res => {
                     const cached = this.findCompiler(compiler.lang, compiler.id);
                     if (cached && cached.mtime.getTime() === res.mtime.getTime()) {
-                        logger.debug(compiler.id + " is unchanged");
+                        logger.debug(`${compiler.id} is unchanged`);
                         return cached;
                     }
                     return new this.factories[type](compiler, this.compilerEnv)

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -46,6 +46,13 @@ const languages = {
         extensions: ['.cpp', '.cxx', '.h', '.hpp', '.hxx', '.c'],
         alias: ['gcc', 'cpp']
     },
+    llvm: {
+        id: 'llvm',
+        name: 'LLVM IR',
+        monaco: 'asm',
+        extensions: ['.ll'],
+        alias: []
+    },
     cppx: {
         id: 'cppx',
         name: 'Cppx',

--- a/test/llvm-ir-tests.js
+++ b/test/llvm-ir-tests.js
@@ -31,9 +31,7 @@ const CompilationEnvironment = require('../lib/compilation-env');
 chai.use(chaiAsPromised);
 chai.should();
 
-const props = function (key, deflt) {
-    return deflt;
-};
+const props = (key, deflt) => deflt;
 
 function createCompiler(compiler) {
     const ce = new CompilationEnvironment(props);
@@ -43,12 +41,10 @@ function createCompiler(compiler) {
         'lang': 'llvm'
     };
 
-    ce.compilerPropsL = function (lang, property, defaultValue) {
-        return '';
-    };
+    ce.compilerPropsL = () => '';
 
     return new compiler(info, ce);
-};
+}
 
 describe('llc options for at&t assembly', function () {
     let compiler = createCompiler(LLCCompiler);
@@ -56,7 +52,7 @@ describe('llc options for at&t assembly', function () {
     compiler.optionsForFilter({
         'intel': false,
         'binary': false
-    },'output.s').should.eql(['-o', 'output.s']);
+    }, 'output.s').should.eql(['-o', 'output.s']);
 });
 
 describe('llc options for intel assembly', function () {
@@ -65,7 +61,7 @@ describe('llc options for intel assembly', function () {
     compiler.optionsForFilter({
         'intel': true,
         'binary': false
-    },'output.s').should.eql(['-o', 'output.s', '-x86-asm-syntax=intel']);
+    }, 'output.s').should.eql(['-o', 'output.s', '-x86-asm-syntax=intel']);
 });
 
 describe('llc options for at&t binary', function () {
@@ -74,7 +70,7 @@ describe('llc options for at&t binary', function () {
     compiler.optionsForFilter({
         'intel': false,
         'binary': true
-    },'output.s').should.eql(['-o', 'output.s', '-filetype=obj']);
+    }, 'output.s').should.eql(['-o', 'output.s', '-filetype=obj']);
 });
 
 describe('llc options for intel binary', function () {
@@ -83,7 +79,7 @@ describe('llc options for intel binary', function () {
     compiler.optionsForFilter({
         'intel': true,
         'binary': true
-    },'output.s').should.eql(['-o', 'output.s', '-filetype=obj']);
+    }, 'output.s').should.eql(['-o', 'output.s', '-filetype=obj']);
 });
 
 describe('opt options', function () {
@@ -92,5 +88,5 @@ describe('opt options', function () {
     compiler.optionsForFilter({
         'intel': false,
         'binary': false
-    },'output.s').should.eql(['-o', 'output.s', '-S']);
+    }, 'output.s').should.eql(['-o', 'output.s', '-S']);
 });

--- a/test/llvm-ir-tests.js
+++ b/test/llvm-ir-tests.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2018, Patrick Quist
+// Copyright (c) 2018, Adrian Bibby Walther
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/test/llvm-ir-tests.js
+++ b/test/llvm-ir-tests.js
@@ -1,0 +1,96 @@
+// Copyright (c) 2012-2018, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const chai = require('chai');
+const chaiAsPromised = require("chai-as-promised");
+const LLCCompiler = require('../lib/compilers/llc');
+const OPTCompiler = require('../lib/compilers/opt');
+const CompilationEnvironment = require('../lib/compilation-env');
+
+chai.use(chaiAsPromised);
+chai.should();
+
+const props = function (key, deflt) {
+    return deflt;
+};
+
+function createCompiler(compiler) {
+    const ce = new CompilationEnvironment(props);
+    const info = {
+        'exe': null,
+        'remote': true,
+        'lang': 'llvm'
+    };
+
+    ce.compilerPropsL = function (lang, property, defaultValue) {
+        return '';
+    };
+
+    return new compiler(info, ce);
+};
+
+describe('llc options for at&t assembly', function () {
+    let compiler = createCompiler(LLCCompiler);
+
+    compiler.optionsForFilter({
+        'intel': false,
+        'binary': false
+    },'output.s').should.eql(['-o', 'output.s']);
+});
+
+describe('llc options for intel assembly', function () {
+    let compiler = createCompiler(LLCCompiler);
+
+    compiler.optionsForFilter({
+        'intel': true,
+        'binary': false
+    },'output.s').should.eql(['-o', 'output.s', '-x86-asm-syntax=intel']);
+});
+
+describe('llc options for at&t binary', function () {
+    let compiler = createCompiler(LLCCompiler);
+
+    compiler.optionsForFilter({
+        'intel': false,
+        'binary': true
+    },'output.s').should.eql(['-o', 'output.s', '-filetype=obj']);
+});
+
+describe('llc options for intel binary', function () {
+    let compiler = createCompiler(LLCCompiler);
+
+    compiler.optionsForFilter({
+        'intel': true,
+        'binary': true
+    },'output.s').should.eql(['-o', 'output.s', '-filetype=obj']);
+});
+
+describe('opt options', function () {
+    let compiler = createCompiler(OPTCompiler);
+
+    compiler.optionsForFilter({
+        'intel': false,
+        'binary': false
+    },'output.s').should.eql(['-o', 'output.s', '-S']);
+});


### PR DESCRIPTION
Only basic support. `opt` compiles to LLVM IR instead of assembly, Monaco uses the `asm` highlighter and execute doesn't work for `llc` and `opt`, but `clang -x ir` works well enough, that I don't care enough to fix the others.

The properties I used are the following:
```properties
compilers=&clang:&llc:&opt

group.clang.compilers=irclang600
group.clang.intelAsm=-masm=intel

group.llc.compilers=llc600
group.llc.compilerType=llc
group.llc.supportsExecute=false

group.opt.compilers=opt600
group.opt.compilerType=opt
group.opt.intelAsm=
group.opt.supportsBinary=false
group.opt.supportsExecute=false

compiler.llc600.exe=/usr/local/bin/llc
compiler.llc600.name=llc 6.0.0

compiler.opt600.exe=/usr/local/bin/opt
compiler.opt600.name=opt 6.0.0

compiler.irclang600.exe=/usr/local/bin/clang
compiler.irclang600.name=clang 6.0.0
compiler.irclang600.options=-x ir

defaultCompiler=irclang600
objdumper=objdump

binaryHideFuncRe=^(__.*|_(init|start|fini)|(de)?register_tm_clones|call_gmon_start|frame_dummy|(_GLOBAL__sub_I_|\.plt).*|.*@plt(-0x[0-9a-f]+)?)$
```
I did not add it to the repository, since the file paths might differ.

I also found out that using relative filepaths broke the server side, because `initialise()` isn't called on the `new`ed object. I did not fix that because I am not familiar with that code, and it might be intentional. It is in `lib/handlers/compile.js` in the `create` method (currently line 97).