### PR TITLE
Set AST and Opt view syntax highlighting to language of the compiler

### DIFF
--- a/static/ast-view.js
+++ b/static/ast-view.js
@@ -25,8 +25,11 @@
 
 var FontScale = require('fontscale');
 var monaco = require('monaco');
+var options = require('options');
 var _ = require('underscore');
 var $ = require('jquery');
+
+var languages = options.languages;
 
 function Ast(hub, container, state) {
     this.container = container;
@@ -37,7 +40,7 @@ function Ast(hub, container, state) {
     this.astEditor = monaco.editor.create(this.domRoot.find(".monaco-placeholder")[0], {
         value: "",
         scrollBeyondLastLine: false,
-        language: 'cppp', //we only support cpp for now
+        language: state.lang ? languages[state.lang].monaco : 'text',
         readOnly: true,
         glyphMargin: true,
         fontFamily: 'Consolas, "Liberation Mono", Courier, monospace',

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -266,12 +266,12 @@ function Compiler(hub, container, state) {
 
     var createOptView = _.bind(function () {
         return Components.getOptViewWith(this.id, this.source, this.lastResult.optOutput, this.getCompilerName(),
-            this.sourceEditorId);
+            this.sourceEditorId, this.currentLangId);
     }, this);
 
     var createAstView = _.bind(function () {
         return Components.getAstViewWith(this.id, this.source, this.lastResult.astOutput, this.getCompilerName(),
-            this.sourceEditorId);
+            this.sourceEditorId, this.currentLangId);
     }, this);
 
     var createGccDumpView = _.bind(function () {

--- a/static/components.js
+++ b/static/components.js
@@ -79,7 +79,7 @@ module.exports = {
             componentState: {}
         };
     },
-    getOptViewWith: function (id, source, optimization, compilerName, editorid) {
+    getOptViewWith: function (id, source, optimization, compilerName, editorid, langid) {
         return {
             type: 'component',
             componentName: 'opt',
@@ -88,7 +88,8 @@ module.exports = {
                 source: source,
                 optOutput: optimization,
                 compilerName: compilerName,
-                editorid: editorid
+                editorid: editorid,
+                lang: langid
             }
         };
     },
@@ -99,7 +100,7 @@ module.exports = {
             componentState: {}
         };
     },
-    getAstViewWith: function (id, source, astOutput, compilerName, editorid) {
+    getAstViewWith: function (id, source, astOutput, compilerName, editorid, langid) {
         return {
             type: 'component',
             componentName: 'ast',
@@ -108,7 +109,8 @@ module.exports = {
                 source: source,
                 astOutput: astOutput,
                 compilerName: compilerName,
-                editorid: editorid
+                editorid: editorid,
+                lang: langid
             }
         };
     },

--- a/static/opt-view.js
+++ b/static/opt-view.js
@@ -25,8 +25,11 @@
 
 var FontScale = require('fontscale');
 var monaco = require('monaco');
+var options = require('options');
 var _ = require('underscore');
 var $ = require('jquery');
+
+var languages = options.languages;
 
 require('asm-mode');
 require('selectize');
@@ -43,7 +46,7 @@ function Opt(hub, container, state) {
     this.optEditor = monaco.editor.create(this.domRoot.find(".monaco-placeholder")[0], {
         value: this.code,
         scrollBeyondLastLine: false,
-        language: 'cppp', //we only support cpp(p) for now
+        language: state.lang ? languages[state.lang].monaco : 'text',
         readOnly: true,
         glyphMargin: true,
         quickSuggestions: false,


### PR DESCRIPTION
@RabsRincon I think this may be the cleanest option of setting the syntax highlighting language for the AST and Opt views.
The language of the Opt view is logically the same as the compiler's language (the editor's language). For the AST view, `compiler` could get another attribute `astLangId` or something like that to get correct highlighting, because the AST "language" may be quite different from the source language.
Saving that for later work though.