### PR TITLE
yarn dev for easier running without needing make

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
   },
   "scripts": {
     "test": "mocha --recursive && make test",
-    "dev": "cross-env NODE_ENV=DEV && node app.js",
-    "run": "cross-env NODE_ENV=LOCAL && npx webpack && node app.js",
+    "dev": "cross-env NODE_ENV=DEV node app.js",
+    "run": "npx webpack && cross-env NODE_ENV=LOCAL node app.js",
     "codecov": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive && codecov",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive",
     "localcoverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report html -- -R spec --recursive"

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "scripts": {
     "test": "mocha --recursive && make test",
+    "webpack": "node node_modules/webpack/bin/webpack.js",
     "codecov": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive && codecov",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive",
     "localcoverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report html -- -R spec --recursive"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "scripts": {
     "test": "mocha --recursive && make test",
-    "webpack": "node node_modules/webpack/bin/webpack.js",
+    "dev": "npx webpack && node app.js",
     "codecov": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive && codecov",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive",
     "localcoverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report html -- -R spec --recursive"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   },
   "scripts": {
     "test": "mocha --recursive && make test",
-    "dev": "npx webpack && node app.js",
+    "dev": "set NODE_ENV=DEV && node app.js",
+    "run": "npx webpack && set NODE_ENV=LOCAL && node app.js",
     "codecov": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive && codecov",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive",
     "localcoverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report html -- -R spec --recursive"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "clipboard": "^1.7.1",
     "compiler-opt-info": "0.0.4",
     "compression": "^1.7.1",
+    "cross-env": "^5.1.3",
     "denodeify": "^1.2.1",
     "es6-promise": "^4.1.1",
     "express": "4.16.x",
@@ -63,8 +64,8 @@
     "codecov": "^3.0.0",
     "copy-webpack-plugin": "^4.1.1",
     "css-loader": "^0.28.7",
-    "extract-text-webpack-plugin": "^3.0.1",
     "eslint": "^4.17.0",
+    "extract-text-webpack-plugin": "^3.0.1",
     "file-loader": "^1.1.5",
     "istanbul": "^0.4.5",
     "mocha": "^3.3.0",
@@ -81,8 +82,8 @@
   },
   "scripts": {
     "test": "mocha --recursive && make test",
-    "dev": "set NODE_ENV=DEV && node app.js",
-    "run": "npx webpack && set NODE_ENV=LOCAL && node app.js",
+    "dev": "cross-env NODE_ENV=DEV && node app.js",
+    "run": "cross-env NODE_ENV=LOCAL && npx webpack && node app.js",
     "codecov": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive && codecov",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive",
     "localcoverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report html -- -R spec --recursive"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "scripts": {
     "test": "mocha --recursive && make test",
     "dev": "cross-env NODE_ENV=DEV node app.js",
-    "run": "npx webpack && cross-env NODE_ENV=LOCAL node app.js",
+    "start": "npx webpack && cross-env NODE_ENV=LOCAL node app.js",
     "codecov": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive && codecov",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive",
     "localcoverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report html -- -R spec --recursive"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,6 +1102,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2863,6 +2870,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 is-wsl@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
I think this is needed, because there's no make on Windows, and this actually makes the website all fancy and ready.

This way you can do "yarn webpack" before doing node app.js and things will work