### PR TITLE
Enable CFG (Graph Output) for LDC and GDC compilers.

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -423,8 +423,7 @@ class BaseCompiler {
     isCfgCompiler(compilerVersion) {
         return compilerVersion.includes("clang") ||
                compilerVersion.indexOf("g++") === 0 ||
-               compilerVersion.indexOf("gdc") === 0 ||
-               compilerVersion.indexOf("LDC") === 0;
+               compilerVersion.indexOf("gdc") === 0;
     }
 
     processAstOutput(output) {

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -421,7 +421,10 @@ class BaseCompiler {
     }
 
     isCfgCompiler(compilerVersion) {
-        return compilerVersion.includes("clang") || compilerVersion.indexOf("g++") === 0;
+        return compilerVersion.includes("clang") ||
+               compilerVersion.indexOf("g++") === 0 ||
+               compilerVersion.indexOf("gdc") === 0 ||
+               compilerVersion.indexOf("LDC") === 0;
     }
 
     processAstOutput(output) {


### PR DESCRIPTION
I may have submitted this in the past, but cannot find the PR.

I believe the objection in the past is that this option should be a parameter/configuration option in the compiler properties. I hope that until then, this small addition is acceptable to enable CFG for more compilers.
(btw, my hunch is that `rustc` will also just work)
