### PR TITLE
Add AST output to LDC.

### DIFF
--- a/lib/compilers/ldc.js
+++ b/lib/compilers/ldc.js
@@ -49,6 +49,36 @@ class LDCCompiler extends BaseCompiler {
     isCfgCompiler() {
         return true;
     }
+
+    couldSupportASTDump(version) {
+        const versionRegex = /\((\d\.\d+)\.\d+/;
+        const versionMatch = versionRegex.exec(version);
+
+        if (versionMatch) {
+            const versionNum = parseFloat(versionMatch[1]);
+            return versionNum >= 1.4;
+        }
+
+        return false;
+    }
+
+    generateAST(inputFilename, options) {
+        // These options make LDC produce an AST dump in a separate file `<inputFilename>.cg`.
+        let newOptions = options.concat("-vcg-ast");
+        let execOptions = this.getDefaultExecOptions();
+        return this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions)
+            .then( () => { return this.loadASTOutput(this.filename(inputFilename)); });
+    }
+
+    loadASTOutput(inputFilename) {
+        // Load the AST output from the `.cg` file.
+        // Demangling is not needed.
+        let astPath = inputFilename.concat(".cg");
+        const maxSize = this.env.ceProps("max-asm-size", 8 * 1024 * 1024);
+        const postCommand = `cat "${astPath}"`;
+        return this.exec("bash", ["-c", postCommand], {maxOutput: maxSize})
+            .then(postResult => { return postResult.stdout; })
+    }
 }
 
 module.exports = LDCCompiler;

--- a/test/d-tests.js
+++ b/test/d-tests.js
@@ -49,4 +49,11 @@ describe('D', () => {
         const compiler = new DMDCompiler(info, ce);
         compiler.filterUserOptions(["hello", "-run", "--something"]).should.deep.equal(["hello", "--something"]);
     });
+
+    it('LDC supports AST output since version 1.4.0', () => {
+        const compiler = new LDCCompiler(info, ce);
+        compiler.couldSupportASTDump("LDC - the LLVM D compiler (1.3.0)").should.equal(false);
+        compiler.couldSupportASTDump("LDC - the LLVM D compiler (1.4.0)").should.equal(true);
+        compiler.couldSupportASTDump("LDC - the LLVM D compiler (1.8.0git-d54d25b-dirty)").should.equal(true);
+    });
 });


### PR DESCRIPTION
This is a proof-of-concept implementation that works locally :-)

LDC outputs an extra file when the `-vcg-ast` option is passed. The extra file is `<inputfile>.cg`, i.e. `.cg` is appended to the full inputfile path. This PR loads that file (using `cat` as is done for the asm output), which can then be output to screen without any parsing (for example, demangling is not needed).

Notes:
- this uses the "Clang AST output" view button. Perhaps rename the button to "AST output" ? 
- syntax highlighting (D syntax) could be applied to the AST view.