### PR TITLE
Go Fix <unknown line number> lines

### DIFF
--- a/lib/compilers/golang.js
+++ b/lib/compilers/golang.js
@@ -28,12 +28,13 @@ const BaseCompiler = require('../base-compiler'),
 class GolangCompiler extends BaseCompiler {
     convertNewGoL(code) {
         const re = /^\s+(0[xX]?[0-9A-Za-z]+)?\s?[0-9]+\s*\(([^:]+):([0-9]+)\)\s*([A-Z]+)(.*)/;
+        const reUnknown = /^\s+(0[xX]?[0-9A-Za-z]+)?\s?[0-9]+\s*\(<unknown line number>)\s*([A-Z]+)(.*)/;
         let prevLine = null;
         let file = null;
         let fileCount = 0;
         return _.compact(code.map(obj => {
             const line = obj.text;
-            const match = line.match(re);
+            let match = line.match(re);
             if (match) {
                 let res = "";
                 if (file !== match[2]) {
@@ -46,8 +47,15 @@ class GolangCompiler extends BaseCompiler {
                     prevLine = match[3];
                 }
                 return res + "\t" + match[4].toLowerCase() + match[5];
-            } else
-                return null;
+            } else {
+                match = line.match(reUnknown);
+                if (match) {
+                    return "\t" + match[2].toLowerCase() + match[3];
+                } else {
+                    return null;
+                }
+            }
+                
         })).join("\n");
     }
 

--- a/lib/compilers/golang.js
+++ b/lib/compilers/golang.js
@@ -28,7 +28,7 @@ const BaseCompiler = require('../base-compiler'),
 class GolangCompiler extends BaseCompiler {
     convertNewGoL(code) {
         const re = /^\s+(0[xX]?[0-9A-Za-z]+)?\s?[0-9]+\s*\(([^:]+):([0-9]+)\)\s*([A-Z]+)(.*)/;
-        const reUnknown = /^\s+(0[xX]?[0-9A-Za-z]+)?\s?[0-9]+\s*\(<unknown line number>)\s*([A-Z]+)(.*)/;
+        const reUnknown = /^\s+(0[xX]?[0-9A-Za-z]+)?\s?[0-9]+\s*\(<unknown line number>\)\s*([A-Z]+)(.*)/;
         let prevLine = null;
         let file = null;
         let fileCount = 0;

--- a/test/golang-tests.js
+++ b/test/golang-tests.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Patrick Quist
+// Copyright (c) 2018, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -39,7 +39,7 @@ const ce = new CompilationEnvironment(props);
 const info = {
     "exe": null,
     "remote": true,
-    "lang": "pascal"
+    "lang": "go"
 };
 
 ce.compilerPropsL = function (lang, property, defaultValue) {

--- a/test/golang-tests.js
+++ b/test/golang-tests.js
@@ -1,0 +1,76 @@
+// Copyright (c) 2018, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const chai = require('chai'),
+    chaiAsPromised = require("chai-as-promised"),
+    fs = require('fs-extra'),
+    utils = require('../lib/utils'),
+    logger = require('../lib/logger').logger,
+    CompilationEnvironment = require('../lib/compilation-env'),
+    GoCompiler = require('../lib/compilers/golang');
+
+chai.use(chaiAsPromised);
+chai.should();
+
+const props = (key, deflt) => deflt;
+
+const ce = new CompilationEnvironment(props);
+const info = {
+    "exe": null,
+    "remote": true,
+    "lang": "pascal"
+};
+
+ce.compilerPropsL = function (lang, property, defaultValue) {
+    return "";
+};
+
+function testGoAsm(basefilename) {
+    const compiler = new GoCompiler(info, ce);
+
+    const asmLines = utils.splitLines(fs.readFileSync(basefilename + ".asm").toString());
+
+    const result = {
+        stdout: asmLines.map((line) => {
+            return {
+                text: line
+            };
+        })
+    };
+
+    return compiler.postProcess(result).then((output) => {
+        const expectedOutput = utils.splitLines(fs.readFileSync(basefilename + ".output.asm").toString()).join("\n");
+
+        return output.should.deep.equal({
+            asm: expectedOutput,
+            stdout: []
+        });
+    });
+}
+
+describe('GO asm tests', () => {
+    it('Handles unknown line number correctly', () => {
+        return testGoAsm("test/golang/bug-901");
+    });
+});

--- a/test/golang/bug-901.asm
+++ b/test/golang/bug-901.asm
@@ -1,0 +1,20 @@
+"".Fun STEXT nosplit size=14 args=0x0 locals=0x0
+	0x0000 00000 (test.go:3)	TEXT	"".Fun(SB), NOSPLIT, $0-0
+	0x0000 00000 (test.go:3)	FUNCDATA	$0, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
+	0x0000 00000 (test.go:3)	FUNCDATA	$1, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
+	0x0000 00000 (test.go:3)	XORL	AX, AX
+	0x0002 00002 (test.go:4)	JMP	7
+	0x0004 00004 (test.go:4)	INCQ	AX
+	0x0007 00007 (test.go:4)	CMPQ	AX, $10
+	0x000b 00011 (test.go:4)	JLT	4
+	0x000d 00013 (<unknown line number>)	RET
+	0x0000 31 c0 eb 03 48 ff c0 48 83 f8 0a 7c f7 c3        1...H..H...|..
+go.info."".Fun SDWARFINFO size=32
+	0x0000 02 22 22 2e 46 75 6e 00 00 00 00 00 00 00 00 00  ."".Fun.........
+	0x0010 00 00 00 00 00 00 00 00 01 9c 00 00 00 00 01 00  ................
+	rel 8+8 t=1 "".Fun+0
+	rel 16+8 t=1 "".Fun+14
+	rel 26+4 t=29 gofile../workspace/go/src/gopractice/io/test.go+0
+go.range."".Fun SDWARFRANGE size=0
+gclocals·33cdeccccebe80329f1fdbee7f5874cb SRODATA dupok size=8
+	0x0000 01 00 00 00 00 00 00 00                          ........

--- a/test/golang/bug-901.output.asm
+++ b/test/golang/bug-901.output.asm
@@ -1,0 +1,12 @@
+	.file 1 "test.go"
+	.loc 1 3 0
+	text	"".Fun(SB), NOSPLIT, $0-0
+	funcdata	$0, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
+	funcdata	$1, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB)
+	xorl	AX, AX
+	.loc 1 4 0
+	jmp	7
+	incq	AX
+	cmpq	AX, $10
+	jlt	4
+	ret


### PR DESCRIPTION
Fixes unknown line number causing asm cut-offs from Go 1.10 output (issued raised in #901)