### PR TITLE
Switchable urlshorten

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Feel free to raise an issue on
  [github](https://github.com/mattgodbolt/compiler-explorer/issues) or
  [email Matt directly](mailto:matt@godbolt.org) for more help.
 
-### Developing or running a local instance
+### Developing
 
 **Compiler Explorer** is written in [Node.js](https://nodejs.org/).
 
@@ -56,11 +56,6 @@ Running with `make EXTRA_ARGS='--language LANG'` will allow you to load
  client side components.
 
 
-If you want to point it at your own GCC or similar binaries, either edit the
- `etc/config/compiler-explorer.defaults.properties` or else make a new one with
- the name `compiler-explorer.local.properties`. `*.local.properties` files
- have the highest priority when loading properties.
-
 The config system leaves a lot to be desired. Work has been done on porting
  [CCS](https://github.com/hellige/ccs-cpp) to Javascript and then something
  more rational can be used.
@@ -68,6 +63,22 @@ The config system leaves a lot to be desired. Work has been done on porting
 
 A [Road map](Roadmap.md) is available which gives a little insight into
  the future plans for **Compiler Explorer**.
+
+### Running a local instance
+
+If you want to point it at your own GCC or similar binaries, either edit the
+ `etc/config/compiler-explorer.defaults.properties` or else make a new one with
+ the name `compiler-explorer.local.properties`. `*.local.properties` files
+ have the highest priority when loading properties.
+
+
+When running in a corporate setting the URL shortening service can be replaced
+ by an internal one to avoid leaking source code outside of the organization.
+ This is done by adding a new module in `static/urlshorten-myservice.js` and
+ setting the `urlShortenService` variable in configuration. This module should
+ export a single function, see the [google module](static/urlshorten-google.js)
+ for an example. `urlShortenService` can also be set to `none` to disable url
+ shortening altogether.
 
 ### RESTful API
 

--- a/app.js
+++ b/app.js
@@ -284,6 +284,7 @@ function ClientOptionsHandler(fileSources) {
         githubEnabled: ceProps('clientGitHubRibbonEnabled', true),
         gapiKey: ceProps('googleApiKey', ''),
         googleShortLinkRewrite: ceProps('googleShortLinkRewrite', '').split('|'),
+        urlShortenService: ceProps('urlShortenService', 'none'),
         defaultSource: ceProps('defaultSource', ''),
         compilers: [],
         libs: libs,

--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -11,3 +11,4 @@ proxyRetryMs=500
 rescanCompilerSecs=3600
 supportsExecute=false
 ravenUrl=https://8e4614f649ad4e3faf3e7e8827b935f9@sentry.io/102028
+urlShortenService=google

--- a/etc/config/compiler-explorer.beta.properties
+++ b/etc/config/compiler-explorer.beta.properties
@@ -1,2 +1,3 @@
 extraBodyClass=beta
 web-alias=/beta
+urlShortenService=google

--- a/etc/config/compiler-explorer.defaults.properties
+++ b/etc/config/compiler-explorer.defaults.properties
@@ -11,6 +11,7 @@ supportsExecute=true
 optionsBlacklistRe=^(-W[alp],)?((--?(wrapper|fplugin.*|specs|load|plugin|include)|(@.*)|-I|-i)(=.*)?|--)$
 allowedShortUrlHostRe=^([-a-z.]+\.)?(xania|godbolt)\.org$
 googleShortLinkRewrite=^https?://goo.gl/(.*)$|https://godbolt.org/g/$1
+urlShortenService=none
 
 wine=/opt/wine-devel/bin/wine64
 python3=/usr/bin/python3

--- a/static/sharing.js
+++ b/static/sharing.js
@@ -25,7 +25,6 @@
 "use strict";
 var $ = require('jquery');
 var _ = require('underscore');
-var options = require('options');
 var shortenURL = require('urlshorten-google');
 var Components = require('components');
 var url = require('./url');
@@ -100,6 +99,11 @@ function initShareButton(getLink, layout) {
 
         getLinks(layout, function (theUrls) {
             urls = theUrls;
+            if (!urls[currentBind])
+                currentBind = 'Full';
+            root.find('.sources a').each(function () {
+                $(this).toggle(!!urls[$(this).data().bind]);
+            });
             update();
         });
         update();
@@ -131,14 +135,10 @@ function getLinks(layout, done) {
         Embed: '<iframe width="800px" height="200px" src="' + getEmbeddedUrl(layout, false) + '"></iframe>',
         'Embed (RO)': '<iframe width="800px" height="200px" src="' + getEmbeddedUrl(layout, true) + '"></iframe>'
     };
-    if (!options.gapiKey) {
+    shortenURL(result.Full, function (shorter) {
+        result.Short = shorter;
         done(result);
-    } else {
-        shortenURL(result.Full, function (shorter) {
-            result.Short = shorter;
-            done(result);
-        });
-    }
+    });
 }
 
 module.exports = {

--- a/static/sharing.js
+++ b/static/sharing.js
@@ -25,7 +25,8 @@
 "use strict";
 var $ = require('jquery');
 var _ = require('underscore');
-var shortenURL = require('urlshorten-google');
+var options = require('options');
+var shortenURL = require('./urlshorten-' + options.urlShortenService);
 var Components = require('components');
 var url = require('./url');
 

--- a/static/urlshorten-google.js
+++ b/static/urlshorten-google.js
@@ -34,6 +34,10 @@ function googleJSClientLoaded() {
 }
 
 function shortenURL(url, done) {
+    if (!options.gapiKey) {
+	done(null);
+	return;
+    }
     var gapi = window.gapi;
     if (!gapi || !gapi.client || !gapi.client.urlshortener) {
         // Load the Google APIs client library asynchronously, then the
@@ -58,7 +62,7 @@ function shortenURL(url, done) {
                 group: "urltoolong",
                 alertClass: "notification-error"
             });
-        done(url);
+        done(null);
     });
 }
 

--- a/static/urlshorten-none.js
+++ b/static/urlshorten-none.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2018, Compiler Explorer Team
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+function shortenURL(url, donecb) {
+    donecb(null);
+}
+
+module.exports = shortenURL;

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -8,8 +8,7 @@
             span.current Short
             span.caret
           ul.dropdown-menu.sources
-            if gapiKey
-              li: a(href="#" data-bind="Short") Short
+            li: a(href="#" data-bind="Short") Short
             li: a(href="#" data-bind="Full") Full
             li: a(href="#" data-bind="Embed") Embed
             li: a(href="#" data-bind="Embed (RO)") Embed (read only)


### PR DESCRIPTION
These small changes make it easy to drop in an alternate url shortening service by simply dropping in a file like `static/urlshorten-homegrown.js` and setting `urlShortenService=homegrown` in an appropiate `.properties` file.

This should improve the situation for running internal compiler-explorer instances without risking leaking any code.