### PR TITLE
Add Systemd socket activation support

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,26 +2,26 @@
 
 // Copyright (c) 2012, Matt Godbolt
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-//     * Redistributions of source code must retain the above copyright notice, 
+//
+//     * Redistributions of source code must retain the above copyright notice,
 //       this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above copyright 
-//       notice, this list of conditions and the following disclaimer in the 
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
 //       documentation and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 // Initialise options and properties. Don't load any handlers here; they
@@ -32,6 +32,7 @@ const nopt = require('nopt'),
     child_process = require('child_process'),
     path = require('path'),
     fs = require('fs-extra'),
+    systemdSocket = require('systemd-socket'),
     http = require('http'),
     url = require('url'),
     _ = require('underscore-node'),
@@ -66,7 +67,7 @@ if ((process.platform === "win32") || child_process.execSync('uname -a').toStrin
 
 // AP: Allow setting of tmpDir (used in lib/base-compiler.js & lib/exec.js) through opts.
 // WSL requires a directory on a Windows volume. Set that to Windows %TEMP% if no tmpDir supplied.
-// If a tempDir is supplied then assume that it will work for WSL processes as well. 
+// If a tempDir is supplied then assume that it will work for WSL processes as well.
 if (opts.tmpDir) {
     process.env.tmpDir = opts.tmpDir;
     process.env.winTmp = opts.tmpDir;
@@ -124,14 +125,14 @@ logger.info("properties hierarchy: " + propHierarchy.join(', '));
 // Propagate debug mode if need be
 if (opts.propDebug) props.setDebug(true);
 
-// *All* files in config dir are parsed 
+// *All* files in config dir are parsed
 props.initialize(rootDir + '/config', propHierarchy);
 
 // Now load up our libraries.
 const aws = require('./lib/aws'),
     google = require('./lib/google');
 
-// Instantiate a function to access records concerning "compiler-explorer" 
+// Instantiate a function to access records concerning "compiler-explorer"
 // in hidden object props.properties
 const ceProps = props.propsFor("compiler-explorer");
 
@@ -664,7 +665,26 @@ Promise.all([findCompilers(), aws.initConfig(awsProps)])
         logger.info("=======================================");
         webServer.use(Raven.errorHandler());
         webServer.on('error', err => logger.error('Caught error:', err, "(in web error handler; continuing)"));
-        webServer.listen(port, hostname);
+
+        const ss = systemdSocket();
+        if (ss) {
+            const timeout = (typeof process.env.IDLE_TIMEOUT !== 'undefined' ? process.env.IDLE_TIMEOUT : 300) * 1000; // ms (5 min default)
+            if (timeout) {
+                let exit = () => {
+                    logger.info("Inactivity timeout reached, exiting.");
+                    process.exit(0);
+                };
+                let reset = () => {
+                    clearTimeout(idleTimer);
+                    idleTimer = setTimeout(exit, timeout);
+                };
+                let idleTimer = setTimeout(exit, timeout);
+                webServer.all('*', reset);
+            }
+            webServer.listen(ss, hostname);
+        } else {
+            webServer.listen(port, hostname);
+        }
     })
     .catch(err => {
         logger.error("Promise error:", err, "(shutting down)");

--- a/docs/SystemdSocketActivation.md
+++ b/docs/SystemdSocketActivation.md
@@ -1,0 +1,45 @@
+# Using Systemd socket based activation to start Compiler Explorer
+
+This document gives a short overview of how to use Systemd to automatically start Compiler Explorer when the web-interface is accessed.
+
+You'll need to create two files in `/etc/systemd/system/`:
+
+compiler-explorer.socket:
+```
+[Socket]
+ListenStream=10240
+
+[Install]
+WantedBy=sockets.target
+```
+
+
+compiler-explorer.service:
+```
+[Service]
+Type=simple
+WorkingDirectory={{path_to_installation_directory}}/compiler-explorer
+ExecStart=/usr/bin/node {{path_to_installation_directory}}/compiler-explorer/app.js
+TimeoutStartSec=60
+TimeoutStopSec=60
+StandardOutput=syslog
+User={{run_as_this_user}}
+Group={{run_as_this_group}}
+```
+
+Replace the bracketed `{{}}` placeholders with your system specifics.
+
+Once the two above files are created Systemd needs to be made aware of the changes:
+
+```sh
+sudo systemctl daemon-reload
+```
+
+Now all that remains is to enable and start the new service:
+
+```sh
+sudo systemctl enable compiler-explorer.socket
+sudo systemctl start compiler-explorer.socket
+```
+
+If all goes well you can now open the web-interface.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "selectize": "^0.12.4",
     "serve-favicon": "^2.4.5",
     "shell-quote": "1.6.x",
+    "systemd-socket": "0.0.0",
     "temp": "0.8.x",
     "tree-kill": "^1.2.0",
     "uglifyjs-webpack-plugin": "^1.1.8",


### PR DESCRIPTION
I made a small modification to `app.js` to allow starting compiler explorer by accessing it's socket, using [Systemd socket activation](http://0pointer.de/blog/projects/socket-activation.html). A rather crude time-out system (disabled when set to `0` seconds by environment variable) is set to a default of 5 minutes.
There is a document with templates for the required Systemd socket and service files.