### PR TITLE
Pascal error output

### DIFF
--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -129,12 +129,16 @@ class FPCCompiler extends BaseCompiler {
         options.push(projectFile);
 
         return this.exec(compiler, options, execOptions).then(result => {
-            const fileWithoutPath = path.basename(inputFilename);
-            result.inputFilename = fileWithoutPath;
-            result.stdout = utils.parseOutput(result.stdout, fileWithoutPath, tempPath);
-            result.stderr = utils.parseOutput(result.stderr, fileWithoutPath, tempPath);
-            return result;
+            return this.parseOutput(result, inputFilename, tempPath);
         });
+    }
+
+    parseOutput(result, inputFilename, tempPath) {
+        const fileWithoutPath = path.basename(inputFilename);
+        result.inputFilename = fileWithoutPath;
+        result.stdout = utils.parseOutput(result.stdout, fileWithoutPath, tempPath);
+        result.stderr = utils.parseOutput(result.stderr, fileWithoutPath, tempPath);
+        return result;
     }
 
     execBinary(executable, result, maxSize) {

--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -131,8 +131,8 @@ class FPCCompiler extends BaseCompiler {
         return this.exec(compiler, options, execOptions).then(result => {
             const fileWithoutPath = path.basename(inputFilename);
             result.inputFilename = fileWithoutPath;
-            result.stdout = utils.parseOutput(result.stdout, fileWithoutPath);
-            result.stderr = utils.parseOutput(result.stderr, fileWithoutPath);
+            result.stdout = utils.parseOutput(result.stdout, fileWithoutPath, tempPath);
+            result.stderr = utils.parseOutput(result.stderr, fileWithoutPath, tempPath);
             return result;
         });
     }

--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -129,7 +129,7 @@ class FPCCompiler extends BaseCompiler {
         options.push(projectFile);
 
         return this.exec(compiler, options, execOptions).then(result => {
-            const fileWithoutPath = path.filename(inputFilename);
+            const fileWithoutPath = path.basename(inputFilename);
             result.inputFilename = fileWithoutPath;
             result.stdout = utils.parseOutput(result.stdout, fileWithoutPath);
             result.stderr = utils.parseOutput(result.stderr, fileWithoutPath);

--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -129,9 +129,10 @@ class FPCCompiler extends BaseCompiler {
         options.push(projectFile);
 
         return this.exec(compiler, options, execOptions).then(result => {
-            result.inputFilename = inputFilename;
-            result.stdout = utils.parseOutput(result.stdout, inputFilename);
-            result.stderr = utils.parseOutput(result.stderr, inputFilename);
+            const fileWithoutPath = path.filename(inputFilename);
+            result.inputFilename = fileWithoutPath;
+            result.stdout = utils.parseOutput(result.stdout, fileWithoutPath);
+            result.stderr = utils.parseOutput(result.stderr, fileWithoutPath);
             return result;
         });
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,11 +54,12 @@ function expandTabs(line) {
 
 exports.expandTabs = expandTabs;
 
-function parseOutput(lines, inputFilename) {
+function parseOutput(lines, inputFilename, pathPrefix) {
     const re = /^\s*<source>[:(]([0-9]+)(:?,?([0-9]+):?)?[):]*\s*(.*)/;
     const result = [];
     eachLine(lines, function (line) {
         line = line.split('<stdin>').join('<source>');
+        if (pathPrefix) line = line.replace(pathPrefix, "");
         if (inputFilename) line = line.split(inputFilename).join('<source>');
         if (line !== "" && line.indexOf("fixme:") !== 0) {
             const lineObj = {text: line};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,7 +55,7 @@ function expandTabs(line) {
 exports.expandTabs = expandTabs;
 
 function parseOutput(lines, inputFilename) {
-    const re = /^\s*<source>[:(]([0-9]+)(:([0-9]+):)?[):]*\s*(.*)/;
+    const re = /^\s*<source>[:(]([0-9]+)(:?,?([0-9]+):?)?[):]*\s*(.*)/;
     const result = [];
     eachLine(lines, function (line) {
         line = line.split('<stdin>').join('<source>');

--- a/test/pascal-tests.js
+++ b/test/pascal-tests.js
@@ -346,3 +346,31 @@ describe('Pascal objdump filtering', function () {
         });
     });
 });
+
+describe('Pascal parseOutput', () => {
+    const ce = new CompilationEnvironment(props);
+    const info = {
+        "exe": null,
+        "remote": true,
+        "lang": "pascal"
+    };
+
+    ce.compilerPropsL = () => "";
+
+    const compiler = new PascalCompiler(info, ce);
+
+    it('should return parsed output', () => {
+        const result = {
+            stdout: "Hello, world!",
+            stderr: ""
+        };
+
+        compiler.parseOutput(result, "/tmp/path/output.pas", "/tmp/path").should.deep.equal({
+            inputFilename: "output.pas",
+            stdout: [{
+                "text": "Hello, world!"
+            }],
+            stderr: []
+        });
+    });
+});

--- a/test/utils-tests.js
+++ b/test/utils-tests.js
@@ -131,6 +131,34 @@ describe('Parses compiler output', () => {
     });
 });
 
+describe('Pascal compiler output', () => {
+    it('recognize fpc identifier not found error', () => {
+        utils.parseOutput('output.pas(13,23) Error: Identifier not found "adsadasd"', 'output.pas').should.deep.equals([
+            {
+                tag: {
+                    column: 23,
+                    line: 13,
+                    text: 'Error: Identifier not found "adsadasd"'
+                },
+                text: '<source>(13,23) Error: Identifier not found "adsadasd"'
+            }
+        ]);
+    });
+
+    it('recognize fpc exiting error', () => {
+        utils.parseOutput('output.pas(17) Fatal: There were 1 errors compiling module, stopping', 'output.pas').should.deep.equals([
+            {
+                tag: {
+                    column: 0,
+                    line: 17,
+                    text: 'Fatal: There were 1 errors compiling module, stopping'
+                },
+                text: '<source>(17) Fatal: There were 1 errors compiling module, stopping'
+            }
+        ]);
+    });
+});
+
 describe('Pads right', () => {
     it('works', () => {
         utils.padRight('abcd', 8).should.equal('abcd    ');

--- a/test/utils-tests.js
+++ b/test/utils-tests.js
@@ -157,6 +157,22 @@ describe('Pascal compiler output', () => {
             }
         ]);
     });
+
+    it('removes the temp path', () => {
+        utils.parseOutput('Compiling /tmp/path/prog.dpr\noutput.pas(17) Fatal: There were 1 errors compiling module, stopping', 'output.pas', '/tmp/path/').should.deep.equals([
+            {
+                text: 'Compiling prog.dpr'
+            },
+            {
+                tag: {
+                    column: 0,
+                    line: 17,
+                    text: 'Fatal: There were 1 errors compiling module, stopping'
+                },
+                text: '<source>(17) Fatal: There were 1 errors compiling module, stopping'
+            }
+        ]);
+    });
 });
 
 describe('Pads right', () => {


### PR DESCRIPTION
So that errors get highlighted for pascal just like for other compilers,
also removes the sourcecode temp folder from the output filenames