### PR TITLE
Demangling changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -288,7 +288,6 @@ function ClientOptionsHandler(fileSources) {
         compileOptions: compilerPropsA(languages, 'defaultOptions', ''),
         supportsBinary: supportsBinary,
         supportsExecute: supportsExecute,
-        demanglerClassFile: props("demanglerClassFile", ""),
         languages: languages,
         sources: sources,
         raven: ceProps('ravenUrl', ''),

--- a/app.js
+++ b/app.js
@@ -315,6 +315,7 @@ function ClientOptionsHandler(fileSources) {
     this.get = () => options;
 }
 
+            demanglerClassFile: props("demanglerClassFile", ""),
 function shortUrlHandler(req, res, next) {
     const resolver = new google.ShortLinkResolver(aws.getConfig('googleApiKey'));
     const bits = req.url.split("/");

--- a/app.js
+++ b/app.js
@@ -288,6 +288,7 @@ function ClientOptionsHandler(fileSources) {
         compileOptions: compilerPropsA(languages, 'defaultOptions', ''),
         supportsBinary: supportsBinary,
         supportsExecute: supportsExecute,
+        demanglerClassFile: props("demanglerClassFile", ""),
         languages: languages,
         sources: sources,
         raven: ceProps('ravenUrl', ''),
@@ -315,7 +316,6 @@ function ClientOptionsHandler(fileSources) {
     this.get = () => options;
 }
 
-            demanglerClassFile: props("demanglerClassFile", ""),
 function shortUrlHandler(req, res, next) {
     const resolver = new google.ShortLinkResolver(aws.getConfig('googleApiKey'));
     const bits = req.url.split("/");

--- a/etc/config/c++.defaults.properties
+++ b/etc/config/c++.defaults.properties
@@ -4,6 +4,7 @@ compilers=/usr/bin/g++-4.4:/usr/bin/g++-4.5:/usr/bin/g++-4.6:/usr/bin/g++-4.7:/u
 defaultCompiler=/usr/bin/g++
 postProcess=
 demangler=c++filt
+demanglerClassFile=demangler-cpp
 objdumper=objdump
 #androidNdk=/opt/google/android-ndk-r9c
 options=
@@ -26,6 +27,9 @@ group.cl.compilerType=WSL-CL
 group.cl.includeFlag=/I
 group.cl.versionFlag=/?
 group.cl.versionRe=^Microsoft \(R\) C/C\+\+.*$
+
+group.cl.demanglerClassFile=cl-support
+
 #group.cl19.compilers=cl19_64:cl19_32:cl19_arm
 #group.cl19.options=/I/opt/compiler-explorer/windows/10.0.10240.0/ucrt/ /I/opt/compiler-explorer/windows/19.10.25017/lib/native/include/
 #compiler.cl19_64.exe=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64/cl.exe

--- a/etc/config/c++.defaults.properties
+++ b/etc/config/c++.defaults.properties
@@ -4,7 +4,7 @@ compilers=/usr/bin/g++-4.4:/usr/bin/g++-4.5:/usr/bin/g++-4.6:/usr/bin/g++-4.7:/u
 defaultCompiler=/usr/bin/g++
 postProcess=
 demangler=c++filt
-demanglerClassFile=demangler-cpp
+demanglerClassFile=./demangler-cpp
 objdumper=objdump
 #androidNdk=/opt/google/android-ndk-r9c
 options=
@@ -28,7 +28,7 @@ group.cl.includeFlag=/I
 group.cl.versionFlag=/?
 group.cl.versionRe=^Microsoft \(R\) C/C\+\+.*$
 
-group.cl.demanglerClassFile=cl-support
+group.cl.demanglerClassFile=./cl-support
 
 #group.cl19.compilers=cl19_64:cl19_32:cl19_arm
 #group.cl19.options=/I/opt/compiler-explorer/windows/10.0.10240.0/ucrt/ /I/opt/compiler-explorer/windows/19.10.25017/lib/native/include/

--- a/etc/config/compiler-explorer.defaults.properties
+++ b/etc/config/compiler-explorer.defaults.properties
@@ -13,6 +13,8 @@ allowedShortUrlHostRe=^([-a-z.]+\.)?(xania|godbolt)\.org$
 googleShortLinkRewrite=^https?://goo.gl/(.*)$|https://godbolt.org/g/$1
 urlShortenService=none
 
+demanglerClassFile=demangler
+
 wine=/opt/wine-devel/bin/wine64
 python3=/usr/bin/python3
 

--- a/etc/config/compiler-explorer.defaults.properties
+++ b/etc/config/compiler-explorer.defaults.properties
@@ -13,7 +13,7 @@ allowedShortUrlHostRe=^([-a-z.]+\.)?(xania|godbolt)\.org$
 googleShortLinkRewrite=^https?://goo.gl/(.*)$|https://godbolt.org/g/$1
 urlShortenService=none
 
-demanglerClassFile=demangler
+demanglerClassFile=./demangler
 
 wine=/opt/wine-devel/bin/wine64
 python3=/usr/bin/python3

--- a/etc/config/pascal.defaults.properties
+++ b/etc/config/pascal.defaults.properties
@@ -8,7 +8,7 @@ options=
 versionFlag=-h | grep "Compiler version" 
 supportsBinary=true
 compilerType=pascal
-demanglerClassFile=pascal-support
+demanglerClassFile=../pascal-support
 
 #################################
 #################################

--- a/etc/config/pascal.defaults.properties
+++ b/etc/config/pascal.defaults.properties
@@ -8,6 +8,7 @@ options=
 versionFlag=-h | grep "Compiler version" 
 supportsBinary=true
 compilerType=pascal
+demanglerClassFile=pascal-support
 
 #################################
 #################################

--- a/lib/asm-raw.js
+++ b/lib/asm-raw.js
@@ -23,9 +23,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 "use strict";
 
-const
-    utils = require("./utils");
-
 class AsmRaw {
     constructor() {
     }

--- a/lib/asm-raw.js
+++ b/lib/asm-raw.js
@@ -23,6 +23,9 @@
 // POSSIBILITY OF SUCH DAMAGE.
 "use strict";
 
+const
+    utils = require("./utils");
+
 class AsmRaw {
     constructor() {
     }

--- a/lib/asm-raw.js
+++ b/lib/asm-raw.js
@@ -23,8 +23,11 @@
 // POSSIBILITY OF SUCH DAMAGE.
 "use strict";
 
-class AsmRaw {
+const AsmRegex = require('./asmregex').AsmRegex;
+
+class AsmRaw extends AsmRegex {
     constructor() {
+        super();
     }
 
     filterAsmLine(line, filters) {
@@ -42,7 +45,6 @@ class AsmRaw {
         let result = [];
         const asmLines = asm.split("\n");
         const asmOpcodeRe = /^\s*([0-9a-f]+):\s*(([0-9a-f][0-9a-f] ?)+)\s*(.*)/;
-        const labelDef = /^([.a-zA-Z_$@][a-zA-Z0-9$_.]*):/;
         const labelRe = /^([0-9a-f]+)\s+<([^>]+)>:$/;
         const destRe = /.*\s([0-9a-f]+)\s+<([^>]+)>$/;
         let source = null;
@@ -57,7 +59,7 @@ class AsmRaw {
                 result.push({text: match[2] + ":", source: null});
                 return;
             } else {
-                match = line.match(labelDef);
+                match = line.match(this.labelDef);
                 if (match) {
                     result.push({text: match[1] + ":", source: null});
                     return;

--- a/lib/asm.js
+++ b/lib/asm.js
@@ -23,10 +23,13 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 const _ = require('underscore-node'),
-    utils = require('./utils');
+    utils = require('./utils'),
+    AsmRegex = require('./asmregex').AsmRegex;
 
-class AsmParser {
+class AsmParser extends AsmRegex {
     constructor(compilerProps) {
+        super();
+
         this.labelFindNonMips = /[.a-zA-Z_][a-zA-Z0-9$_.]*/g;
         // MIPS labels can start with a $ sign, but other assemblers use $ to mean literal.
         this.labelFindMips = /[$.a-zA-Z_][a-zA-Z0-9$_.]*/g;
@@ -36,7 +39,6 @@ class AsmParser {
         this.hasOpcodeRe = /^\s*[a-zA-Z]/;
         this.definesFunction = /^\s*\.type.*,\s*[@%]function$/;
         this.definesGlobal = /^\s*\.globa?l\s*([.a-zA-Z_][a-zA-Z0-9$_.]*)/;
-        this.labelDef = /^([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
         this.indentedLabelDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
         this.assignmentDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]+)\s*=/;
         this.directive = /^\s*\..*$/;

--- a/lib/asmregex.js
+++ b/lib/asmregex.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2018, Compiler Explorer Team
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+class AsmRegex {
+    constructor() {
+        this.labelDef = /^([.a-z_$@][a-z0-9$_@.]*):/i;
+    }
+}
+
+exports.AsmRegex = AsmRegex;

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -89,7 +89,8 @@ class BaseCompiler {
             timeoutMs: this.env.ceProps("compileTimeoutMs", 7500),
             maxErrorOutput: this.env.ceProps("max-error-output", 5000),
             env: this.env.getEnv(this.compiler.needsMulti),
-            wrapper: this.compilerProps("compiler-wrapper")
+            wrapper: this.compilerProps("compiler-wrapper"),
+            wrapperOptions: this.compilerProps("compiler-wrapper-options")
         };
     }
 

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -372,7 +372,7 @@ class BaseCompiler {
         const demanglerClass = require(demanglerClassFile).Demangler;
 
         const demangler = new demanglerClass(demanglerExe, null, this);
-        return demangler.Process(result);
+        return demangler.process(result);
     }
 
     processOptOutput(hasOptOutput, optPath) {

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -368,10 +368,9 @@ class BaseCompiler {
         const demanglerExe = this.compiler.demangler;
         if (!demanglerExe) return result;
 
-        const demanglerClassFile = this.compilerProps("demanglerClassFile");
-        const demanglerClass = require(demanglerClassFile).Demangler;
+        const demanglerClass = require(this.compiler.demanglerClassFile).Demangler;
 
-        const demangler = new demanglerClass(demanglerExe, null, this);
+        const demangler = new demanglerClass(demanglerExe, this);
         return demangler.process(result);
     }
 

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -35,7 +35,8 @@ const temp = require('temp'),
     argumentParsers = require("./compilers/argument-parsers"),
     cfg = require('./cfg'),
     languages = require('./languages').list,
-    Demangler = require('./demangler').Demangler;
+    Demangler = require('./demangler').Demangler,
+    DemanglerCPP = require('./demangler-cpp').DemanglerCPP;
 
 class BaseCompiler {
     constructor(compiler, env) {
@@ -370,7 +371,10 @@ class BaseCompiler {
         const demanglerExe = this.compiler.demangler;
         if (!demanglerExe) return result;
 
-        const demangler = new Demangler(demanglerExe);
+        let demangler = null;
+        if (this.lang === "c++") demangler = new DemanglerCPP(demanglerExe);
+        else demangler = new Demangler(demanglerExe);
+
         return demangler.Process(result);
     }
 

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -34,9 +34,7 @@ const temp = require('temp'),
     compilerOptInfo = require("compiler-opt-info"),
     argumentParsers = require("./compilers/argument-parsers"),
     cfg = require('./cfg'),
-    languages = require('./languages').list,
-    Demangler = require('./demangler').Demangler,
-    DemanglerCPP = require('./demangler-cpp').DemanglerCPP;
+    languages = require('./languages').list;
 
 class BaseCompiler {
     constructor(compiler, env) {
@@ -370,11 +368,10 @@ class BaseCompiler {
         const demanglerExe = this.compiler.demangler;
         if (!demanglerExe) return result;
 
-        let demangler = null;
+        const demanglerClassFile = this.compilerProps("demanglerClassFile");
+        const demanglerClass = require(demanglerClassFile).Demangler;
 
-        if (this.lang.id === "c++") demangler = new DemanglerCPP(demanglerExe);
-        else demangler = new Demangler(demanglerExe);
-
+        const demangler = new demanglerClass(demanglerExe, null, this);
         return demangler.Process(result);
     }
 

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -371,7 +371,8 @@ class BaseCompiler {
         if (!demanglerExe) return result;
 
         let demangler = null;
-        if (this.lang === "c++") demangler = new DemanglerCPP(demanglerExe);
+
+        if (this.lang.id === "c++") demangler = new DemanglerCPP(demanglerExe);
         else demangler = new Demangler(demanglerExe);
 
         return demangler.Process(result);

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -34,7 +34,8 @@ const temp = require('temp'),
     compilerOptInfo = require("compiler-opt-info"),
     argumentParsers = require("./compilers/argument-parsers"),
     cfg = require('./cfg'),
-    languages = require('./languages').list;
+    languages = require('./languages').list,
+    Demangler = require('./demangler').Demangler;
 
 class BaseCompiler {
     constructor(compiler, env) {
@@ -365,15 +366,11 @@ class BaseCompiler {
 
     postProcessAsm(result) {
         if (!result.okToCache) return result;
-        const demangler = this.compiler.demangler;
-        if (!demangler) return result;
-        return this.exec(demangler, [], {input: _.pluck(result.asm, 'text').join("\n")})
-            .then((demangleResult) => {
-                const lines = utils.splitLines(demangleResult.stdout);
-                for (let i = 0; i < result.asm.length; ++i)
-                    result.asm[i].text = lines[i];
-                return result;
-            });
+        const demanglerExe = this.compiler.demangler;
+        if (!demanglerExe) return result;
+
+        const demangler = new Demangler(demanglerExe);
+        return demangler.Process(result);
     }
 
     processOptOutput(hasOptOutput, optPath) {

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -90,8 +90,7 @@ class BaseCompiler {
             timeoutMs: this.env.ceProps("compileTimeoutMs", 7500),
             maxErrorOutput: this.env.ceProps("max-error-output", 5000),
             env: this.env.getEnv(this.compiler.needsMulti),
-            wrapper: this.compilerProps("compiler-wrapper"),
-            wrapperOptions: this.compilerProps("compiler-wrapper-options")
+            wrapper: this.compilerProps("compiler-wrapper")
         };
     }
 

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -27,7 +27,8 @@
 const fs = require('fs-extra'),
     path = require('path'),
     _ = require('underscore-node'),
-    utils = require('./utils');
+    utils = require('./utils'),
+    Demangler = require("./demangler").Demangler;
 
 function OverwriteAsmLines(result, demangleOutput) {
     const lines = utils.splitLines(demangleOutput);
@@ -62,6 +63,10 @@ function RunCLDemangler(compiler, result) {
         return compiler.exec(demangler, [], {input: asmFileContent})
             .then(demangleResult => OverwriteAsmLines(result, demangleResult.stdout));
     }
+}
+
+class CLDemangler extends Demangler {
+
 }
 
 exports.RunCLDemangler = RunCLDemangler;

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -32,9 +32,9 @@ class CLDemangler extends DemanglerCPP {
     constructor(demanglerExe, compiler) {
         super(demanglerExe, compiler);
 
-        this.labelDef = /^([.a-z_$?]+[a-z0-9$_.@]*)\sPROC.*/i;
+        this.labelDef = /^([.a-z_$?]+[a-z0-9$_.@]*)(?::|\sproc)+.*/i;
         this.jumpDef = /(j.+|b|bl|blx)\s+([.a-z_$?]+[a-z0-9$_.@]*)/i;
-        this.callDef = /(call|mov|lea|EXTRN)[a-z]*\s+([a-z0-9_$?]+[a-z0-9$_@]*)/i;
+        this.callDef = /(call|mov|lea|extrn)[a-z]*\s+([a-z0-9_$?]+[a-z0-9$_@]*)/i;
     }
 
     execDemangler(options) {

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -26,7 +26,7 @@
 
 const fs = require('fs-extra'),
     path = require('path'),
-    DemanglerCPP = require("./demangler-cpp").DemanglerCPP;
+    DemanglerCPP = require("./demangler-cpp").Demangler;
 
 class CLDemangler extends DemanglerCPP {
     constructor(demanglerExe, symbolstore, compiler) {

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -43,9 +43,9 @@ class CLDemangler extends DemanglerCPP {
 
         this.compiler = compiler;
 
-        this.labelDef = /^([.a-z_$][a-z0-9$_.]*):/i;
-        this.jumpDef = /j.+\s+([.a-z_$\?][a-z0-9$_.@]*)/i;
-        this.callDef = /(call|mov|lea).+\s+([.a-z_$\?][a-z0-9$_.@]*)/i;
+        this.labelDef = /^([.a-z_$\?]+[a-z0-9$_.@]*)\sPROC.*/i;
+        this.jumpDef = /j.+\s+([.a-z_$\?]+[a-z0-9$_.@]*)/i;
+        this.callDef = /(call|mov|lea|EXTRN).+\s+([.a-z_$\?]+[a-z0-9$_.@]*)/i;
     }
 
     ExecDemangler(options) {

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -61,4 +61,4 @@ class CLDemangler extends DemanglerCPP {
     }
 }
 
-exports.CLDemangler = CLDemangler;
+exports.Demangler = CLDemangler;

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -37,36 +37,37 @@ function OverwriteAsmLines(result, demangleOutput) {
     return result;
 }
 
-function RunCLDemangler(compiler, result) {
-    if (!result.okToCache) return result;
-    let demangler = compiler.compiler.demangler;
-    if (!demangler) return result;
+class CLDemangler extends DemanglerCPP {
+    constructor(demanglerExe, symbolstore, compiler) {
+        super(demanglerExe, symbolstore);
 
-    const asmFileContent = _.pluck(result.asm, 'text').join("\n");
+        this.compiler = compiler;
 
-    if (demangler.toLowerCase().endsWith("undname.exe")) {
-        return compiler.newTempDir().then(tmpDir => {
-            const tmpfile = path.join(tmpDir, "output.s");
-            fs.writeFileSync(tmpfile, asmFileContent);
+        this.labelDef = /^([.a-z_$][a-z0-9$_.]*):/i;
+        this.jumpDef = /j.+\s+([.a-z_$\?][a-z0-9$_.@]*)/i;
+        this.callDef = /(call|mov|lea).+\s+([.a-z_$\?][a-z0-9$_.@]*)/i;
+    }
 
-            const tmpFileAsArgument = compiler.filename(tmpfile);
+    ExecDemangler(options) {
+        if (this.demanglerExe.toLowerCase().endsWith("undname.exe")) {
+            return this.compiler.newTempDir().then(tmpDir => {
+                const tmpfile = path.join(tmpDir, "output.s");
+                fs.writeFileSync(tmpfile, options.input);
 
-            return compiler.exec(demangler, [tmpFileAsArgument], compiler.getDefaultExecOptions())
-                .then(demangleResult => {
-                    fs.unlink(tmpfile, () => {
-                        fs.remove(tmpDir, () => {});
+                const tmpFileAsArgument = this.compiler.filename(tmpfile);
+
+                return this.compiler.exec(this.demanglerExe, [tmpFileAsArgument], this.compiler.getDefaultExecOptions())
+                    .then(demangleResult => {
+                        fs.unlink(tmpfile, () => {
+                            fs.remove(tmpDir, () => {});
+                        });
+                        return demangleResult;
                     });
-                    return OverwriteAsmLines(result, demangleResult.stdout);
-                });
-        });
-    } else {
-        return compiler.exec(demangler, [], {input: asmFileContent})
-            .then(demangleResult => OverwriteAsmLines(result, demangleResult.stdout));
+            });
+        } else {
+            return this.compiler.exec(this.demanglerExe, [], {input: options.input});
+        }
     }
 }
 
-class CLDemangler extends DemanglerCPP {
-
-}
-
-exports.RunCLDemangler = RunCLDemangler;
+exports.CLDemangler = CLDemangler;

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -29,14 +29,12 @@ const fs = require('fs-extra'),
     DemanglerCPP = require("./demangler-cpp").Demangler;
 
 class CLDemangler extends DemanglerCPP {
-    constructor(demanglerExe, symbolstore, compiler) {
-        super(demanglerExe, symbolstore);
-
-        this.compiler = compiler;
+    constructor(demanglerExe, compiler) {
+        super(demanglerExe, compiler);
 
         this.labelDef = /^([.a-z_$?]+[a-z0-9$_.@]*)\sPROC.*/i;
         this.jumpDef = /j.+\s+([.a-z_$?]+[a-z0-9$_.@]*)/i;
-        this.callDef = /(call|mov|lea|EXTRN).+\s+([.a-z_$?]+[a-z0-9$_.@]*)/i;
+        this.callDef = /(call|mov|lea|EXTRN)[a-z]*\s+([a-z0-9_$?]+[a-z0-9$_@]*)/i;
     }
 
     execDemangler(options) {

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -39,7 +39,7 @@ class CLDemangler extends DemanglerCPP {
         this.callDef = /(call|mov|lea|EXTRN).+\s+([.a-z_$?]+[a-z0-9$_.@]*)/i;
     }
 
-    ExecDemangler(options) {
+    execDemangler(options) {
         if (this.demanglerExe.toLowerCase().endsWith("undname.exe")) {
             return this.compiler.newTempDir().then(tmpDir => {
                 const tmpfile = path.join(tmpDir, "output.s");

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -28,7 +28,7 @@ const fs = require('fs-extra'),
     path = require('path'),
     _ = require('underscore-node'),
     utils = require('./utils'),
-    Demangler = require("./demangler").Demangler;
+    DemanglerCPP = require("./demangler-cpp").DemanglerCPP;
 
 function OverwriteAsmLines(result, demangleOutput) {
     const lines = utils.splitLines(demangleOutput);
@@ -65,7 +65,7 @@ function RunCLDemangler(compiler, result) {
     }
 }
 
-class CLDemangler extends Demangler {
+class CLDemangler extends DemanglerCPP {
 
 }
 

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -56,7 +56,7 @@ class CLDemangler extends DemanglerCPP {
                     });
             });
         } else {
-            return this.compiler.exec(this.demanglerExe, [], {input: options.input});
+            return super.execDemangler(options);
         }
     }
 }

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -26,16 +26,7 @@
 
 const fs = require('fs-extra'),
     path = require('path'),
-    _ = require('underscore-node'),
-    utils = require('./utils'),
     DemanglerCPP = require("./demangler-cpp").DemanglerCPP;
-
-function OverwriteAsmLines(result, demangleOutput) {
-    const lines = utils.splitLines(demangleOutput);
-    for (let i = 0; i < result.asm.length; ++i)
-        result.asm[i].text = lines[i];
-    return result;
-}
 
 class CLDemangler extends DemanglerCPP {
     constructor(demanglerExe, symbolstore, compiler) {
@@ -43,9 +34,9 @@ class CLDemangler extends DemanglerCPP {
 
         this.compiler = compiler;
 
-        this.labelDef = /^([.a-z_$\?]+[a-z0-9$_.@]*)\sPROC.*/i;
-        this.jumpDef = /j.+\s+([.a-z_$\?]+[a-z0-9$_.@]*)/i;
-        this.callDef = /(call|mov|lea|EXTRN).+\s+([.a-z_$\?]+[a-z0-9$_.@]*)/i;
+        this.labelDef = /^([.a-z_$?]+[a-z0-9$_.@]*)\sPROC.*/i;
+        this.jumpDef = /j.+\s+([.a-z_$?]+[a-z0-9$_.@]*)/i;
+        this.callDef = /(call|mov|lea|EXTRN).+\s+([.a-z_$?]+[a-z0-9$_.@]*)/i;
     }
 
     ExecDemangler(options) {

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -33,7 +33,7 @@ class CLDemangler extends DemanglerCPP {
         super(demanglerExe, compiler);
 
         this.labelDef = /^([.a-z_$?]+[a-z0-9$_.@]*)\sPROC.*/i;
-        this.jumpDef = /j.+\s+([.a-z_$?]+[a-z0-9$_.@]*)/i;
+        this.jumpDef = /(j.+|b|bl|blx)\s+([.a-z_$?]+[a-z0-9$_.@]*)/i;
         this.callDef = /(call|mov|lea|EXTRN)[a-z]*\s+([a-z0-9_$?]+[a-z0-9$_@]*)/i;
     }
 

--- a/lib/cl-support.js
+++ b/lib/cl-support.js
@@ -32,7 +32,7 @@ class CLDemangler extends DemanglerCPP {
     constructor(demanglerExe, compiler) {
         super(demanglerExe, compiler);
 
-        this.labelDef = /^([.a-z_$?]+[a-z0-9$_.@]*)(?::|\sproc)+.*/i;
+        this.labelDef = /^([.a-z_$?]+[a-z0-9$_.@]*)\sproc.*/i;
         this.jumpDef = /(j.+|b|bl|blx)\s+([.a-z_$?]+[a-z0-9$_.@]*)/i;
         this.callDef = /(call|mov|lea|extrn)[a-z]*\s+([a-z0-9_$?]+[a-z0-9$_@]*)/i;
     }

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -123,6 +123,7 @@ class CompilerFinder {
             versionRe: props("versionRe"),
             compilerType: props("compilerType", ""),
             demangler: demangler,
+            demanglerClassFile: props("demanglerClassFile", ""),
             objdumper: props("objdumper", ""),
             intelAsm: props("intelAsm", ""),
             needsMulti: !!props("needsMulti", true),

--- a/lib/compilers/WSL-CL.js
+++ b/lib/compilers/WSL-CL.js
@@ -31,7 +31,6 @@
 const BaseCompiler = require('../base-compiler'),
     asmCl = require('../asm-cl'),
     temp = require('temp'),
-    CLDemangler = require('../cl-support').CLDemangler,
     argumentParsers = require("./argument-parsers");
 
 class WSLCLCompiler extends BaseCompiler {
@@ -74,15 +73,6 @@ class WSLCLCompiler extends BaseCompiler {
 
     getArgumentParser() {
         return argumentParsers.Base;
-    }
-
-    postProcessAsm(result) {
-        if (!result.okToCache) return result;
-        const demanglerExe = this.compiler.demangler;
-        if (!demanglerExe) return result;
-
-        const demangler = new CLDemangler(demanglerExe, null, this);
-        return demangler.Process(result);
     }
 
     optionsForFilter(filters, outputFilename) {

--- a/lib/compilers/WSL-CL.js
+++ b/lib/compilers/WSL-CL.js
@@ -31,7 +31,7 @@
 const BaseCompiler = require('../base-compiler'),
     asmCl = require('../asm-cl'),
     temp = require('temp'),
-    RunCLDemangler = require('../cl-support').RunCLDemangler,
+    CLDemangler = require('../cl-support').CLDemangler,
     argumentParsers = require("./argument-parsers");
 
 class WSLCLCompiler extends BaseCompiler {
@@ -77,7 +77,12 @@ class WSLCLCompiler extends BaseCompiler {
     }
 
     postProcessAsm(result) {
-        return RunCLDemangler(this, result);
+        if (!result.okToCache) return result;
+        const demanglerExe = this.compiler.demangler;
+        if (!demanglerExe) return result;
+
+        const demangler = new CLDemangler(demanglerExe, null, this);
+        return demangler.Process(result);
     }
 
     optionsForFilter(filters, outputFilename) {

--- a/lib/compilers/Wine-CL.js
+++ b/lib/compilers/Wine-CL.js
@@ -24,7 +24,7 @@
 
 const BaseCompiler = require('../base-compiler'),
     asmCl = require('../asm-cl'),
-    RunCLDemangler = require('../cl-support').RunCLDemangler,
+    CLDemangler = require('../cl-support').CLDemangler,
     argumentParsers = require("./argument-parsers");
 
 
@@ -56,7 +56,12 @@ class CLCompiler extends BaseCompiler {
     }
 
     postProcessAsm(result) {
-        return RunCLDemangler(this, result);
+        if (!result.okToCache) return result;
+        const demanglerExe = this.compiler.demangler;
+        if (!demanglerExe) return result;
+
+        const demangler = new CLDemangler(demanglerExe, null, this);
+        return demangler.Process(result);
     }
 
     optionsForFilter(filters, outputFilename) {

--- a/lib/compilers/Wine-CL.js
+++ b/lib/compilers/Wine-CL.js
@@ -24,7 +24,6 @@
 
 const BaseCompiler = require('../base-compiler'),
     asmCl = require('../asm-cl'),
-    CLDemangler = require('../cl-support').CLDemangler,
     argumentParsers = require("./argument-parsers");
 
 
@@ -53,15 +52,6 @@ class CLCompiler extends BaseCompiler {
 
     getArgumentParser() {
         return argumentParsers.Base;
-    }
-
-    postProcessAsm(result) {
-        if (!result.okToCache) return result;
-        const demanglerExe = this.compiler.demangler;
-        if (!demanglerExe) return result;
-
-        const demangler = new CLDemangler(demanglerExe, null, this);
-        return demangler.Process(result);
     }
 
     optionsForFilter(filters, outputFilename) {

--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -34,7 +34,7 @@ class FPCCompiler extends BaseCompiler {
     constructor(info, env) {
         super(info, env);
 
-        let demanglerClassFile = this.compilerProps("demanglerClassFile");
+        let demanglerClassFile = this.compiler.demanglerClassFile;
         if (!demanglerClassFile) demanglerClassFile = "../pascal-support";
         const demanglerClass = require(demanglerClassFile).Demangler;
 

--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -24,7 +24,6 @@
 "use strict";
 
 const BaseCompiler = require('../base-compiler'),
-    PascalDemangler = require('../pascal-support').demangler,
     utils = require('../utils'),
     _ = require('underscore-node'),
     fs = require("fs"),
@@ -34,7 +33,7 @@ const BaseCompiler = require('../base-compiler'),
 class FPCCompiler extends BaseCompiler {
     constructor(info, env) {
         super(info, env);
-        this.demangler = new PascalDemangler();
+        this.demangler = require(this.compilerProps("demanglerClassFile")).Demangler;
         this.compileFilename = 'output.pas';
         this.supportsOptOutput = false;
     }

--- a/lib/compilers/pascal.js
+++ b/lib/compilers/pascal.js
@@ -33,7 +33,12 @@ const BaseCompiler = require('../base-compiler'),
 class FPCCompiler extends BaseCompiler {
     constructor(info, env) {
         super(info, env);
-        this.demangler = require(this.compilerProps("demanglerClassFile")).Demangler;
+
+        let demanglerClassFile = this.compilerProps("demanglerClassFile");
+        if (!demanglerClassFile) demanglerClassFile = "../pascal-support";
+        const demanglerClass = require(demanglerClassFile).Demangler;
+
+        this.demangler = new demanglerClass(null, null, this);
         this.compileFilename = 'output.pas';
         this.supportsOptOutput = false;
     }

--- a/lib/demangler-cpp.js
+++ b/lib/demangler-cpp.js
@@ -49,4 +49,4 @@ class DemanglerCPP extends Demangler {
     }
 }
 
-exports.DemanglerCPP = DemanglerCPP;
+exports.Demangler = DemanglerCPP;

--- a/lib/demangler-cpp.js
+++ b/lib/demangler-cpp.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2018, Patrick Quist
+// Copyright (c) 2018, Patrick Quist
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -53,3 +53,5 @@ class DemanglerCPP extends Demangler {
         return metadata;
     }
 }
+
+exports.DemanglerCPP = DemanglerCPP;

--- a/lib/demangler-cpp.js
+++ b/lib/demangler-cpp.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Patrick Quist
+// Copyright (c) 2018, Compiler Explorer Team
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/lib/demangler-cpp.js
+++ b/lib/demangler-cpp.js
@@ -36,7 +36,7 @@ const LabelMetadata = [
 ];
 
 class DemanglerCPP extends Demangler {
-    GetMetadata(symbol) {
+    getMetadata(symbol) {
         let metadata = [];
 
         for (let i = 0; i < LabelMetadata.length; ++i) {

--- a/lib/demangler-cpp.js
+++ b/lib/demangler-cpp.js
@@ -1,0 +1,44 @@
+// Copyright (c) 2012-2018, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+const
+    SymbolStore = require('./symbol-store').SymbolStore,
+    _ = require('underscore-node'),
+    utils = require('../lib/utils'),
+    exec = require('../lib/exec'),
+    logger = require('../lib/logger').logger,
+    Demangler = require("./demangler").Demangler;
+
+const LabelMetadata = [
+    {'ident': 'C1', 'description': 'complete object constructor'},
+    {'ident': 'C2', 'description': 'base object constructor'},
+    {'ident': 'C3', 'description': 'complete object allocating constructor'},
+    {'ident': 'D0', 'description': 'deleting destructor'},
+    {'ident': 'D1', 'description': 'complete object destructor'},
+    {'ident': 'D2', 'description': 'base object destructor'}
+];
+
+class DemanglerCPP extends Demangler {
+}

--- a/lib/demangler-cpp.js
+++ b/lib/demangler-cpp.js
@@ -41,4 +41,15 @@ const LabelMetadata = [
 ];
 
 class DemanglerCPP extends Demangler {
+    GetMetadata(symbol) {
+        let metadata = [];
+
+        for (let i = 0; i < LabelMetadata.length; ++i) {
+            if (symbol.includes(LabelMetadata[i].ident)) {
+                metadata.push(LabelMetadata[i]);
+            }
+        }
+        
+        return metadata;
+    }
 }

--- a/lib/demangler-cpp.js
+++ b/lib/demangler-cpp.js
@@ -24,11 +24,6 @@
 "use strict";
 
 const
-    SymbolStore = require('./symbol-store').SymbolStore,
-    _ = require('underscore-node'),
-    utils = require('../lib/utils'),
-    exec = require('../lib/exec'),
-    logger = require('../lib/logger').logger,
     Demangler = require("./demangler").Demangler;
 
 const LabelMetadata = [

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -43,7 +43,7 @@ class Demangler {
         this.compiler = compiler;
 
         this.labelDef = /^([.a-z_$][a-z0-9$_@.]*):/i;
-        this.jumpDef = /j.+\s+([.a-z_$][a-z0-9$_@.]*)/i;
+        this.jumpDef = /(j.+|b|bl|blx)\s+([.a-z_$][a-z0-9$_@.]*)/i;
         this.callDef = /call[q]?\s+([.a-z_$][a-z0-9$_@.]*)/i;
 
         // symbols in a mov or lea command starting with an underscore

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -48,6 +48,7 @@ class Demangler {
     constructor(demanglerExe, symbolstore) {
         this.demanglerExe = demanglerExe;
         this.symbolstore = symbolstore;
+        this.othersymbols = new SymbolStore();
         this.result = {};
         this.input = [];
         this.includeMetadata = true;
@@ -55,18 +56,35 @@ class Demangler {
 
     CollectLabels() {
         const labelDef = /^([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
+        const jumpDef = /j.+\s+([.a-zA-Z_$][a-zA-Z0-9$_.]*)/;
+        const callDef = /call.+\s+([.a-zA-Z_$][a-zA-Z0-9$_.]*)/;
 
         for (var j = 0; j < this.result.asm.length; ++j) {
             const line = this.result.asm[j].text;
-            const matches = line.match(labelDef);
+            let matches = line.match(labelDef);
             if (matches) {
                 this.symbolstore.Add(matches[1], matches[1]);
             }
+
+            matches = line.match(jumpDef);
+            if (matches) {
+                this.othersymbols.Add(matches[1], matches[1]);
+            }
+
+            matches = line.match(callDef);
+            if (matches) {
+                this.othersymbols.Add(matches[1], matches[1]);
+            }
         }
+
+        this.othersymbols.Exclude(this.symbolstore);
     }
 
     GetInput() {
-        this.input = this.symbolstore.ListSymbols();
+        this.input = [];
+        this.input = this.input.concat(this.symbolstore.ListSymbols());
+        this.input = this.input.concat(this.othersymbols.ListSymbols());
+
         return this.input.join("\n");
     }
 
@@ -90,7 +108,11 @@ class Demangler {
             metadataStr = metadata.map((meta) => " [" + meta.description + "]").join();
         }
 
-        this.symbolstore.Add(symbol, translation + metadataStr);
+        if (this.symbolstore.Contains(symbol)) {
+            this.symbolstore.Add(symbol, translation + metadataStr);
+        } else {
+            this.othersymbols.Add(symbol, translation + metadataStr);
+        }
     }
 
     ProcessOutput(output) {
@@ -99,10 +121,15 @@ class Demangler {
             this.AddTranslation(this.input[i], lines[i]);
 
         const translations = this.symbolstore.ListTranslations();
+        const extratranslations = this.othersymbols.ListTranslations();
+
         for (let i = 0; i < this.result.asm.length; ++i) {
             let line = this.result.asm[i].text;
             for (let j = 0; j < translations.length; ++j) {
                 line = line.replace(translations[j][0], translations[j][1]);
+            }
+            for (let j = 0; j < extratranslations.length; ++j) {
+                line = line.replace(extratranslations[j][0], extratranslations[j][1]);
             }
             this.result.asm[i].text = line;
         }
@@ -110,7 +137,8 @@ class Demangler {
         return this.result;
     }
 
-    Process(result) {
+    Process(result, execOptions) {
+        let options = execOptions || {};
         this.result = result;
 
         if (!this.symbolstore) {
@@ -118,7 +146,8 @@ class Demangler {
             this.CollectLabels();
         }
 
-        const options = {input: this.GetInput()};
+        options.input = this.GetInput();
+
         return exec.execute(
             this.demanglerExe,
             [],

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -25,15 +25,18 @@
 
 const
     SymbolStore = require('./symbol-store').SymbolStore,
-    utils = require('../lib/utils');
+    utils = require('../lib/utils'),
+    AsmRegex = require('../lib/asmregex').AsmRegex;
 
-class Demangler {
+class Demangler extends AsmRegex {
     /**
      * 
      * @param {string} demanglerExe 
      * @param {BaseCompiler} compiler 
      */
     constructor(demanglerExe, compiler) {
+        super();
+
         this.demanglerExe = demanglerExe;
         this.symbolstore = null;
         this.othersymbols = new SymbolStore();
@@ -42,7 +45,6 @@ class Demangler {
         this.includeMetadata = true;
         this.compiler = compiler;
 
-        this.labelDef = /^([.a-z_$][a-z0-9$_@.]*):/i;
         this.jumpDef = /(j.+|b|bl|blx)\s+([.a-z_$][a-z0-9$_@.]*)/i;
         this.callDef = /call[q]?\s+([.a-z_$][a-z0-9$_@.]*)/i;
 

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -145,7 +145,7 @@ class Demangler extends AsmRegex {
     execDemangler(options) {
         return this.compiler.exec(
             this.demanglerExe,
-            ['-n'],
+            [],
             options
         );
     }

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -155,7 +155,7 @@ class Demangler {
         options.input = this.GetInput();
 
         if (options.input === "") {
-            return this.result;
+            return new Promise((resolve) => resolve(this.result));
         } else {
             return this.ExecDemangler(options).then((output) => this.ProcessOutput(output));
         }

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -30,6 +30,15 @@ const
     exec = require('../lib/exec'),
     logger = require('../lib/logger').logger;
 
+const LabelMetadata = [
+    {'ident': 'C1', 'description': 'complete object constructor'},
+    {'ident': 'C2', 'description': 'base object constructor'},
+    {'ident': 'C3', 'description': 'complete object allocating constructor'},
+    {'ident': 'D0', 'description': 'deleting destructor'},
+    {'ident': 'D1', 'description': 'complete object destructor'},
+    {'ident': 'D2', 'description': 'base object destructor'}
+];
+
 class Demangler {
     /**
      * 
@@ -40,6 +49,8 @@ class Demangler {
         this.demanglerExe = demanglerExe;
         this.symbolstore = symbolstore;
         this.result = {};
+        this.input = [];
+        this.includeMetadata = true;
     }
 
     CollectLabels() {
@@ -54,23 +65,48 @@ class Demangler {
         }
     }
 
-    ProcessNew(result) {
-
-        // for (var j = 0; j < result.asm.length; ++j)
-        //     result.asm[j].text = demangleIfNeeded(result.asm[j].text);
-
+    GetInput() {
+        this.input = this.symbolstore.ListSymbols();
+        return this.input.join("\n");
     }
 
-    GetInput() {
-        return _.pluck(this.result.asm, 'text').join("\n");
+    GetMetadata(symbol) {
+        let metadata = [];
 
-        //return this.symbolstore.ListSymbols().join("\n");
+        for (let i = 0; i < LabelMetadata.length; ++i) {
+            if (symbol.includes(LabelMetadata[i].ident)) {
+                metadata.push(LabelMetadata[i]);
+            }
+        }
+        
+        return metadata;
+    }
+
+    AddTranslation(symbol, translation) {
+        let metadataStr = "";
+
+        if (this.includeMetadata) {
+            const metadata = this.GetMetadata(symbol);
+            metadataStr = metadata.map((meta) => " [" + meta.description + "]").join();
+        }
+
+        this.symbolstore.Add(symbol, translation + metadataStr);
     }
 
     ProcessOutput(output) {
         const lines = utils.splitLines(output.stdout);
-        for (let i = 0; i < this.result.asm.length; ++i)
-            this.result.asm[i].text = lines[i];
+        for (let i = 0; i < lines.length; ++i)
+            this.AddTranslation(this.input[i], lines[i]);
+
+        const translations = this.symbolstore.ListTranslations();
+        for (let i = 0; i < this.result.asm.length; ++i) {
+            let line = this.result.asm[i].text;
+            for (let j = 0; j < translations.length; ++j) {
+                line = line.replace(translations[j][0], translations[j][1]);
+            }
+            this.result.asm[i].text = line;
+        }
+
         return this.result;
     }
 
@@ -83,8 +119,6 @@ class Demangler {
         }
 
         const options = {input: this.GetInput()};
-        if (options.input.length == 0) return this.result;
-
         return exec.execute(
             this.demanglerExe,
             [],

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -41,28 +41,32 @@ class Demangler {
         this.result = {};
         this.input = [];
         this.includeMetadata = true;
+
+        this.labelDef = /^([.a-z_$][a-z0-9$_.]*):/i;
+        this.jumpDef = /j.+\s+([.a-z_$][a-z0-9$_.]*)/i;
+        this.callDef = /call.+\s+([.a-z_$][a-z0-9$_.]*)/i;
     }
 
     CollectLabels() {
-        const labelDef = /^([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
-        const jumpDef = /j.+\s+([.a-zA-Z_$][a-zA-Z0-9$_.]*)/;
-        const callDef = /call.+\s+([.a-zA-Z_$][a-zA-Z0-9$_.]*)/;
-
         for (var j = 0; j < this.result.asm.length; ++j) {
             const line = this.result.asm[j].text;
-            let matches = line.match(labelDef);
+
+            let matches = line.match(this.labelDef);
             if (matches) {
-                this.symbolstore.Add(matches[1], matches[1]);
+                const midx = matches.length - 1;
+                this.symbolstore.Add(matches[midx], matches[midx]);
             }
 
-            matches = line.match(jumpDef);
+            matches = line.match(this.jumpDef);
             if (matches) {
-                this.othersymbols.Add(matches[1], matches[1]);
+                const midx = matches.length - 1;
+                this.othersymbols.Add(matches[midx], matches[midx]);
             }
 
-            matches = line.match(callDef);
+            matches = line.match(this.callDef);
             if (matches) {
-                this.othersymbols.Add(matches[1], matches[1]);
+                const midx = matches.length - 1;
+                this.othersymbols.Add(matches[midx], matches[midx]);
             }
         }
 
@@ -141,7 +145,11 @@ class Demangler {
 
         options.input = this.GetInput();
 
-        return this.ExecDemangler(options).then((output) => this.ProcessOutput(output));
+        if (options.input === "") {
+            return this.result;
+        } else {
+            return this.ExecDemangler(options).then((output) => this.ProcessOutput(output));
+        }
     }
 }
 

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -25,10 +25,8 @@
 
 const
     SymbolStore = require('./symbol-store').SymbolStore,
-    _ = require('underscore-node'),
     utils = require('../lib/utils'),
-    exec = require('../lib/exec'),
-    logger = require('../lib/logger').logger;
+    exec = require('../lib/exec');
 
 class Demangler {
     /**

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -48,14 +48,17 @@ class Demangler {
 
         // symbols in a mov or lea command starting with an underscore
         this.movUnderscoreDef = /mov.*\s(_[a-z0-9$_@.]*)/i;
-        this.leaUnderscoreDef = /lea.*\s(_[a-z0-9$_@.]*)/i
+        this.leaUnderscoreDef = /lea.*\s(_[a-z0-9$_@.]*)/i;
+        this.quadUnderscoreDef = /\.quad\s*(_[a-z0-9$_@.]*)/i;
     }
 
     AddMatchToOtherSymbols(matches) {
-        if (matches) {
-            const midx = matches.length - 1;
-            this.othersymbols.Add(matches[midx], matches[midx]);
-        }
+        if (!matches) return false;
+
+        const midx = matches.length - 1;
+        this.othersymbols.Add(matches[midx], matches[midx]);
+
+        return true;
     }
 
     CollectLabels() {
@@ -68,10 +71,11 @@ class Demangler {
                 this.symbolstore.Add(matches[midx], matches[midx]);
             }
 
-            this.AddMatchToOtherSymbols(line.match(this.jumpDef));
-            this.AddMatchToOtherSymbols(line.match(this.callDef));
-            this.AddMatchToOtherSymbols(line.match(this.movUnderscoreDef));
-            this.AddMatchToOtherSymbols(line.match(this.leaUnderscoreDef));
+            if (this.AddMatchToOtherSymbols(line.match(this.jumpDef))) continue;
+            if (this.AddMatchToOtherSymbols(line.match(this.callDef))) continue;
+            if (this.AddMatchToOtherSymbols(line.match(this.movUnderscoreDef))) continue;
+            if (this.AddMatchToOtherSymbols(line.match(this.leaUnderscoreDef))) continue;
+            if (this.AddMatchToOtherSymbols(line.match(this.quadUnderscoreDef))) continue;
         }
 
         this.othersymbols.Exclude(this.symbolstore);

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2018, Patrick Quist
+// Copyright (c) 2018, Patrick Quist
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -81,12 +81,21 @@ class Demangler {
         return this.input.join("\n");
     }
 
-    GetMetadata(symbol) {
+    /**
+     * 
+     * @param {string} symbol 
+     */
+    GetMetadata() {
         let metadata = [];
         
         return metadata;
     }
 
+    /**
+     * 
+     * @param {string} symbol 
+     * @param {string} translation 
+     */
     AddTranslation(symbol, translation) {
         let metadataStr = "";
 

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -30,15 +30,6 @@ const
     exec = require('../lib/exec'),
     logger = require('../lib/logger').logger;
 
-const LabelMetadata = [
-    {'ident': 'C1', 'description': 'complete object constructor'},
-    {'ident': 'C2', 'description': 'base object constructor'},
-    {'ident': 'C3', 'description': 'complete object allocating constructor'},
-    {'ident': 'D0', 'description': 'deleting destructor'},
-    {'ident': 'D1', 'description': 'complete object destructor'},
-    {'ident': 'D2', 'description': 'base object destructor'}
-];
-
 class Demangler {
     /**
      * 
@@ -139,6 +130,14 @@ class Demangler {
         return this.result;
     }
 
+    ExecDemangler() {
+        return exec.execute(
+            this.demanglerExe,
+            [],
+            options
+        );
+    }
+
     Process(result, execOptions) {
         let options = execOptions || {};
         this.result = result;
@@ -150,11 +149,7 @@ class Demangler {
 
         options.input = this.GetInput();
 
-        return exec.execute(
-            this.demanglerExe,
-            [],
-            options
-        ).then((output) => this.ProcessOutput(output));
+        return ExecDemangler().then((output) => this.ProcessOutput(output));
     }
 }
 

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -44,7 +44,7 @@ class Demangler {
 
         this.labelDef = /^([.a-z_$][a-z0-9$_@.]*):/i;
         this.jumpDef = /j.+\s+([.a-z_$][a-z0-9$_@.]*)/i;
-        this.callDef = /call.+\s+([.a-z_$][a-z0-9$_@.]*)/i;
+        this.callDef = /call[q]?\s+([.a-z_$][a-z0-9$_@.]*)/i;
     }
 
     CollectLabels() {

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -25,8 +25,7 @@
 
 const
     SymbolStore = require('./symbol-store').SymbolStore,
-    utils = require('../lib/utils'),
-    exec = require('../lib/exec');
+    utils = require('../lib/utils');
 
 class Demangler {
     /**
@@ -144,7 +143,7 @@ class Demangler {
     }
 
     execDemangler(options) {
-        return exec.execute(
+        return this.compiler.exec(
             this.demanglerExe,
             [],
             options

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -38,6 +38,7 @@ class Demangler extends AsmRegex {
         super();
 
         this.demanglerExe = demanglerExe;
+        this.demanglerArguments = [];
         this.symbolstore = null;
         this.othersymbols = new SymbolStore();
         this.result = {};
@@ -145,7 +146,7 @@ class Demangler extends AsmRegex {
     execDemangler(options) {
         return this.compiler.exec(
             this.demanglerExe,
-            [],
+            this.demanglerArguments,
             options
         );
     }

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -31,15 +31,16 @@ class Demangler {
     /**
      * 
      * @param {string} demanglerExe 
-     * @param {SymbolStore} symbolstore 
+     * @param {BaseCompiler} compiler 
      */
-    constructor(demanglerExe, symbolstore) {
+    constructor(demanglerExe, compiler) {
         this.demanglerExe = demanglerExe;
-        this.symbolstore = symbolstore;
+        this.symbolstore = null;
         this.othersymbols = new SymbolStore();
         this.result = {};
         this.input = [];
         this.includeMetadata = true;
+        this.compiler = compiler;
 
         this.labelDef = /^([.a-z_$][a-z0-9$_@.]*):/i;
         this.jumpDef = /j.+\s+([.a-z_$][a-z0-9$_@.]*)/i;

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -42,9 +42,9 @@ class Demangler {
         this.input = [];
         this.includeMetadata = true;
 
-        this.labelDef = /^([.a-z_$][a-z0-9$_.]*):/i;
-        this.jumpDef = /j.+\s+([.a-z_$][a-z0-9$_.]*)/i;
-        this.callDef = /call.+\s+([.a-z_$][a-z0-9$_.]*)/i;
+        this.labelDef = /^([.a-z_$][a-z0-9$_@.]*):/i;
+        this.jumpDef = /j.+\s+([.a-z_$][a-z0-9$_@.]*)/i;
+        this.callDef = /call.+\s+([.a-z_$][a-z0-9$_@.]*)/i;
     }
 
     CollectLabels() {

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -81,12 +81,6 @@ class Demangler {
 
     GetMetadata(symbol) {
         let metadata = [];
-
-        for (let i = 0; i < LabelMetadata.length; ++i) {
-            if (symbol.includes(LabelMetadata[i].ident)) {
-                metadata.push(LabelMetadata[i]);
-            }
-        }
         
         return metadata;
     }

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Patrick Quist
+// Copyright (c) 2018, Compiler Explorer Team
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -143,7 +143,7 @@ class Demangler {
     execDemangler(options) {
         return this.compiler.exec(
             this.demanglerExe,
-            [],
+            ['-n'],
             options
         );
     }

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -1,0 +1,96 @@
+// Copyright (c) 2012-2018, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+const
+    SymbolStore = require('./symbol-store').SymbolStore,
+    _ = require('underscore-node'),
+    utils = require('../lib/utils'),
+    exec = require('../lib/exec'),
+    logger = require('../lib/logger').logger;
+
+class Demangler {
+    /**
+     * 
+     * @param {string} demanglerExe 
+     * @param {SymbolStore} symbolstore 
+     */
+    constructor(demanglerExe, symbolstore) {
+        this.demanglerExe = demanglerExe;
+        this.symbolstore = symbolstore;
+        this.result = {};
+    }
+
+    CollectLabels() {
+        const labelDef = /^([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
+
+        for (var j = 0; j < this.result.asm.length; ++j) {
+            const line = this.result.asm[j].text;
+            const matches = line.match(labelDef);
+            if (matches) {
+                this.symbolstore.Add(matches[1], matches[1]);
+            }
+        }
+    }
+
+    ProcessNew(result) {
+
+        // for (var j = 0; j < result.asm.length; ++j)
+        //     result.asm[j].text = demangleIfNeeded(result.asm[j].text);
+
+    }
+
+    GetInput() {
+        return _.pluck(this.result.asm, 'text').join("\n");
+
+        //return this.symbolstore.ListSymbols().join("\n");
+    }
+
+    ProcessOutput(output) {
+        const lines = utils.splitLines(output.stdout);
+        for (let i = 0; i < this.result.asm.length; ++i)
+            this.result.asm[i].text = lines[i];
+        return this.result;
+    }
+
+    Process(result) {
+        this.result = result;
+
+        if (!this.symbolstore) {
+            this.symbolstore = new SymbolStore();
+            this.CollectLabels();
+        }
+
+        const options = {input: this.GetInput()};
+        if (options.input.length == 0) return this.result;
+
+        return exec.execute(
+            this.demanglerExe,
+            [],
+            options
+        ).then((output) => this.ProcessOutput(output));
+    }
+}
+
+exports.Demangler = Demangler;

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -130,7 +130,7 @@ class Demangler {
         return this.result;
     }
 
-    ExecDemangler() {
+    ExecDemangler(options) {
         return exec.execute(
             this.demanglerExe,
             [],
@@ -149,7 +149,7 @@ class Demangler {
 
         options.input = this.GetInput();
 
-        return ExecDemangler().then((output) => this.ProcessOutput(output));
+        return this.ExecDemangler(options).then((output) => this.ProcessOutput(output));
     }
 }
 

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -124,18 +124,15 @@ class Demangler {
         for (let i = 0; i < lines.length; ++i)
             this.addTranslation(this.input[i], lines[i]);
 
-        const translations = this.symbolstore.listTranslations();
-        const extratranslations = this.othersymbols.listTranslations();
+        let translations = [];
+        translations = translations.concat(this.symbolstore.listTranslations());
+        translations = translations.concat(this.othersymbols.listTranslations());
 
         for (let i = 0; i < this.result.asm.length; ++i) {
             let line = this.result.asm[i].text;
             for (let j = 0; j < translations.length; ++j) {
                 line = line.replace(translations[j][0], translations[j][1]);
                 line = line.replace(translations[j][0], translations[j][1]);
-            }
-            for (let j = 0; j < extratranslations.length; ++j) {
-                line = line.replace(extratranslations[j][0], extratranslations[j][1]);
-                line = line.replace(extratranslations[j][0], extratranslations[j][1]);
             }
             this.result.asm[i].text = line;
         }

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -127,8 +127,10 @@ class Demangler {
             let line = this.result.asm[i].text;
             for (let j = 0; j < translations.length; ++j) {
                 line = line.replace(translations[j][0], translations[j][1]);
+                line = line.replace(translations[j][0], translations[j][1]);
             }
             for (let j = 0; j < extratranslations.length; ++j) {
+                line = line.replace(extratranslations[j][0], extratranslations[j][1]);
                 line = line.replace(extratranslations[j][0], extratranslations[j][1]);
             }
             this.result.asm[i].text = line;

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -45,6 +45,17 @@ class Demangler {
         this.labelDef = /^([.a-z_$][a-z0-9$_@.]*):/i;
         this.jumpDef = /j.+\s+([.a-z_$][a-z0-9$_@.]*)/i;
         this.callDef = /call[q]?\s+([.a-z_$][a-z0-9$_@.]*)/i;
+
+        // symbols in a mov or lea command starting with an underscore
+        this.movUnderscoreDef = /mov.*\s(_[a-z0-9$_@.]*)/i;
+        this.leaUnderscoreDef = /lea.*\s(_[a-z0-9$_@.]*)/i
+    }
+
+    AddMatchToOtherSymbols(matches) {
+        if (matches) {
+            const midx = matches.length - 1;
+            this.othersymbols.Add(matches[midx], matches[midx]);
+        }
     }
 
     CollectLabels() {
@@ -57,17 +68,10 @@ class Demangler {
                 this.symbolstore.Add(matches[midx], matches[midx]);
             }
 
-            matches = line.match(this.jumpDef);
-            if (matches) {
-                const midx = matches.length - 1;
-                this.othersymbols.Add(matches[midx], matches[midx]);
-            }
-
-            matches = line.match(this.callDef);
-            if (matches) {
-                const midx = matches.length - 1;
-                this.othersymbols.Add(matches[midx], matches[midx]);
-            }
+            this.AddMatchToOtherSymbols(line.match(this.jumpDef));
+            this.AddMatchToOtherSymbols(line.match(this.callDef));
+            this.AddMatchToOtherSymbols(line.match(this.movUnderscoreDef));
+            this.AddMatchToOtherSymbols(line.match(this.leaUnderscoreDef));
         }
 
         this.othersymbols.Exclude(this.symbolstore);

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -52,39 +52,39 @@ class Demangler {
         this.quadUnderscoreDef = /\.quad\s*(_[a-z0-9$_@.]*)/i;
     }
 
-    AddMatchToOtherSymbols(matches) {
+    addMatchToOtherSymbols(matches) {
         if (!matches) return false;
 
         const midx = matches.length - 1;
-        this.othersymbols.Add(matches[midx], matches[midx]);
+        this.othersymbols.add(matches[midx], matches[midx]);
 
         return true;
     }
 
-    CollectLabels() {
+    collectLabels() {
         for (var j = 0; j < this.result.asm.length; ++j) {
             const line = this.result.asm[j].text;
 
             let matches = line.match(this.labelDef);
             if (matches) {
                 const midx = matches.length - 1;
-                this.symbolstore.Add(matches[midx], matches[midx]);
+                this.symbolstore.add(matches[midx], matches[midx]);
             }
 
-            if (this.AddMatchToOtherSymbols(line.match(this.jumpDef))) continue;
-            if (this.AddMatchToOtherSymbols(line.match(this.callDef))) continue;
-            if (this.AddMatchToOtherSymbols(line.match(this.movUnderscoreDef))) continue;
-            if (this.AddMatchToOtherSymbols(line.match(this.leaUnderscoreDef))) continue;
-            if (this.AddMatchToOtherSymbols(line.match(this.quadUnderscoreDef))) continue;
+            if (this.addMatchToOtherSymbols(line.match(this.jumpDef))) continue;
+            if (this.addMatchToOtherSymbols(line.match(this.callDef))) continue;
+            if (this.addMatchToOtherSymbols(line.match(this.movUnderscoreDef))) continue;
+            if (this.addMatchToOtherSymbols(line.match(this.leaUnderscoreDef))) continue;
+            if (this.addMatchToOtherSymbols(line.match(this.quadUnderscoreDef))) continue;
         }
 
-        this.othersymbols.Exclude(this.symbolstore);
+        this.othersymbols.exclude(this.symbolstore);
     }
 
-    GetInput() {
+    getInput() {
         this.input = [];
-        this.input = this.input.concat(this.symbolstore.ListSymbols());
-        this.input = this.input.concat(this.othersymbols.ListSymbols());
+        this.input = this.input.concat(this.symbolstore.listSymbols());
+        this.input = this.input.concat(this.othersymbols.listSymbols());
 
         return this.input.join("\n");
     }
@@ -93,7 +93,7 @@ class Demangler {
      * 
      * @param {string} symbol 
      */
-    GetMetadata() {
+    getMetadata() {
         let metadata = [];
         
         return metadata;
@@ -104,28 +104,28 @@ class Demangler {
      * @param {string} symbol 
      * @param {string} translation 
      */
-    AddTranslation(symbol, translation) {
+    addTranslation(symbol, translation) {
         let metadataStr = "";
 
         if (this.includeMetadata) {
-            const metadata = this.GetMetadata(symbol);
+            const metadata = this.getMetadata(symbol);
             metadataStr = metadata.map((meta) => " [" + meta.description + "]").join();
         }
 
-        if (this.symbolstore.Contains(symbol)) {
-            this.symbolstore.Add(symbol, translation + metadataStr);
+        if (this.symbolstore.contains(symbol)) {
+            this.symbolstore.add(symbol, translation + metadataStr);
         } else {
-            this.othersymbols.Add(symbol, translation + metadataStr);
+            this.othersymbols.add(symbol, translation + metadataStr);
         }
     }
 
-    ProcessOutput(output) {
+    processOutput(output) {
         const lines = utils.splitLines(output.stdout);
         for (let i = 0; i < lines.length; ++i)
-            this.AddTranslation(this.input[i], lines[i]);
+            this.addTranslation(this.input[i], lines[i]);
 
-        const translations = this.symbolstore.ListTranslations();
-        const extratranslations = this.othersymbols.ListTranslations();
+        const translations = this.symbolstore.listTranslations();
+        const extratranslations = this.othersymbols.listTranslations();
 
         for (let i = 0; i < this.result.asm.length; ++i) {
             let line = this.result.asm[i].text;
@@ -143,7 +143,7 @@ class Demangler {
         return this.result;
     }
 
-    ExecDemangler(options) {
+    execDemangler(options) {
         return exec.execute(
             this.demanglerExe,
             [],
@@ -151,21 +151,21 @@ class Demangler {
         );
     }
 
-    Process(result, execOptions) {
+    process(result, execOptions) {
         let options = execOptions || {};
         this.result = result;
 
         if (!this.symbolstore) {
             this.symbolstore = new SymbolStore();
-            this.CollectLabels();
+            this.collectLabels();
         }
 
-        options.input = this.GetInput();
+        options.input = this.getInput();
 
         if (options.input === "") {
             return new Promise((resolve) => resolve(this.result));
         } else {
-            return this.ExecDemangler(options).then((output) => this.ProcessOutput(output));
+            return this.execDemangler(options).then((output) => this.processOutput(output));
         }
     }
 }

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -36,7 +36,9 @@ function execute(command, args, options) {
 
     if (options.wrapper) {
         args = args.slice(0); // prevent mutating the caller's arguments
+        if (command.startsWith('./')) command = path.join(process.cwd(), command);
         args.unshift(command);
+        if (options.wrapperOptions) args.unshift(options.wrapperOptions);
         command = options.wrapper;
 
         if (command.startsWith('./')) command = path.join(process.cwd(), command);

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -36,9 +36,7 @@ function execute(command, args, options) {
 
     if (options.wrapper) {
         args = args.slice(0); // prevent mutating the caller's arguments
-        if (command.startsWith('./')) command = path.join(process.cwd(), command);
         args.unshift(command);
-        if (options.wrapperOptions) args.unshift(options.wrapperOptions);
         command = options.wrapper;
 
         if (command.startsWith('./')) command = path.join(process.cwd(), command);

--- a/lib/pascal-support.js
+++ b/lib/pascal-support.js
@@ -202,4 +202,4 @@ class PascalDemangler extends Demangler {
     }
 }
 
-exports.demangler = PascalDemangler;
+exports.Demangler = PascalDemangler;

--- a/lib/pascal-support.js
+++ b/lib/pascal-support.js
@@ -27,7 +27,9 @@ const SymbolStore = require("./symbol-store").SymbolStore;
 const Demangler = require("./demangler").Demangler;
 
 class PascalDemangler extends Demangler {
-    constructor() {
+    constructor(demanglerExe, symbolstore) {
+        super(demanglerExe, symbolstore);
+
         this.symbolStore = new SymbolStore();
         this.fixedsymbols = {};
         this.ignoredsymbols = [];
@@ -183,6 +185,20 @@ class PascalDemangler extends Demangler {
         } else {
             return text;
         }
+    }
+
+    Process(result, execOptions) {
+        let options = execOptions || {};
+        this.result = result;
+
+        if (!this.symbolstore) {
+            this.symbolstore = new SymbolStore();
+            this.CollectLabels();
+        }
+
+        options.input = this.GetInput();
+
+        return options.input;
     }
 }
 

--- a/lib/pascal-support.js
+++ b/lib/pascal-support.js
@@ -87,18 +87,18 @@ class PascalDemangler extends Demangler {
         for (let k in this.fixedsymbols) {
             if (text === k) {
                 text = text.replace(k, this.fixedsymbols[k]);
-                this.symbolStore.Add(k, this.fixedsymbols[k]);
+                this.symbolStore.add(k, this.fixedsymbols[k]);
                 return this.fixedsymbols[k];
             }
         }
 
         if (text.startsWith("U_$OUTPUT_$$_")) {
             let unmangledGlobalVar = text.substr(13).toLowerCase();
-            this.symbolStore.Add(text, unmangledGlobalVar);
+            this.symbolStore.add(text, unmangledGlobalVar);
             return unmangledGlobalVar;
         } else if (text.startsWith("U_OUTPUT_")) {
             let unmangledGlobalVar = text.substr(9).toLowerCase();
-            this.symbolStore.Add(text, unmangledGlobalVar);
+            this.symbolStore.add(text, unmangledGlobalVar);
             return unmangledGlobalVar;
         }
 
@@ -161,7 +161,7 @@ class PascalDemangler extends Demangler {
         }
 
         const unmangled = this.composeReadableMethodSignature(unitname, classname, methodname, params);
-        this.symbolStore.Add(text, unmangled);
+        this.symbolStore.add(text, unmangled);
 
         return unmangled;
     }
@@ -176,7 +176,7 @@ class PascalDemangler extends Demangler {
                 return text;
             }
 
-            const translations = this.symbolStore.ListTranslations();
+            const translations = this.symbolStore.listTranslations();
             for (let idx in translations) {
                 text = text.replace(translations[idx][0], translations[idx][1]);
             }
@@ -187,16 +187,16 @@ class PascalDemangler extends Demangler {
         }
     }
 
-    Process(result, execOptions) {
+    process(result, execOptions) {
         let options = execOptions || {};
         this.result = result;
 
         if (!this.symbolstore) {
             this.symbolstore = new SymbolStore();
-            this.CollectLabels();
+            this.collectLabels();
         }
 
-        options.input = this.GetInput();
+        options.input = this.getInput();
 
         return options.input;
     }

--- a/lib/pascal-support.js
+++ b/lib/pascal-support.js
@@ -24,8 +24,9 @@
 "use strict";
 
 const SymbolStore = require("./symbol-store").SymbolStore;
+const Demangler = require("./demangler").Demangler;
 
-class PascalDemangler {
+class PascalDemangler extends Demangler {
     constructor() {
         this.symbolStore = new SymbolStore();
         this.fixedsymbols = {};

--- a/lib/symbol-store.js
+++ b/lib/symbol-store.js
@@ -30,7 +30,7 @@ class SymbolStore {
         this.isSorted = true;
     }
 
-    Sort() {
+    sort() {
         this.sortedSymbols = [];
         for (let symbol in this.uniqueSymbols) {
             this.sortedSymbols.push([symbol, this.uniqueSymbols[symbol]]);
@@ -43,7 +43,7 @@ class SymbolStore {
         this.isSorted = true;
     }
 
-    Add(symbol, demangled) {
+    add(symbol, demangled) {
         if (demangled !== undefined) {
             this.uniqueSymbols[symbol] = demangled;
         } else {
@@ -53,11 +53,11 @@ class SymbolStore {
         this.isSorted = false;
     }
 
-    Contains(symbol) {
+    contains(symbol) {
         return this.uniqueSymbols[symbol] !== undefined;
     }
 
-    Exclude(otherStore) {
+    exclude(otherStore) {
         for (const symbol in otherStore.uniqueSymbols) {
             delete this.uniqueSymbols[symbol];
         }
@@ -65,7 +65,7 @@ class SymbolStore {
         this.isSorted = false;
     }
 
-    SoftExclude(otherStore) {
+    softExclude(otherStore) {
         for (const symbol in otherStore.uniqueSymbols) {
             let shouldExclude = false;
             let checksymbol;
@@ -82,7 +82,7 @@ class SymbolStore {
         this.isSorted = false;
     }
 
-    AddMany(symbols) {
+    addMany(symbols) {
         symbols.forEach(symbol => {
             this.uniqueSymbols[symbol] = symbol;
         });
@@ -90,16 +90,16 @@ class SymbolStore {
         this.isSorted = false;
     }
 
-    ListSymbols() {
-        if (!this.isSorted) this.Sort();
+    listSymbols() {
+        if (!this.isSorted) this.sort();
 
         return this.sortedSymbols.map(function (elem) {
             return elem[0];
         });
     }
 
-    ListTranslations() {
-        if (!this.isSorted) this.Sort();
+    listTranslations() {
+        if (!this.isSorted) this.sort();
 
         return this.sortedSymbols;
     }

--- a/lib/symbol-store.js
+++ b/lib/symbol-store.js
@@ -53,6 +53,35 @@ class SymbolStore {
         this.isSorted = false;
     }
 
+    Contains(symbol) {
+        return this.uniqueSymbols[symbol] !== undefined;
+    }
+
+    Exclude(otherStore) {
+        for (const symbol in otherStore.uniqueSymbols) {
+            delete this.uniqueSymbols[symbol];
+        }
+
+        this.isSorted = false;
+    }
+
+    SoftExclude(otherStore) {
+        for (const symbol in otherStore.uniqueSymbols) {
+            let shouldExclude = false;
+            let checksymbol;
+            for (checksymbol in this.uniqueSymbols) {
+                if (checksymbol.endsWith(symbol)) {
+                    shouldExclude = true;
+                    break;
+                }
+            }
+
+            if (shouldExclude) delete this.uniqueSymbols[checksymbol];
+        }
+
+        this.isSorted = false;
+    }
+
     AddMany(symbols) {
         symbols.forEach(symbol => {
             this.uniqueSymbols[symbol] = symbol;

--- a/test/demangle-cases/bug-515.asm
+++ b/test/demangle-cases/bug-515.asm
@@ -1,0 +1,10 @@
+_Z3barv:
+        movl    $_ZL3foo, %eax
+        ret
+_Z4bar2v:
+        movl    $foo2, %eax
+        ret
+foo2:
+        .long   1
+_ZL3foo:
+        .long   2

--- a/test/demangle-cases/bug-515.asm.demangle
+++ b/test/demangle-cases/bug-515.asm.demangle
@@ -1,0 +1,10 @@
+bar():
+        movl    $foo, %eax
+        ret
+bar2():
+        movl    $foo2, %eax
+        ret
+foo2:
+        .long   1
+foo:
+        .long   23

--- a/test/demangle-cases/bug-515.asm.demangle
+++ b/test/demangle-cases/bug-515.asm.demangle
@@ -7,4 +7,4 @@ bar2():
 foo2:
         .long   1
 foo:
-        .long   23
+        .long   2

--- a/test/demangle-cases/bug-660.asm
+++ b/test/demangle-cases/bug-660.asm
@@ -1,0 +1,768 @@
+        .section .mdebug.abi32
+        .previous
+        .nan    legacy
+        .module fp=32
+        .module nooddspreg
+        .abicalls
+        .option pic0
+        .text
+$Ltext0:
+        .section        .rodata.str1.4,"aMS",@progbits,1
+        .align  2
+$LC0:
+        .ascii  "hello world\000"
+        .text
+        .align  2
+        .globl  main
+$LFB12 = .
+        .file 1 "/tmp/compiler-explorer-compiler118012-54-8izljx.aer9e/example.cpp"
+        .loc 1 2 0
+        .cfi_startproc
+        .set    nomips16
+        .set    nomicromips
+        .ent    main
+        .type   main, @function
+main:
+        .frame  $sp,32,$31      # vars= 0, regs= 1/0, args= 16, gp= 8
+        .mask   0x80000000,-4
+        .fmask  0x00000000,0
+        .set    noreorder
+        .set    nomacro
+        addiu   $sp,$sp,-32
+        .cfi_def_cfa_offset 32
+        sw      $31,28($sp)
+        .cfi_offset 31, -4
+        .loc 1 3 0
+        lui     $4,%hi($LC0)
+        addiu   $4,$4,%lo($LC0)
+        jal     puts
+        nop
+
+$LVL0 = .
+        .loc 1 4 0
+        move    $2,$0
+        lw      $31,28($sp)
+        nop
+        j       $31
+        addiu   $sp,$sp,32
+
+        .cfi_def_cfa_offset 0
+        .cfi_restore 31
+        .set    macro
+        .set    reorder
+        .end    main
+        .cfi_endproc
+$LFE12:
+        .size   main, .-main
+$Letext0:
+        .file 2 "/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/lib/gcc/mips-unknown-linux-gnu/5.4.0/include/stddef.h"
+        .file 3 "/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/mips-unknown-linux-gnu/sysroot/usr/include/bits/types.h"
+        .file 4 "/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/mips-unknown-linux-gnu/sysroot/usr/include/libio.h"
+        .file 5 "/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/mips-unknown-linux-gnu/sysroot/usr/include/stdio.h"
+        .section        .debug_info,"",@progbits
+$Ldebug_info0:
+        .4byte  0x2dd
+        .2byte  0x4
+        .4byte  $Ldebug_abbrev0
+        .byte   0x4
+        .uleb128 0x1
+        .4byte  $LASF51
+        .byte   0x4
+        .4byte  $LASF52
+        .4byte  $Ltext0
+        .4byte  $Letext0-$Ltext0
+        .4byte  $Ldebug_line0
+        .uleb128 0x2
+        .4byte  $LASF8
+        .byte   0x2
+        .byte   0xd8
+        .4byte  0x2c
+        .uleb128 0x3
+        .byte   0x4
+        .byte   0x7
+        .4byte  $LASF0
+        .uleb128 0x3
+        .byte   0x1
+        .byte   0x8
+        .4byte  $LASF1
+        .uleb128 0x3
+        .byte   0x2
+        .byte   0x7
+        .4byte  $LASF2
+        .uleb128 0x3
+        .byte   0x4
+        .byte   0x7
+        .4byte  $LASF3
+        .uleb128 0x3
+        .byte   0x1
+        .byte   0x6
+        .4byte  $LASF4
+        .uleb128 0x3
+        .byte   0x2
+        .byte   0x5
+        .4byte  $LASF5
+        .uleb128 0x4
+        .byte   0x4
+        .byte   0x5
+        .ascii  "int\000"
+        .uleb128 0x3
+        .byte   0x8
+        .byte   0x5
+        .4byte  $LASF6
+        .uleb128 0x3
+        .byte   0x8
+        .byte   0x7
+        .4byte  $LASF7
+        .uleb128 0x2
+        .4byte  $LASF9
+        .byte   0x3
+        .byte   0x37
+        .4byte  0x5d
+        .uleb128 0x2
+        .4byte  $LASF10
+        .byte   0x3
+        .byte   0x8c
+        .4byte  0x81
+        .uleb128 0x3
+        .byte   0x4
+        .byte   0x5
+        .4byte  $LASF11
+        .uleb128 0x2
+        .4byte  $LASF12
+        .byte   0x3
+        .byte   0x8d
+        .4byte  0x6b
+        .uleb128 0x3
+        .byte   0x4
+        .byte   0x7
+        .4byte  $LASF13
+        .uleb128 0x5
+        .byte   0x4
+        .uleb128 0x6
+        .byte   0x4
+        .4byte  0xa2
+        .uleb128 0x3
+        .byte   0x1
+        .byte   0x6
+        .4byte  $LASF14
+        .uleb128 0x7
+        .4byte  $LASF44
+        .byte   0x98
+        .byte   0x4
+        .byte   0xf1
+        .4byte  0x226
+        .uleb128 0x8
+        .4byte  $LASF15
+        .byte   0x4
+        .byte   0xf2
+        .4byte  0x56
+        .byte   0
+        .uleb128 0x8
+        .4byte  $LASF16
+        .byte   0x4
+        .byte   0xf7
+        .4byte  0x9c
+        .byte   0x4
+        .uleb128 0x8
+        .4byte  $LASF17
+        .byte   0x4
+        .byte   0xf8
+        .4byte  0x9c
+        .byte   0x8
+        .uleb128 0x8
+        .4byte  $LASF18
+        .byte   0x4
+        .byte   0xf9
+        .4byte  0x9c
+        .byte   0xc
+        .uleb128 0x8
+        .4byte  $LASF19
+        .byte   0x4
+        .byte   0xfa
+        .4byte  0x9c
+        .byte   0x10
+        .uleb128 0x8
+        .4byte  $LASF20
+        .byte   0x4
+        .byte   0xfb
+        .4byte  0x9c
+        .byte   0x14
+        .uleb128 0x8
+        .4byte  $LASF21
+        .byte   0x4
+        .byte   0xfc
+        .4byte  0x9c
+        .byte   0x18
+        .uleb128 0x8
+        .4byte  $LASF22
+        .byte   0x4
+        .byte   0xfd
+        .4byte  0x9c
+        .byte   0x1c
+        .uleb128 0x8
+        .4byte  $LASF23
+        .byte   0x4
+        .byte   0xfe
+        .4byte  0x9c
+        .byte   0x20
+        .uleb128 0x9
+        .4byte  $LASF24
+        .byte   0x4
+        .2byte  0x100
+        .4byte  0x9c
+        .byte   0x24
+        .uleb128 0x9
+        .4byte  $LASF25
+        .byte   0x4
+        .2byte  0x101
+        .4byte  0x9c
+        .byte   0x28
+        .uleb128 0x9
+        .4byte  $LASF26
+        .byte   0x4
+        .2byte  0x102
+        .4byte  0x9c
+        .byte   0x2c
+        .uleb128 0x9
+        .4byte  $LASF27
+        .byte   0x4
+        .2byte  0x104
+        .4byte  0x25e
+        .byte   0x30
+        .uleb128 0x9
+        .4byte  $LASF28
+        .byte   0x4
+        .2byte  0x106
+        .4byte  0x264
+        .byte   0x34
+        .uleb128 0x9
+        .4byte  $LASF29
+        .byte   0x4
+        .2byte  0x108
+        .4byte  0x56
+        .byte   0x38
+        .uleb128 0x9
+        .4byte  $LASF30
+        .byte   0x4
+        .2byte  0x10c
+        .4byte  0x56
+        .byte   0x3c
+        .uleb128 0x9
+        .4byte  $LASF31
+        .byte   0x4
+        .2byte  0x10e
+        .4byte  0x76
+        .byte   0x40
+        .uleb128 0x9
+        .4byte  $LASF32
+        .byte   0x4
+        .2byte  0x112
+        .4byte  0x3a
+        .byte   0x44
+        .uleb128 0x9
+        .4byte  $LASF33
+        .byte   0x4
+        .2byte  0x113
+        .4byte  0x48
+        .byte   0x46
+        .uleb128 0x9
+        .4byte  $LASF34
+        .byte   0x4
+        .2byte  0x114
+        .4byte  0x26a
+        .byte   0x47
+        .uleb128 0x9
+        .4byte  $LASF35
+        .byte   0x4
+        .2byte  0x118
+        .4byte  0x27a
+        .byte   0x48
+        .uleb128 0x9
+        .4byte  $LASF36
+        .byte   0x4
+        .2byte  0x121
+        .4byte  0x88
+        .byte   0x50
+        .uleb128 0x9
+        .4byte  $LASF37
+        .byte   0x4
+        .2byte  0x129
+        .4byte  0x9a
+        .byte   0x58
+        .uleb128 0x9
+        .4byte  $LASF38
+        .byte   0x4
+        .2byte  0x12a
+        .4byte  0x9a
+        .byte   0x5c
+        .uleb128 0x9
+        .4byte  $LASF39
+        .byte   0x4
+        .2byte  0x12b
+        .4byte  0x9a
+        .byte   0x60
+        .uleb128 0x9
+        .4byte  $LASF40
+        .byte   0x4
+        .2byte  0x12c
+        .4byte  0x9a
+        .byte   0x64
+        .uleb128 0x9
+        .4byte  $LASF41
+        .byte   0x4
+        .2byte  0x12e
+        .4byte  0x21
+        .byte   0x68
+        .uleb128 0x9
+        .4byte  $LASF42
+        .byte   0x4
+        .2byte  0x12f
+        .4byte  0x56
+        .byte   0x6c
+        .uleb128 0x9
+        .4byte  $LASF43
+        .byte   0x4
+        .2byte  0x131
+        .4byte  0x280
+        .byte   0x70
+        .byte   0
+        .uleb128 0xa
+        .4byte  $LASF53
+        .byte   0x4
+        .byte   0x96
+        .uleb128 0x7
+        .4byte  $LASF45
+        .byte   0xc
+        .byte   0x4
+        .byte   0x9c
+        .4byte  0x25e
+        .uleb128 0x8
+        .4byte  $LASF46
+        .byte   0x4
+        .byte   0x9d
+        .4byte  0x25e
+        .byte   0
+        .uleb128 0x8
+        .4byte  $LASF47
+        .byte   0x4
+        .byte   0x9e
+        .4byte  0x264
+        .byte   0x4
+        .uleb128 0x8
+        .4byte  $LASF48
+        .byte   0x4
+        .byte   0xa2
+        .4byte  0x56
+        .byte   0x8
+        .byte   0
+        .uleb128 0x6
+        .byte   0x4
+        .4byte  0x22d
+        .uleb128 0x6
+        .byte   0x4
+        .4byte  0xa9
+        .uleb128 0xb
+        .4byte  0xa2
+        .4byte  0x27a
+        .uleb128 0xc
+        .4byte  0x93
+        .byte   0
+        .byte   0
+        .uleb128 0x6
+        .byte   0x4
+        .4byte  0x226
+        .uleb128 0xb
+        .4byte  0xa2
+        .4byte  0x290
+        .uleb128 0xc
+        .4byte  0x93
+        .byte   0x27
+        .byte   0
+        .uleb128 0xd
+        .4byte  $LASF54
+        .byte   0x1
+        .byte   0x2
+        .4byte  0x56
+        .4byte  $LFB12
+        .4byte  $LFE12-$LFB12
+        .uleb128 0x1
+        .byte   0x9c
+        .4byte  0x2bd
+        .uleb128 0xe
+        .4byte  $LVL0
+        .4byte  0x2d3
+        .uleb128 0xf
+        .uleb128 0x1
+        .byte   0x54
+        .uleb128 0x5
+        .byte   0x3
+        .4byte  $LC0
+        .byte   0
+        .byte   0
+        .uleb128 0x10
+        .4byte  $LASF49
+        .byte   0x5
+        .byte   0xab
+        .4byte  0x264
+        .uleb128 0x10
+        .4byte  $LASF50
+        .byte   0x5
+        .byte   0xac
+        .4byte  0x264
+        .uleb128 0x11
+        .4byte  $LASF55
+        .4byte  $LASF56
+        .4byte  $LASF55
+        .byte   0
+        .section        .debug_abbrev,"",@progbits
+$Ldebug_abbrev0:
+        .uleb128 0x1
+        .uleb128 0x11
+        .byte   0x1
+        .uleb128 0x25
+        .uleb128 0xe
+        .uleb128 0x13
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x6
+        .uleb128 0x10
+        .uleb128 0x17
+        .byte   0
+        .byte   0
+        .uleb128 0x2
+        .uleb128 0x16
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0x24
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3e
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0xe
+        .byte   0
+        .byte   0
+        .uleb128 0x4
+        .uleb128 0x24
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3e
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0x8
+        .byte   0
+        .byte   0
+        .uleb128 0x5
+        .uleb128 0xf
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0x6
+        .uleb128 0xf
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x7
+        .uleb128 0x13
+        .byte   0x1
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x8
+        .uleb128 0xd
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x38
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0x9
+        .uleb128 0xd
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0x5
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x38
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0xa
+        .uleb128 0x16
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0x1
+        .byte   0x1
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xc
+        .uleb128 0x21
+        .byte   0
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x2f
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0xd
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x6
+        .uleb128 0x40
+        .uleb128 0x18
+        .uleb128 0x2117
+        .uleb128 0x19
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xe
+        .uleb128 0x4109
+        .byte   0x1
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xf
+        .uleb128 0x410a
+        .byte   0
+        .uleb128 0x2
+        .uleb128 0x18
+        .uleb128 0x2111
+        .uleb128 0x18
+        .byte   0
+        .byte   0
+        .uleb128 0x10
+        .uleb128 0x34
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3c
+        .uleb128 0x19
+        .byte   0
+        .byte   0
+        .uleb128 0x11
+        .uleb128 0x2e
+        .byte   0
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x6e
+        .uleb128 0xe
+        .byte   0
+        .byte   0
+        .byte   0
+        .section        .debug_aranges,"",@progbits
+        .4byte  0x1c
+        .2byte  0x2
+        .4byte  $Ldebug_info0
+        .byte   0x4
+        .byte   0
+        .2byte  0
+        .2byte  0
+        .4byte  $Ltext0
+        .4byte  $Letext0-$Ltext0
+        .4byte  0
+        .4byte  0
+        .section        .debug_line,"",@progbits
+$Ldebug_line0:
+        .section        .debug_str,"MS",@progbits,1
+$LASF23:
+        .ascii  "_IO_buf_end\000"
+$LASF9:
+        .ascii  "__quad_t\000"
+$LASF31:
+        .ascii  "_old_offset\000"
+$LASF56:
+        .ascii  "__builtin_puts\000"
+$LASF26:
+        .ascii  "_IO_save_end\000"
+$LASF52:
+        .ascii  "/tmp/compiler-explorer-compiler118012-54-8izljx.aer9e/ex"
+        .ascii  "ample.cpp\000"
+$LASF5:
+        .ascii  "short int\000"
+$LASF8:
+        .ascii  "size_t\000"
+$LASF13:
+        .ascii  "sizetype\000"
+$LASF36:
+        .ascii  "_offset\000"
+$LASF20:
+        .ascii  "_IO_write_ptr\000"
+$LASF15:
+        .ascii  "_flags\000"
+$LASF22:
+        .ascii  "_IO_buf_base\000"
+$LASF27:
+        .ascii  "_markers\000"
+$LASF17:
+        .ascii  "_IO_read_end\000"
+$LASF51:
+        .ascii  "GNU C++ 5.4.0 -meb -march=mips1 -mabi=32 -mhard-float -m"
+        .ascii  "llsc -mplt -mips1 -mno-shared -g -O\000"
+$LASF6:
+        .ascii  "long long int\000"
+$LASF35:
+        .ascii  "_lock\000"
+$LASF11:
+        .ascii  "long int\000"
+$LASF32:
+        .ascii  "_cur_column\000"
+$LASF48:
+        .ascii  "_pos\000"
+$LASF47:
+        .ascii  "_sbuf\000"
+$LASF44:
+        .ascii  "_IO_FILE\000"
+$LASF1:
+        .ascii  "unsigned char\000"
+$LASF4:
+        .ascii  "signed char\000"
+$LASF7:
+        .ascii  "long long unsigned int\000"
+$LASF0:
+        .ascii  "unsigned int\000"
+$LASF45:
+        .ascii  "_IO_marker\000"
+$LASF34:
+        .ascii  "_shortbuf\000"
+$LASF55:
+        .ascii  "puts\000"
+$LASF19:
+        .ascii  "_IO_write_base\000"
+$LASF43:
+        .ascii  "_unused2\000"
+$LASF16:
+        .ascii  "_IO_read_ptr\000"
+$LASF2:
+        .ascii  "short unsigned int\000"
+$LASF14:
+        .ascii  "char\000"
+$LASF54:
+        .ascii  "main\000"
+$LASF46:
+        .ascii  "_next\000"
+$LASF37:
+        .ascii  "__pad1\000"
+$LASF38:
+        .ascii  "__pad2\000"
+$LASF39:
+        .ascii  "__pad3\000"
+$LASF40:
+        .ascii  "__pad4\000"
+$LASF41:
+        .ascii  "__pad5\000"
+$LASF3:
+        .ascii  "long unsigned int\000"
+$LASF21:
+        .ascii  "_IO_write_end\000"
+$LASF12:
+        .ascii  "__off64_t\000"
+$LASF10:
+        .ascii  "__off_t\000"
+$LASF28:
+        .ascii  "_chain\000"
+$LASF25:
+        .ascii  "_IO_backup_base\000"
+$LASF49:
+        .ascii  "stdin\000"
+$LASF30:
+        .ascii  "_flags2\000"
+$LASF42:
+        .ascii  "_mode\000"
+$LASF18:
+        .ascii  "_IO_read_base\000"
+$LASF33:
+        .ascii  "_vtable_offset\000"
+$LASF24:
+        .ascii  "_IO_save_base\000"
+$LASF29:
+        .ascii  "_fileno\000"
+$LASF50:
+        .ascii  "stdout\000"
+$LASF53:
+        .ascii  "_IO_lock_t\000"
+        .ident  "GCC: (crosstool-NG crosstool-ng-1.23.0-rc2) 5.4.0"

--- a/test/demangle-cases/bug-660.asm.demangle
+++ b/test/demangle-cases/bug-660.asm.demangle
@@ -1,0 +1,768 @@
+        .section .mdebug.abi32
+        .previous
+        .nan    legacy
+        .module fp=32
+        .module nooddspreg
+        .abicalls
+        .option pic0
+        .text
+$Ltext0:
+        .section        .rodata.str1.4,"aMS",@progbits,1
+        .align  2
+$LC0:
+        .ascii  "hello world\000"
+        .text
+        .align  2
+        .globl  main
+$LFB12 = .
+        .file 1 "/tmp/compiler-explorer-compiler118012-54-8izljx.aer9e/example.cpp"
+        .loc 1 2 0
+        .cfi_startproc
+        .set    nomips16
+        .set    nomicromips
+        .ent    main
+        .type   main, @function
+main:
+        .frame  $sp,32,$31      # vars= 0, regs= 1/0, args= 16, gp= 8
+        .mask   0x80000000,-4
+        .fmask  0x00000000,0
+        .set    noreorder
+        .set    nomacro
+        addiu   $sp,$sp,-32
+        .cfi_def_cfa_offset 32
+        sw      $31,28($sp)
+        .cfi_offset 31, -4
+        .loc 1 3 0
+        lui     $4,%hi($LC0)
+        addiu   $4,$4,%lo($LC0)
+        jal     puts
+        nop
+
+$LVL0 = .
+        .loc 1 4 0
+        move    $2,$0
+        lw      $31,28($sp)
+        nop
+        j       $31
+        addiu   $sp,$sp,32
+
+        .cfi_def_cfa_offset 0
+        .cfi_restore 31
+        .set    macro
+        .set    reorder
+        .end    main
+        .cfi_endproc
+$LFE12:
+        .size   main, .-main
+$Letext0:
+        .file 2 "/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/lib/gcc/mips-unknown-linux-gnu/5.4.0/include/stddef.h"
+        .file 3 "/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/mips-unknown-linux-gnu/sysroot/usr/include/bits/types.h"
+        .file 4 "/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/mips-unknown-linux-gnu/sysroot/usr/include/libio.h"
+        .file 5 "/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/mips-unknown-linux-gnu/sysroot/usr/include/stdio.h"
+        .section        .debug_info,"",@progbits
+$Ldebug_info0:
+        .4byte  0x2dd
+        .2byte  0x4
+        .4byte  $Ldebug_abbrev0
+        .byte   0x4
+        .uleb128 0x1
+        .4byte  $LASF51
+        .byte   0x4
+        .4byte  $LASF52
+        .4byte  $Ltext0
+        .4byte  $Letext0-$Ltext0
+        .4byte  $Ldebug_line0
+        .uleb128 0x2
+        .4byte  $LASF8
+        .byte   0x2
+        .byte   0xd8
+        .4byte  0x2c
+        .uleb128 0x3
+        .byte   0x4
+        .byte   0x7
+        .4byte  $LASF0
+        .uleb128 0x3
+        .byte   0x1
+        .byte   0x8
+        .4byte  $LASF1
+        .uleb128 0x3
+        .byte   0x2
+        .byte   0x7
+        .4byte  $LASF2
+        .uleb128 0x3
+        .byte   0x4
+        .byte   0x7
+        .4byte  $LASF3
+        .uleb128 0x3
+        .byte   0x1
+        .byte   0x6
+        .4byte  $LASF4
+        .uleb128 0x3
+        .byte   0x2
+        .byte   0x5
+        .4byte  $LASF5
+        .uleb128 0x4
+        .byte   0x4
+        .byte   0x5
+        .ascii  "int\000"
+        .uleb128 0x3
+        .byte   0x8
+        .byte   0x5
+        .4byte  $LASF6
+        .uleb128 0x3
+        .byte   0x8
+        .byte   0x7
+        .4byte  $LASF7
+        .uleb128 0x2
+        .4byte  $LASF9
+        .byte   0x3
+        .byte   0x37
+        .4byte  0x5d
+        .uleb128 0x2
+        .4byte  $LASF10
+        .byte   0x3
+        .byte   0x8c
+        .4byte  0x81
+        .uleb128 0x3
+        .byte   0x4
+        .byte   0x5
+        .4byte  $LASF11
+        .uleb128 0x2
+        .4byte  $LASF12
+        .byte   0x3
+        .byte   0x8d
+        .4byte  0x6b
+        .uleb128 0x3
+        .byte   0x4
+        .byte   0x7
+        .4byte  $LASF13
+        .uleb128 0x5
+        .byte   0x4
+        .uleb128 0x6
+        .byte   0x4
+        .4byte  0xa2
+        .uleb128 0x3
+        .byte   0x1
+        .byte   0x6
+        .4byte  $LASF14
+        .uleb128 0x7
+        .4byte  $LASF44
+        .byte   0x98
+        .byte   0x4
+        .byte   0xf1
+        .4byte  0x226
+        .uleb128 0x8
+        .4byte  $LASF15
+        .byte   0x4
+        .byte   0xf2
+        .4byte  0x56
+        .byte   0
+        .uleb128 0x8
+        .4byte  $LASF16
+        .byte   0x4
+        .byte   0xf7
+        .4byte  0x9c
+        .byte   0x4
+        .uleb128 0x8
+        .4byte  $LASF17
+        .byte   0x4
+        .byte   0xf8
+        .4byte  0x9c
+        .byte   0x8
+        .uleb128 0x8
+        .4byte  $LASF18
+        .byte   0x4
+        .byte   0xf9
+        .4byte  0x9c
+        .byte   0xc
+        .uleb128 0x8
+        .4byte  $LASF19
+        .byte   0x4
+        .byte   0xfa
+        .4byte  0x9c
+        .byte   0x10
+        .uleb128 0x8
+        .4byte  $LASF20
+        .byte   0x4
+        .byte   0xfb
+        .4byte  0x9c
+        .byte   0x14
+        .uleb128 0x8
+        .4byte  $LASF21
+        .byte   0x4
+        .byte   0xfc
+        .4byte  0x9c
+        .byte   0x18
+        .uleb128 0x8
+        .4byte  $LASF22
+        .byte   0x4
+        .byte   0xfd
+        .4byte  0x9c
+        .byte   0x1c
+        .uleb128 0x8
+        .4byte  $LASF23
+        .byte   0x4
+        .byte   0xfe
+        .4byte  0x9c
+        .byte   0x20
+        .uleb128 0x9
+        .4byte  $LASF24
+        .byte   0x4
+        .2byte  0x100
+        .4byte  0x9c
+        .byte   0x24
+        .uleb128 0x9
+        .4byte  $LASF25
+        .byte   0x4
+        .2byte  0x101
+        .4byte  0x9c
+        .byte   0x28
+        .uleb128 0x9
+        .4byte  $LASF26
+        .byte   0x4
+        .2byte  0x102
+        .4byte  0x9c
+        .byte   0x2c
+        .uleb128 0x9
+        .4byte  $LASF27
+        .byte   0x4
+        .2byte  0x104
+        .4byte  0x25e
+        .byte   0x30
+        .uleb128 0x9
+        .4byte  $LASF28
+        .byte   0x4
+        .2byte  0x106
+        .4byte  0x264
+        .byte   0x34
+        .uleb128 0x9
+        .4byte  $LASF29
+        .byte   0x4
+        .2byte  0x108
+        .4byte  0x56
+        .byte   0x38
+        .uleb128 0x9
+        .4byte  $LASF30
+        .byte   0x4
+        .2byte  0x10c
+        .4byte  0x56
+        .byte   0x3c
+        .uleb128 0x9
+        .4byte  $LASF31
+        .byte   0x4
+        .2byte  0x10e
+        .4byte  0x76
+        .byte   0x40
+        .uleb128 0x9
+        .4byte  $LASF32
+        .byte   0x4
+        .2byte  0x112
+        .4byte  0x3a
+        .byte   0x44
+        .uleb128 0x9
+        .4byte  $LASF33
+        .byte   0x4
+        .2byte  0x113
+        .4byte  0x48
+        .byte   0x46
+        .uleb128 0x9
+        .4byte  $LASF34
+        .byte   0x4
+        .2byte  0x114
+        .4byte  0x26a
+        .byte   0x47
+        .uleb128 0x9
+        .4byte  $LASF35
+        .byte   0x4
+        .2byte  0x118
+        .4byte  0x27a
+        .byte   0x48
+        .uleb128 0x9
+        .4byte  $LASF36
+        .byte   0x4
+        .2byte  0x121
+        .4byte  0x88
+        .byte   0x50
+        .uleb128 0x9
+        .4byte  $LASF37
+        .byte   0x4
+        .2byte  0x129
+        .4byte  0x9a
+        .byte   0x58
+        .uleb128 0x9
+        .4byte  $LASF38
+        .byte   0x4
+        .2byte  0x12a
+        .4byte  0x9a
+        .byte   0x5c
+        .uleb128 0x9
+        .4byte  $LASF39
+        .byte   0x4
+        .2byte  0x12b
+        .4byte  0x9a
+        .byte   0x60
+        .uleb128 0x9
+        .4byte  $LASF40
+        .byte   0x4
+        .2byte  0x12c
+        .4byte  0x9a
+        .byte   0x64
+        .uleb128 0x9
+        .4byte  $LASF41
+        .byte   0x4
+        .2byte  0x12e
+        .4byte  0x21
+        .byte   0x68
+        .uleb128 0x9
+        .4byte  $LASF42
+        .byte   0x4
+        .2byte  0x12f
+        .4byte  0x56
+        .byte   0x6c
+        .uleb128 0x9
+        .4byte  $LASF43
+        .byte   0x4
+        .2byte  0x131
+        .4byte  0x280
+        .byte   0x70
+        .byte   0
+        .uleb128 0xa
+        .4byte  $LASF53
+        .byte   0x4
+        .byte   0x96
+        .uleb128 0x7
+        .4byte  $LASF45
+        .byte   0xc
+        .byte   0x4
+        .byte   0x9c
+        .4byte  0x25e
+        .uleb128 0x8
+        .4byte  $LASF46
+        .byte   0x4
+        .byte   0x9d
+        .4byte  0x25e
+        .byte   0
+        .uleb128 0x8
+        .4byte  $LASF47
+        .byte   0x4
+        .byte   0x9e
+        .4byte  0x264
+        .byte   0x4
+        .uleb128 0x8
+        .4byte  $LASF48
+        .byte   0x4
+        .byte   0xa2
+        .4byte  0x56
+        .byte   0x8
+        .byte   0
+        .uleb128 0x6
+        .byte   0x4
+        .4byte  0x22d
+        .uleb128 0x6
+        .byte   0x4
+        .4byte  0xa9
+        .uleb128 0xb
+        .4byte  0xa2
+        .4byte  0x27a
+        .uleb128 0xc
+        .4byte  0x93
+        .byte   0
+        .byte   0
+        .uleb128 0x6
+        .byte   0x4
+        .4byte  0x226
+        .uleb128 0xb
+        .4byte  0xa2
+        .4byte  0x290
+        .uleb128 0xc
+        .4byte  0x93
+        .byte   0x27
+        .byte   0
+        .uleb128 0xd
+        .4byte  $LASF54
+        .byte   0x1
+        .byte   0x2
+        .4byte  0x56
+        .4byte  $LFB12
+        .4byte  $LFE12-$LFB12
+        .uleb128 0x1
+        .byte   0x9c
+        .4byte  0x2bd
+        .uleb128 0xe
+        .4byte  $LVL0
+        .4byte  0x2d3
+        .uleb128 0xf
+        .uleb128 0x1
+        .byte   0x54
+        .uleb128 0x5
+        .byte   0x3
+        .4byte  $LC0
+        .byte   0
+        .byte   0
+        .uleb128 0x10
+        .4byte  $LASF49
+        .byte   0x5
+        .byte   0xab
+        .4byte  0x264
+        .uleb128 0x10
+        .4byte  $LASF50
+        .byte   0x5
+        .byte   0xac
+        .4byte  0x264
+        .uleb128 0x11
+        .4byte  $LASF55
+        .4byte  $LASF56
+        .4byte  $LASF55
+        .byte   0
+        .section        .debug_abbrev,"",@progbits
+$Ldebug_abbrev0:
+        .uleb128 0x1
+        .uleb128 0x11
+        .byte   0x1
+        .uleb128 0x25
+        .uleb128 0xe
+        .uleb128 0x13
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x6
+        .uleb128 0x10
+        .uleb128 0x17
+        .byte   0
+        .byte   0
+        .uleb128 0x2
+        .uleb128 0x16
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0x24
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3e
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0xe
+        .byte   0
+        .byte   0
+        .uleb128 0x4
+        .uleb128 0x24
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3e
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0x8
+        .byte   0
+        .byte   0
+        .uleb128 0x5
+        .uleb128 0xf
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0x6
+        .uleb128 0xf
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x7
+        .uleb128 0x13
+        .byte   0x1
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x8
+        .uleb128 0xd
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x38
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0x9
+        .uleb128 0xd
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0x5
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x38
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0xa
+        .uleb128 0x16
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0x1
+        .byte   0x1
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xc
+        .uleb128 0x21
+        .byte   0
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x2f
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0xd
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x6
+        .uleb128 0x40
+        .uleb128 0x18
+        .uleb128 0x2117
+        .uleb128 0x19
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xe
+        .uleb128 0x4109
+        .byte   0x1
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xf
+        .uleb128 0x410a
+        .byte   0
+        .uleb128 0x2
+        .uleb128 0x18
+        .uleb128 0x2111
+        .uleb128 0x18
+        .byte   0
+        .byte   0
+        .uleb128 0x10
+        .uleb128 0x34
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3c
+        .uleb128 0x19
+        .byte   0
+        .byte   0
+        .uleb128 0x11
+        .uleb128 0x2e
+        .byte   0
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x6e
+        .uleb128 0xe
+        .byte   0
+        .byte   0
+        .byte   0
+        .section        .debug_aranges,"",@progbits
+        .4byte  0x1c
+        .2byte  0x2
+        .4byte  $Ldebug_info0
+        .byte   0x4
+        .byte   0
+        .2byte  0
+        .2byte  0
+        .4byte  $Ltext0
+        .4byte  $Letext0-$Ltext0
+        .4byte  0
+        .4byte  0
+        .section        .debug_line,"",@progbits
+$Ldebug_line0:
+        .section        .debug_str,"MS",@progbits,1
+$LASF23:
+        .ascii  "_IO_buf_end\000"
+$LASF9:
+        .ascii  "__quad_t\000"
+$LASF31:
+        .ascii  "_old_offset\000"
+$LASF56:
+        .ascii  "__builtin_puts\000"
+$LASF26:
+        .ascii  "_IO_save_end\000"
+$LASF52:
+        .ascii  "/tmp/compiler-explorer-compiler118012-54-8izljx.aer9e/ex"
+        .ascii  "ample.cpp\000"
+$LASF5:
+        .ascii  "short int\000"
+$LASF8:
+        .ascii  "size_t\000"
+$LASF13:
+        .ascii  "sizetype\000"
+$LASF36:
+        .ascii  "_offset\000"
+$LASF20:
+        .ascii  "_IO_write_ptr\000"
+$LASF15:
+        .ascii  "_flags\000"
+$LASF22:
+        .ascii  "_IO_buf_base\000"
+$LASF27:
+        .ascii  "_markers\000"
+$LASF17:
+        .ascii  "_IO_read_end\000"
+$LASF51:
+        .ascii  "GNU C++ 5.4.0 -meb -march=mips1 -mabi=32 -mhard-float -m"
+        .ascii  "llsc -mplt -mips1 -mno-shared -g -O\000"
+$LASF6:
+        .ascii  "long long int\000"
+$LASF35:
+        .ascii  "_lock\000"
+$LASF11:
+        .ascii  "long int\000"
+$LASF32:
+        .ascii  "_cur_column\000"
+$LASF48:
+        .ascii  "_pos\000"
+$LASF47:
+        .ascii  "_sbuf\000"
+$LASF44:
+        .ascii  "_IO_FILE\000"
+$LASF1:
+        .ascii  "unsigned char\000"
+$LASF4:
+        .ascii  "signed char\000"
+$LASF7:
+        .ascii  "long long unsigned int\000"
+$LASF0:
+        .ascii  "unsigned int\000"
+$LASF45:
+        .ascii  "_IO_marker\000"
+$LASF34:
+        .ascii  "_shortbuf\000"
+$LASF55:
+        .ascii  "puts\000"
+$LASF19:
+        .ascii  "_IO_write_base\000"
+$LASF43:
+        .ascii  "_unused2\000"
+$LASF16:
+        .ascii  "_IO_read_ptr\000"
+$LASF2:
+        .ascii  "short unsigned int\000"
+$LASF14:
+        .ascii  "char\000"
+$LASF54:
+        .ascii  "main\000"
+$LASF46:
+        .ascii  "_next\000"
+$LASF37:
+        .ascii  "__pad1\000"
+$LASF38:
+        .ascii  "__pad2\000"
+$LASF39:
+        .ascii  "__pad3\000"
+$LASF40:
+        .ascii  "__pad4\000"
+$LASF41:
+        .ascii  "__pad5\000"
+$LASF3:
+        .ascii  "long unsigned int\000"
+$LASF21:
+        .ascii  "_IO_write_end\000"
+$LASF12:
+        .ascii  "__off64_t\000"
+$LASF10:
+        .ascii  "__off_t\000"
+$LASF28:
+        .ascii  "_chain\000"
+$LASF25:
+        .ascii  "_IO_backup_base\000"
+$LASF49:
+        .ascii  "stdin\000"
+$LASF30:
+        .ascii  "_flags2\000"
+$LASF42:
+        .ascii  "_mode\000"
+$LASF18:
+        .ascii  "_IO_read_base\000"
+$LASF33:
+        .ascii  "_vtable_offset\000"
+$LASF24:
+        .ascii  "_IO_save_base\000"
+$LASF29:
+        .ascii  "_fileno\000"
+$LASF50:
+        .ascii  "stdout\000"
+$LASF53:
+        .ascii  "_IO_lock_t\000"
+        .ident  "GCC: (crosstool-NG crosstool-ng-1.23.0-rc2) 5.4.0"

--- a/test/demangle-cases/bug-713.asm
+++ b/test/demangle-cases/bug-713.asm
@@ -1,0 +1,1287 @@
+        .file   "example.cpp"
+        .text
+.Ltext0:
+        .section        .text._ZN6NormalD2Ev,"axG",@progbits,_ZN6NormalD5Ev,comdat
+        .align 2
+        .p2align 4,,15
+        .weak   _ZN6NormalD2Ev
+        .type   _ZN6NormalD2Ev, @function
+_ZN6NormalD2Ev:
+.LFB6:
+        .file 1 "/tmp/compiler-explorer-compiler118012-54-4arhbo.s5ady/example.cpp"
+        .loc 1 8 0
+        .cfi_startproc
+.LVL0:
+.LBB11:
+        .loc 1 8 0
+        movq    $_ZTV6Normal+16, (%rdi)
+        addq    $8, %rdi
+.LVL1:
+        jmp     _ZN3FooD1Ev
+.LVL2:
+.LBE11:
+        .cfi_endproc
+.LFE6:
+        .size   _ZN6NormalD2Ev, .-_ZN6NormalD2Ev
+        .weak   _ZN6NormalD1Ev
+        .set    _ZN6NormalD1Ev,_ZN6NormalD2Ev
+        .section        .text._ZN6NormalD0Ev,"axG",@progbits,_ZN6NormalD5Ev,comdat
+        .align 2
+        .p2align 4,,15
+        .weak   _ZN6NormalD0Ev
+        .type   _ZN6NormalD0Ev, @function
+_ZN6NormalD0Ev:
+.LFB8:
+        .loc 1 8 0
+        .cfi_startproc
+.LVL3:
+        pushq   %rbx
+        .cfi_def_cfa_offset 16
+        .cfi_offset 3, -16
+        .loc 1 8 0
+        movq    %rdi, %rbx
+.LBB14:
+.LBB15:
+        movq    $_ZTV6Normal+16, (%rdi)
+        leaq    8(%rdi), %rdi
+.LVL4:
+        call    _ZN3FooD1Ev
+.LVL5:
+.LBE15:
+.LBE14:
+        movq    %rbx, %rdi
+        movl    $16, %esi
+        popq    %rbx
+        .cfi_def_cfa_offset 8
+.LVL6:
+        jmp     _ZdlPvm
+.LVL7:
+        .cfi_endproc
+.LFE8:
+        .size   _ZN6NormalD0Ev, .-_ZN6NormalD0Ev
+        .text
+        .p2align 4,,15
+        .globl  _Z7caller1v
+        .type   _Z7caller1v, @function
+_Z7caller1v:
+.LFB0:
+        .loc 1 14 0
+        .cfi_startproc
+        subq    $24, %rsp
+        .cfi_def_cfa_offset 32
+.LVL8:
+.LBB16:
+.LBB17:
+        .loc 1 6 0
+        leaq    8(%rsp), %rdi
+        movq    $_ZTV6Normal+16, (%rsp)
+        call    _ZN3FooC1Ev
+.LVL9:
+.LBE17:
+.LBE16:
+.LBB18:
+.LBB19:
+        .loc 1 8 0
+        leaq    8(%rsp), %rdi
+        movq    $_ZTV6Normal+16, (%rsp)
+        call    _ZN3FooD1Ev
+.LVL10:
+.LBE19:
+.LBE18:
+        .loc 1 16 0
+        addq    $24, %rsp
+        .cfi_def_cfa_offset 8
+        ret
+        .cfi_endproc
+.LFE0:
+        .size   _Z7caller1v, .-_Z7caller1v
+        .p2align 4,,15
+        .globl  _Z7caller2P6Normal
+        .type   _Z7caller2P6Normal, @function
+_Z7caller2P6Normal:
+.LFB4:
+        .loc 1 18 0
+        .cfi_startproc
+.LVL11:
+        .loc 1 19 0
+        testq   %rdi, %rdi
+        je      .L7
+        .loc 1 19 0 is_stmt 0 discriminator 1
+        movq    (%rdi), %rax
+        movq    8(%rax), %rax
+        cmpq    $_ZN6NormalD0Ev, %rax
+        jne     .L9
+        .loc 1 18 0 is_stmt 1
+        pushq   %rbx
+        .cfi_def_cfa_offset 16
+        .cfi_offset 3, -16
+        movq    %rdi, %rbx
+.LVL12:
+.LBB24:
+.LBB25:
+.LBB26:
+.LBB27:
+        .loc 1 8 0
+        movq    $_ZTV6Normal+16, (%rdi)
+        leaq    8(%rdi), %rdi
+.LVL13:
+        call    _ZN3FooD1Ev
+.LVL14:
+.LBE27:
+.LBE26:
+        movq    %rbx, %rdi
+        movl    $16, %esi
+.LBE25:
+.LBE24:
+        .loc 1 20 0
+        popq    %rbx
+        .cfi_restore 3
+        .cfi_def_cfa_offset 8
+.LVL15:
+.LBB29:
+.LBB28:
+        .loc 1 8 0
+        jmp     _ZdlPvm
+.LVL16:
+        .p2align 4,,10
+        .p2align 3
+.L7:
+        rep ret
+        .p2align 4,,10
+        .p2align 3
+.L9:
+.LBE28:
+.LBE29:
+        .loc 1 19 0 discriminator 1
+        jmp     *%rax
+.LVL17:
+        .cfi_endproc
+.LFE4:
+        .size   _Z7caller2P6Normal, .-_Z7caller2P6Normal
+        .weak   _ZTS6Normal
+        .section        .rodata._ZTS6Normal,"aG",@progbits,_ZTS6Normal,comdat
+        .align 8
+        .type   _ZTS6Normal, @object
+        .size   _ZTS6Normal, 8
+_ZTS6Normal:
+        .string "6Normal"
+        .weak   _ZTI6Normal
+        .section        .rodata._ZTI6Normal,"aG",@progbits,_ZTI6Normal,comdat
+        .align 8
+        .type   _ZTI6Normal, @object
+        .size   _ZTI6Normal, 16
+_ZTI6Normal:
+        .quad   _ZTVN10__cxxabiv117__class_type_infoE+16
+        .quad   _ZTS6Normal
+        .weak   _ZTV6Normal
+        .section        .rodata._ZTV6Normal,"aG",@progbits,_ZTV6Normal,comdat
+        .align 8
+        .type   _ZTV6Normal, @object
+        .size   _ZTV6Normal, 32
+_ZTV6Normal:
+        .quad   0
+        .quad   _ZTI6Normal
+        .quad   _ZN6NormalD1Ev
+        .quad   _ZN6NormalD0Ev
+        .text
+.Letext0:
+        .section        .debug_info,"",@progbits
+.Ldebug_info0:
+        .long   0x379
+        .value  0x4
+        .long   .Ldebug_abbrev0
+        .byte   0x8
+        .uleb128 0x1
+        .long   .LASF9
+        .byte   0x4
+        .long   .LASF10
+        .long   .LASF11
+        .long   .Ldebug_ranges0+0x30
+        .quad   0
+        .long   .Ldebug_line0
+        .uleb128 0x2
+        .string "Foo"
+        .byte   0x1
+        .byte   0x1
+        .byte   0x1
+        .long   0x69
+        .uleb128 0x3
+        .string "Foo"
+        .byte   0x1
+        .byte   0x2
+        .long   .LASF12
+        .long   0x48
+        .long   0x4e
+        .uleb128 0x4
+        .long   0x69
+        .byte   0
+        .uleb128 0x5
+        .long   .LASF13
+        .byte   0x1
+        .byte   0x3
+        .long   .LASF14
+        .long   0x5d
+        .uleb128 0x4
+        .long   0x69
+        .uleb128 0x4
+        .long   0x6f
+        .byte   0
+        .byte   0
+        .uleb128 0x6
+        .byte   0x8
+        .long   0x29
+        .uleb128 0x7
+        .byte   0x4
+        .byte   0x5
+        .string "int"
+        .uleb128 0x8
+        .long   0x6f
+        .uleb128 0x9
+        .long   .LASF2
+        .byte   0x10
+        .byte   0x1
+        .byte   0x6
+        .long   0x7b
+        .long   0xf9
+        .uleb128 0xa
+        .long   .LASF0
+        .long   0x109
+        .byte   0
+        .byte   0x1
+        .uleb128 0xb
+        .long   .LASF1
+        .byte   0x1
+        .byte   0xb
+        .long   0x29
+        .byte   0x8
+        .uleb128 0xc
+        .long   .LASF2
+        .long   .LASF3
+        .byte   0x1
+        .long   0xb4
+        .long   0xbf
+        .uleb128 0x4
+        .long   0x119
+        .uleb128 0xd
+        .long   0x124
+        .byte   0
+        .uleb128 0xc
+        .long   .LASF2
+        .long   .LASF4
+        .byte   0x1
+        .long   0xd1
+        .long   0xd7
+        .uleb128 0x4
+        .long   0x119
+        .byte   0
+        .uleb128 0xe
+        .long   .LASF15
+        .byte   0x1
+        .byte   0x8
+        .long   .LASF16
+        .byte   0x1
+        .long   0x7b
+        .byte   0x1
+        .byte   0x1
+        .long   0xed
+        .uleb128 0x4
+        .long   0x119
+        .uleb128 0x4
+        .long   0x6f
+        .byte   0
+        .byte   0
+        .uleb128 0x8
+        .long   0x7b
+        .uleb128 0xf
+        .long   0x6f
+        .long   0x109
+        .uleb128 0x10
+        .byte   0
+        .uleb128 0x6
+        .byte   0x8
+        .long   0x10f
+        .uleb128 0x11
+        .byte   0x8
+        .long   .LASF17
+        .long   0xfe
+        .uleb128 0x6
+        .byte   0x8
+        .long   0x7b
+        .uleb128 0x8
+        .long   0x119
+        .uleb128 0x12
+        .byte   0x8
+        .long   0xf9
+        .uleb128 0x13
+        .long   0xd7
+        .byte   0x2
+        .long   0x138
+        .long   0x14b
+        .uleb128 0x14
+        .long   .LASF5
+        .long   0x11f
+        .uleb128 0x14
+        .long   .LASF6
+        .long   0x76
+        .byte   0
+        .uleb128 0x15
+        .long   0x12a
+        .long   .LASF7
+        .long   0x172
+        .quad   .LFB8
+        .quad   .LFE8-.LFB8
+        .uleb128 0x1
+        .byte   0x9c
+        .long   0x172
+        .long   0x1cb
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST1
+        .uleb128 0x17
+        .long   0x12a
+        .quad   .LBB14
+        .quad   .LBE14-.LBB14
+        .byte   0x1
+        .byte   0x8
+        .long   0x1b0
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST2
+        .uleb128 0x18
+        .quad   .LVL5
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x2
+        .byte   0x73
+        .sleb128 8
+        .byte   0
+        .byte   0
+        .uleb128 0x1a
+        .quad   .LVL7
+        .long   0x36f
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x3
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x54
+        .uleb128 0x1
+        .byte   0x40
+        .byte   0
+        .byte   0
+        .uleb128 0x15
+        .long   0x12a
+        .long   .LASF8
+        .long   0x1f2
+        .quad   .LFB6
+        .quad   .LFE6-.LFB6
+        .uleb128 0x1
+        .byte   0x9c
+        .long   0x1f2
+        .long   0x20f
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST0
+        .uleb128 0x1b
+        .quad   .LVL2
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x5
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x23
+        .uleb128 0x8
+        .byte   0
+        .byte   0
+        .uleb128 0x1c
+        .long   .LASF18
+        .byte   0x1
+        .byte   0x12
+        .long   .LASF19
+        .quad   .LFB4
+        .quad   .LFE4-.LFB4
+        .uleb128 0x1
+        .byte   0x9c
+        .long   0x2aa
+        .uleb128 0x1d
+        .string "n"
+        .byte   0x1
+        .byte   0x12
+        .long   0x119
+        .long   .LLST5
+        .uleb128 0x1e
+        .long   0x12a
+        .quad   .LBB24
+        .long   .Ldebug_ranges0+0
+        .byte   0x1
+        .byte   0x13
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST6
+        .uleb128 0x17
+        .long   0x12a
+        .quad   .LBB26
+        .quad   .LBE26-.LBB26
+        .byte   0x1
+        .byte   0x8
+        .long   0x28e
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST7
+        .uleb128 0x18
+        .quad   .LVL14
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x2
+        .byte   0x73
+        .sleb128 8
+        .byte   0
+        .byte   0
+        .uleb128 0x1a
+        .quad   .LVL16
+        .long   0x36f
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x3
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x54
+        .uleb128 0x1
+        .byte   0x40
+        .byte   0
+        .byte   0
+        .byte   0
+        .uleb128 0x1f
+        .long   .LASF20
+        .byte   0x1
+        .byte   0xe
+        .long   .LASF21
+        .quad   .LFB0
+        .quad   .LFE0-.LFB0
+        .uleb128 0x1
+        .byte   0x9c
+        .long   0x33e
+        .uleb128 0x20
+        .string "n"
+        .byte   0x1
+        .byte   0xf
+        .long   0x7b
+        .uleb128 0x2
+        .byte   0x91
+        .sleb128 -32
+        .uleb128 0x17
+        .long   0x33e
+        .quad   .LBB16
+        .quad   .LBE16-.LBB16
+        .byte   0x1
+        .byte   0xf
+        .long   0x30c
+        .uleb128 0x16
+        .long   0x34e
+        .long   .LLST3
+        .uleb128 0x18
+        .quad   .LVL9
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x2
+        .byte   0x91
+        .sleb128 -24
+        .byte   0
+        .byte   0
+        .uleb128 0x21
+        .long   0x12a
+        .quad   .LBB18
+        .quad   .LBE18-.LBB18
+        .byte   0x1
+        .byte   0xf
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST4
+        .uleb128 0x18
+        .quad   .LVL10
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x2
+        .byte   0x91
+        .sleb128 -24
+        .byte   0
+        .byte   0
+        .byte   0
+        .uleb128 0x22
+        .long   0xbf
+        .byte   0x1
+        .byte   0x6
+        .byte   0x2
+        .long   0x34e
+        .long   0x358
+        .uleb128 0x14
+        .long   .LASF5
+        .long   0x11f
+        .byte   0
+        .uleb128 0x23
+        .long   0x33e
+        .long   .LASF22
+        .long   0x369
+        .long   0x36f
+        .uleb128 0x24
+        .long   0x34e
+        .byte   0
+        .uleb128 0x25
+        .long   .LASF23
+        .long   .LASF24
+        .long   .LASF23
+        .byte   0
+        .section        .debug_abbrev,"",@progbits
+.Ldebug_abbrev0:
+        .uleb128 0x1
+        .uleb128 0x11
+        .byte   0x1
+        .uleb128 0x25
+        .uleb128 0xe
+        .uleb128 0x13
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x1b
+        .uleb128 0xe
+        .uleb128 0x55
+        .uleb128 0x17
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x10
+        .uleb128 0x17
+        .byte   0
+        .byte   0
+        .uleb128 0x2
+        .uleb128 0x13
+        .byte   0x1
+        .uleb128 0x3
+        .uleb128 0x8
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0x8
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x4
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x34
+        .uleb128 0x19
+        .byte   0
+        .byte   0
+        .uleb128 0x5
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x64
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x6
+        .uleb128 0xf
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x7
+        .uleb128 0x24
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3e
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0x8
+        .byte   0
+        .byte   0
+        .uleb128 0x8
+        .uleb128 0x26
+        .byte   0
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x9
+        .uleb128 0x2
+        .byte   0x1
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x1d
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xa
+        .uleb128 0xd
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x38
+        .uleb128 0xb
+        .uleb128 0x34
+        .uleb128 0x19
+        .uleb128 0x32
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xd
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x38
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0xc
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x34
+        .uleb128 0x19
+        .uleb128 0x32
+        .uleb128 0xb
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xd
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xe
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x4c
+        .uleb128 0xb
+        .uleb128 0x1d
+        .uleb128 0x13
+        .uleb128 0x32
+        .uleb128 0xb
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x8b
+        .uleb128 0xb
+        .uleb128 0x64
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xf
+        .uleb128 0x15
+        .byte   0x1
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x10
+        .uleb128 0x18
+        .byte   0
+        .byte   0
+        .byte   0
+        .uleb128 0x11
+        .uleb128 0xf
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x12
+        .uleb128 0x10
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x13
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x47
+        .uleb128 0x13
+        .uleb128 0x20
+        .uleb128 0xb
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x14
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x34
+        .uleb128 0x19
+        .byte   0
+        .byte   0
+        .uleb128 0x15
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x7
+        .uleb128 0x40
+        .uleb128 0x18
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x2117
+        .uleb128 0x19
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x16
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x2
+        .uleb128 0x17
+        .byte   0
+        .byte   0
+        .uleb128 0x17
+        .uleb128 0x1d
+        .byte   0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x7
+        .uleb128 0x58
+        .uleb128 0xb
+        .uleb128 0x59
+        .uleb128 0xb
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x18
+        .uleb128 0x4109
+        .byte   0x1
+        .uleb128 0x11
+        .uleb128 0x1
+        .byte   0
+        .byte   0
+        .uleb128 0x19
+        .uleb128 0x410a
+        .byte   0
+        .uleb128 0x2
+        .uleb128 0x18
+        .uleb128 0x2111
+        .uleb128 0x18
+        .byte   0
+        .byte   0
+        .uleb128 0x1a
+        .uleb128 0x4109
+        .byte   0x1
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x2115
+        .uleb128 0x19
+        .uleb128 0x31
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x1b
+        .uleb128 0x4109
+        .byte   0x1
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x2115
+        .uleb128 0x19
+        .byte   0
+        .byte   0
+        .uleb128 0x1c
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x7
+        .uleb128 0x40
+        .uleb128 0x18
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x1d
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0x8
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x2
+        .uleb128 0x17
+        .byte   0
+        .byte   0
+        .uleb128 0x1e
+        .uleb128 0x1d
+        .byte   0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x52
+        .uleb128 0x1
+        .uleb128 0x55
+        .uleb128 0x17
+        .uleb128 0x58
+        .uleb128 0xb
+        .uleb128 0x59
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0x1f
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x7
+        .uleb128 0x40
+        .uleb128 0x18
+        .uleb128 0x2117
+        .uleb128 0x19
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x20
+        .uleb128 0x34
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0x8
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x2
+        .uleb128 0x18
+        .byte   0
+        .byte   0
+        .uleb128 0x21
+        .uleb128 0x1d
+        .byte   0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x7
+        .uleb128 0x58
+        .uleb128 0xb
+        .uleb128 0x59
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0x22
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x47
+        .uleb128 0x13
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x20
+        .uleb128 0xb
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x23
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x24
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x31
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x25
+        .uleb128 0x2e
+        .byte   0
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x6e
+        .uleb128 0xe
+        .byte   0
+        .byte   0
+        .byte   0
+        .section        .debug_loc,"",@progbits
+.Ldebug_loc0:
+.LLST1:
+        .quad   .LVL3
+        .quad   .LVL4
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL4
+        .quad   .LVL6
+        .value  0x1
+        .byte   0x53
+        .quad   .LVL6
+        .quad   .LVL7-1
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL7-1
+        .quad   .LFE8
+        .value  0x4
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x9f
+        .quad   0
+        .quad   0
+.LLST2:
+        .quad   .LVL3
+        .quad   .LVL4
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL4
+        .quad   .LVL5
+        .value  0x1
+        .byte   0x53
+        .quad   0
+        .quad   0
+.LLST0:
+        .quad   .LVL0
+        .quad   .LVL1
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL1
+        .quad   .LVL2-1
+        .value  0x3
+        .byte   0x75
+        .sleb128 -8
+        .byte   0x9f
+        .quad   .LVL2-1
+        .quad   .LFE6
+        .value  0x4
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x9f
+        .quad   0
+        .quad   0
+.LLST5:
+        .quad   .LVL11
+        .quad   .LVL13
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL13
+        .quad   .LVL15
+        .value  0x1
+        .byte   0x53
+        .quad   .LVL15
+        .quad   .LVL16-1
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL16-1
+        .quad   .LVL16
+        .value  0x4
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x9f
+        .quad   .LVL16
+        .quad   .LVL17-1
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL17-1
+        .quad   .LFE4
+        .value  0x4
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x9f
+        .quad   0
+        .quad   0
+.LLST6:
+        .quad   .LVL12
+        .quad   .LVL13
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL13
+        .quad   .LVL15
+        .value  0x1
+        .byte   0x53
+        .quad   .LVL15
+        .quad   .LVL16-1
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL16-1
+        .quad   .LVL16
+        .value  0x4
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x9f
+        .quad   0
+        .quad   0
+.LLST7:
+        .quad   .LVL12
+        .quad   .LVL13
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL13
+        .quad   .LVL14
+        .value  0x1
+        .byte   0x53
+        .quad   0
+        .quad   0
+.LLST3:
+        .quad   .LVL8
+        .quad   .LVL9
+        .value  0x1
+        .byte   0x57
+        .quad   0
+        .quad   0
+.LLST4:
+        .quad   .LVL9
+        .quad   .LVL10
+        .value  0x1
+        .byte   0x57
+        .quad   0
+        .quad   0
+        .section        .debug_aranges,"",@progbits
+        .long   0x4c
+        .value  0x2
+        .long   .Ldebug_info0
+        .byte   0x8
+        .byte   0
+        .value  0
+        .value  0
+        .quad   .Ltext0
+        .quad   .Letext0-.Ltext0
+        .quad   .LFB6
+        .quad   .LFE6-.LFB6
+        .quad   .LFB8
+        .quad   .LFE8-.LFB8
+        .quad   0
+        .quad   0
+        .section        .debug_ranges,"",@progbits
+.Ldebug_ranges0:
+        .quad   .LBB24
+        .quad   .LBE24
+        .quad   .LBB29
+        .quad   .LBE29
+        .quad   0
+        .quad   0
+        .quad   .Ltext0
+        .quad   .Letext0
+        .quad   .LFB6
+        .quad   .LFE6
+        .quad   .LFB8
+        .quad   .LFE8
+        .quad   0
+        .quad   0
+        .section        .debug_line,"",@progbits
+.Ldebug_line0:
+        .section        .debug_str,"MS",@progbits,1
+.LASF21:
+        .string "_Z7caller1v"
+.LASF16:
+        .string "_ZN6NormalD4Ev"
+.LASF3:
+        .string "_ZN6NormalC4ERKS_"
+.LASF9:
+        .string "GNU C++14 7.2.0 -mtune=generic -march=x86-64 -g -O2 -std=c++1z"
+.LASF22:
+        .string "_ZN6NormalC2Ev"
+.LASF17:
+        .string "__vtbl_ptr_type"
+.LASF1:
+        .string "foo_"
+.LASF0:
+        .string "_vptr.Normal"
+.LASF23:
+        .string "_ZdlPvm"
+.LASF13:
+        .string "~Foo"
+.LASF14:
+        .string "_ZN3FooD4Ev"
+.LASF11:
+        .string "/compiler-explorer"
+.LASF4:
+        .string "_ZN6NormalC4Ev"
+.LASF5:
+        .string "this"
+.LASF2:
+        .string "Normal"
+.LASF15:
+        .string "~Normal"
+.LASF10:
+        .string "/tmp/compiler-explorer-compiler118012-54-4arhbo.s5ady/example.cpp"
+.LASF6:
+        .string "__in_chrg"
+.LASF7:
+        .string "_ZN6NormalD0Ev"
+.LASF19:
+        .string "_Z7caller2P6Normal"
+.LASF20:
+        .string "caller1"
+.LASF18:
+        .string "caller2"
+.LASF8:
+        .string "_ZN6NormalD2Ev"
+.LASF12:
+        .string "_ZN3FooC4Ev"
+.LASF24:
+        .string "operator delete"
+        .ident  "GCC: (GCC-Explorer-Build) 7.2.0"
+        .section        .note.GNU-stack,"",@progbits

--- a/test/demangle-cases/bug-713.asm.demangle
+++ b/test/demangle-cases/bug-713.asm.demangle
@@ -1,0 +1,1287 @@
+        .file   "example.cpp"
+        .text
+.Ltext0:
+        .section        .text.Normal::~Normal() [base object destructor],"axG",@progbits,_ZN6NormalD5Ev,comdat
+        .align 2
+        .p2align 4,,15
+        .weak   Normal::~Normal() [base object destructor]
+        .type   Normal::~Normal() [base object destructor], @function
+Normal::~Normal() [base object destructor]:
+.LFB6:
+        .file 1 "/tmp/compiler-explorer-compiler118012-54-4arhbo.s5ady/example.cpp"
+        .loc 1 8 0
+        .cfi_startproc
+.LVL0:
+.LBB11:
+        .loc 1 8 0
+        movq    $vtable for Normal+16, (%rdi)
+        addq    $8, %rdi
+.LVL1:
+        jmp     Foo::~Foo() [complete object destructor]
+.LVL2:
+.LBE11:
+        .cfi_endproc
+.LFE6:
+        .size   Normal::~Normal() [base object destructor], .-Normal::~Normal() [base object destructor]
+        .weak   _ZN6NormalD1Ev
+        .set    _ZN6NormalD1Ev,Normal::~Normal() [base object destructor]
+        .section        .text.Normal::~Normal() [deleting destructor],"axG",@progbits,_ZN6NormalD5Ev,comdat
+        .align 2
+        .p2align 4,,15
+        .weak   Normal::~Normal() [deleting destructor]
+        .type   Normal::~Normal() [deleting destructor], @function
+Normal::~Normal() [deleting destructor]:
+.LFB8:
+        .loc 1 8 0
+        .cfi_startproc
+.LVL3:
+        pushq   %rbx
+        .cfi_def_cfa_offset 16
+        .cfi_offset 3, -16
+        .loc 1 8 0
+        movq    %rdi, %rbx
+.LBB14:
+.LBB15:
+        movq    $vtable for Normal+16, (%rdi)
+        leaq    8(%rdi), %rdi
+.LVL4:
+        call    Foo::~Foo() [complete object destructor]
+.LVL5:
+.LBE15:
+.LBE14:
+        movq    %rbx, %rdi
+        movl    $16, %esi
+        popq    %rbx
+        .cfi_def_cfa_offset 8
+.LVL6:
+        jmp     operator delete(void*, unsigned long)
+.LVL7:
+        .cfi_endproc
+.LFE8:
+        .size   Normal::~Normal() [deleting destructor], .-Normal::~Normal() [deleting destructor]
+        .text
+        .p2align 4,,15
+        .globl  caller1()
+        .type   caller1(), @function
+caller1():
+.LFB0:
+        .loc 1 14 0
+        .cfi_startproc
+        subq    $24, %rsp
+        .cfi_def_cfa_offset 32
+.LVL8:
+.LBB16:
+.LBB17:
+        .loc 1 6 0
+        leaq    8(%rsp), %rdi
+        movq    $vtable for Normal+16, (%rsp)
+        call    Foo::Foo() [complete object constructor]
+.LVL9:
+.LBE17:
+.LBE16:
+.LBB18:
+.LBB19:
+        .loc 1 8 0
+        leaq    8(%rsp), %rdi
+        movq    $vtable for Normal+16, (%rsp)
+        call    Foo::~Foo() [complete object destructor]
+.LVL10:
+.LBE19:
+.LBE18:
+        .loc 1 16 0
+        addq    $24, %rsp
+        .cfi_def_cfa_offset 8
+        ret
+        .cfi_endproc
+.LFE0:
+        .size   caller1(), .-caller1()
+        .p2align 4,,15
+        .globl  caller2(Normal*)
+        .type   caller2(Normal*), @function
+caller2(Normal*):
+.LFB4:
+        .loc 1 18 0
+        .cfi_startproc
+.LVL11:
+        .loc 1 19 0
+        testq   %rdi, %rdi
+        je      .L7
+        .loc 1 19 0 is_stmt 0 discriminator 1
+        movq    (%rdi), %rax
+        movq    8(%rax), %rax
+        cmpq    $Normal::~Normal() [deleting destructor], %rax
+        jne     .L9
+        .loc 1 18 0 is_stmt 1
+        pushq   %rbx
+        .cfi_def_cfa_offset 16
+        .cfi_offset 3, -16
+        movq    %rdi, %rbx
+.LVL12:
+.LBB24:
+.LBB25:
+.LBB26:
+.LBB27:
+        .loc 1 8 0
+        movq    $vtable for Normal+16, (%rdi)
+        leaq    8(%rdi), %rdi
+.LVL13:
+        call    Foo::~Foo() [complete object destructor]
+.LVL14:
+.LBE27:
+.LBE26:
+        movq    %rbx, %rdi
+        movl    $16, %esi
+.LBE25:
+.LBE24:
+        .loc 1 20 0
+        popq    %rbx
+        .cfi_restore 3
+        .cfi_def_cfa_offset 8
+.LVL15:
+.LBB29:
+.LBB28:
+        .loc 1 8 0
+        jmp     operator delete(void*, unsigned long)
+.LVL16:
+        .p2align 4,,10
+        .p2align 3
+.L7:
+        rep ret
+        .p2align 4,,10
+        .p2align 3
+.L9:
+.LBE28:
+.LBE29:
+        .loc 1 19 0 discriminator 1
+        jmp     *%rax
+.LVL17:
+        .cfi_endproc
+.LFE4:
+        .size   caller2(Normal*), .-caller2(Normal*)
+        .weak   typeinfo name for Normal
+        .section        .rodata.typeinfo name for Normal,"aG",@progbits,typeinfo name for Normal,comdat
+        .align 8
+        .type   typeinfo name for Normal, @object
+        .size   typeinfo name for Normal, 8
+typeinfo name for Normal:
+        .string "6Normal"
+        .weak   typeinfo for Normal
+        .section        .rodata.typeinfo for Normal,"aG",@progbits,typeinfo for Normal,comdat
+        .align 8
+        .type   typeinfo for Normal, @object
+        .size   typeinfo for Normal, 16
+typeinfo for Normal:
+        .quad   _ZTVN10__cxxabiv117__class_type_infoE+16
+        .quad   typeinfo name for Normal
+        .weak   vtable for Normal
+        .section        .rodata.vtable for Normal,"aG",@progbits,vtable for Normal,comdat
+        .align 8
+        .type   vtable for Normal, @object
+        .size   vtable for Normal, 32
+vtable for Normal:
+        .quad   0
+        .quad   typeinfo for Normal
+        .quad   _ZN6NormalD1Ev
+        .quad   Normal::~Normal() [deleting destructor]
+        .text
+.Letext0:
+        .section        .debug_info,"",@progbits
+.Ldebug_info0:
+        .long   0x379
+        .value  0x4
+        .long   .Ldebug_abbrev0
+        .byte   0x8
+        .uleb128 0x1
+        .long   .LASF9
+        .byte   0x4
+        .long   .LASF10
+        .long   .LASF11
+        .long   .Ldebug_ranges0+0x30
+        .quad   0
+        .long   .Ldebug_line0
+        .uleb128 0x2
+        .string "Foo"
+        .byte   0x1
+        .byte   0x1
+        .byte   0x1
+        .long   0x69
+        .uleb128 0x3
+        .string "Foo"
+        .byte   0x1
+        .byte   0x2
+        .long   .LASF12
+        .long   0x48
+        .long   0x4e
+        .uleb128 0x4
+        .long   0x69
+        .byte   0
+        .uleb128 0x5
+        .long   .LASF13
+        .byte   0x1
+        .byte   0x3
+        .long   .LASF14
+        .long   0x5d
+        .uleb128 0x4
+        .long   0x69
+        .uleb128 0x4
+        .long   0x6f
+        .byte   0
+        .byte   0
+        .uleb128 0x6
+        .byte   0x8
+        .long   0x29
+        .uleb128 0x7
+        .byte   0x4
+        .byte   0x5
+        .string "int"
+        .uleb128 0x8
+        .long   0x6f
+        .uleb128 0x9
+        .long   .LASF2
+        .byte   0x10
+        .byte   0x1
+        .byte   0x6
+        .long   0x7b
+        .long   0xf9
+        .uleb128 0xa
+        .long   .LASF0
+        .long   0x109
+        .byte   0
+        .byte   0x1
+        .uleb128 0xb
+        .long   .LASF1
+        .byte   0x1
+        .byte   0xb
+        .long   0x29
+        .byte   0x8
+        .uleb128 0xc
+        .long   .LASF2
+        .long   .LASF3
+        .byte   0x1
+        .long   0xb4
+        .long   0xbf
+        .uleb128 0x4
+        .long   0x119
+        .uleb128 0xd
+        .long   0x124
+        .byte   0
+        .uleb128 0xc
+        .long   .LASF2
+        .long   .LASF4
+        .byte   0x1
+        .long   0xd1
+        .long   0xd7
+        .uleb128 0x4
+        .long   0x119
+        .byte   0
+        .uleb128 0xe
+        .long   .LASF15
+        .byte   0x1
+        .byte   0x8
+        .long   .LASF16
+        .byte   0x1
+        .long   0x7b
+        .byte   0x1
+        .byte   0x1
+        .long   0xed
+        .uleb128 0x4
+        .long   0x119
+        .uleb128 0x4
+        .long   0x6f
+        .byte   0
+        .byte   0
+        .uleb128 0x8
+        .long   0x7b
+        .uleb128 0xf
+        .long   0x6f
+        .long   0x109
+        .uleb128 0x10
+        .byte   0
+        .uleb128 0x6
+        .byte   0x8
+        .long   0x10f
+        .uleb128 0x11
+        .byte   0x8
+        .long   .LASF17
+        .long   0xfe
+        .uleb128 0x6
+        .byte   0x8
+        .long   0x7b
+        .uleb128 0x8
+        .long   0x119
+        .uleb128 0x12
+        .byte   0x8
+        .long   0xf9
+        .uleb128 0x13
+        .long   0xd7
+        .byte   0x2
+        .long   0x138
+        .long   0x14b
+        .uleb128 0x14
+        .long   .LASF5
+        .long   0x11f
+        .uleb128 0x14
+        .long   .LASF6
+        .long   0x76
+        .byte   0
+        .uleb128 0x15
+        .long   0x12a
+        .long   .LASF7
+        .long   0x172
+        .quad   .LFB8
+        .quad   .LFE8-.LFB8
+        .uleb128 0x1
+        .byte   0x9c
+        .long   0x172
+        .long   0x1cb
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST1
+        .uleb128 0x17
+        .long   0x12a
+        .quad   .LBB14
+        .quad   .LBE14-.LBB14
+        .byte   0x1
+        .byte   0x8
+        .long   0x1b0
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST2
+        .uleb128 0x18
+        .quad   .LVL5
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x2
+        .byte   0x73
+        .sleb128 8
+        .byte   0
+        .byte   0
+        .uleb128 0x1a
+        .quad   .LVL7
+        .long   0x36f
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x3
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x54
+        .uleb128 0x1
+        .byte   0x40
+        .byte   0
+        .byte   0
+        .uleb128 0x15
+        .long   0x12a
+        .long   .LASF8
+        .long   0x1f2
+        .quad   .LFB6
+        .quad   .LFE6-.LFB6
+        .uleb128 0x1
+        .byte   0x9c
+        .long   0x1f2
+        .long   0x20f
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST0
+        .uleb128 0x1b
+        .quad   .LVL2
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x5
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x23
+        .uleb128 0x8
+        .byte   0
+        .byte   0
+        .uleb128 0x1c
+        .long   .LASF18
+        .byte   0x1
+        .byte   0x12
+        .long   .LASF19
+        .quad   .LFB4
+        .quad   .LFE4-.LFB4
+        .uleb128 0x1
+        .byte   0x9c
+        .long   0x2aa
+        .uleb128 0x1d
+        .string "n"
+        .byte   0x1
+        .byte   0x12
+        .long   0x119
+        .long   .LLST5
+        .uleb128 0x1e
+        .long   0x12a
+        .quad   .LBB24
+        .long   .Ldebug_ranges0+0
+        .byte   0x1
+        .byte   0x13
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST6
+        .uleb128 0x17
+        .long   0x12a
+        .quad   .LBB26
+        .quad   .LBE26-.LBB26
+        .byte   0x1
+        .byte   0x8
+        .long   0x28e
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST7
+        .uleb128 0x18
+        .quad   .LVL14
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x2
+        .byte   0x73
+        .sleb128 8
+        .byte   0
+        .byte   0
+        .uleb128 0x1a
+        .quad   .LVL16
+        .long   0x36f
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x3
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x54
+        .uleb128 0x1
+        .byte   0x40
+        .byte   0
+        .byte   0
+        .byte   0
+        .uleb128 0x1f
+        .long   .LASF20
+        .byte   0x1
+        .byte   0xe
+        .long   .LASF21
+        .quad   .LFB0
+        .quad   .LFE0-.LFB0
+        .uleb128 0x1
+        .byte   0x9c
+        .long   0x33e
+        .uleb128 0x20
+        .string "n"
+        .byte   0x1
+        .byte   0xf
+        .long   0x7b
+        .uleb128 0x2
+        .byte   0x91
+        .sleb128 -32
+        .uleb128 0x17
+        .long   0x33e
+        .quad   .LBB16
+        .quad   .LBE16-.LBB16
+        .byte   0x1
+        .byte   0xf
+        .long   0x30c
+        .uleb128 0x16
+        .long   0x34e
+        .long   .LLST3
+        .uleb128 0x18
+        .quad   .LVL9
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x2
+        .byte   0x91
+        .sleb128 -24
+        .byte   0
+        .byte   0
+        .uleb128 0x21
+        .long   0x12a
+        .quad   .LBB18
+        .quad   .LBE18-.LBB18
+        .byte   0x1
+        .byte   0xf
+        .uleb128 0x16
+        .long   0x138
+        .long   .LLST4
+        .uleb128 0x18
+        .quad   .LVL10
+        .uleb128 0x19
+        .uleb128 0x1
+        .byte   0x55
+        .uleb128 0x2
+        .byte   0x91
+        .sleb128 -24
+        .byte   0
+        .byte   0
+        .byte   0
+        .uleb128 0x22
+        .long   0xbf
+        .byte   0x1
+        .byte   0x6
+        .byte   0x2
+        .long   0x34e
+        .long   0x358
+        .uleb128 0x14
+        .long   .LASF5
+        .long   0x11f
+        .byte   0
+        .uleb128 0x23
+        .long   0x33e
+        .long   .LASF22
+        .long   0x369
+        .long   0x36f
+        .uleb128 0x24
+        .long   0x34e
+        .byte   0
+        .uleb128 0x25
+        .long   .LASF23
+        .long   .LASF24
+        .long   .LASF23
+        .byte   0
+        .section        .debug_abbrev,"",@progbits
+.Ldebug_abbrev0:
+        .uleb128 0x1
+        .uleb128 0x11
+        .byte   0x1
+        .uleb128 0x25
+        .uleb128 0xe
+        .uleb128 0x13
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x1b
+        .uleb128 0xe
+        .uleb128 0x55
+        .uleb128 0x17
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x10
+        .uleb128 0x17
+        .byte   0
+        .byte   0
+        .uleb128 0x2
+        .uleb128 0x13
+        .byte   0x1
+        .uleb128 0x3
+        .uleb128 0x8
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0x8
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x4
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x34
+        .uleb128 0x19
+        .byte   0
+        .byte   0
+        .uleb128 0x5
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x64
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x6
+        .uleb128 0xf
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x7
+        .uleb128 0x24
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3e
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0x8
+        .byte   0
+        .byte   0
+        .uleb128 0x8
+        .uleb128 0x26
+        .byte   0
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x9
+        .uleb128 0x2
+        .byte   0x1
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x1d
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xa
+        .uleb128 0xd
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x38
+        .uleb128 0xb
+        .uleb128 0x34
+        .uleb128 0x19
+        .uleb128 0x32
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xd
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x38
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0xc
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x34
+        .uleb128 0x19
+        .uleb128 0x32
+        .uleb128 0xb
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xd
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xe
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x4c
+        .uleb128 0xb
+        .uleb128 0x1d
+        .uleb128 0x13
+        .uleb128 0x32
+        .uleb128 0xb
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x8b
+        .uleb128 0xb
+        .uleb128 0x64
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0xf
+        .uleb128 0x15
+        .byte   0x1
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x10
+        .uleb128 0x18
+        .byte   0
+        .byte   0
+        .byte   0
+        .uleb128 0x11
+        .uleb128 0xf
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x12
+        .uleb128 0x10
+        .byte   0
+        .uleb128 0xb
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x13
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x47
+        .uleb128 0x13
+        .uleb128 0x20
+        .uleb128 0xb
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x14
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x34
+        .uleb128 0x19
+        .byte   0
+        .byte   0
+        .uleb128 0x15
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x7
+        .uleb128 0x40
+        .uleb128 0x18
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x2117
+        .uleb128 0x19
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x16
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x2
+        .uleb128 0x17
+        .byte   0
+        .byte   0
+        .uleb128 0x17
+        .uleb128 0x1d
+        .byte   0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x7
+        .uleb128 0x58
+        .uleb128 0xb
+        .uleb128 0x59
+        .uleb128 0xb
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x18
+        .uleb128 0x4109
+        .byte   0x1
+        .uleb128 0x11
+        .uleb128 0x1
+        .byte   0
+        .byte   0
+        .uleb128 0x19
+        .uleb128 0x410a
+        .byte   0
+        .uleb128 0x2
+        .uleb128 0x18
+        .uleb128 0x2111
+        .uleb128 0x18
+        .byte   0
+        .byte   0
+        .uleb128 0x1a
+        .uleb128 0x4109
+        .byte   0x1
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x2115
+        .uleb128 0x19
+        .uleb128 0x31
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x1b
+        .uleb128 0x4109
+        .byte   0x1
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x2115
+        .uleb128 0x19
+        .byte   0
+        .byte   0
+        .uleb128 0x1c
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x7
+        .uleb128 0x40
+        .uleb128 0x18
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x1d
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0x8
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x2
+        .uleb128 0x17
+        .byte   0
+        .byte   0
+        .uleb128 0x1e
+        .uleb128 0x1d
+        .byte   0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x52
+        .uleb128 0x1
+        .uleb128 0x55
+        .uleb128 0x17
+        .uleb128 0x58
+        .uleb128 0xb
+        .uleb128 0x59
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0x1f
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x7
+        .uleb128 0x40
+        .uleb128 0x18
+        .uleb128 0x2117
+        .uleb128 0x19
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x20
+        .uleb128 0x34
+        .byte   0
+        .uleb128 0x3
+        .uleb128 0x8
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x49
+        .uleb128 0x13
+        .uleb128 0x2
+        .uleb128 0x18
+        .byte   0
+        .byte   0
+        .uleb128 0x21
+        .uleb128 0x1d
+        .byte   0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x11
+        .uleb128 0x1
+        .uleb128 0x12
+        .uleb128 0x7
+        .uleb128 0x58
+        .uleb128 0xb
+        .uleb128 0x59
+        .uleb128 0xb
+        .byte   0
+        .byte   0
+        .uleb128 0x22
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x47
+        .uleb128 0x13
+        .uleb128 0x3a
+        .uleb128 0xb
+        .uleb128 0x3b
+        .uleb128 0xb
+        .uleb128 0x20
+        .uleb128 0xb
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x23
+        .uleb128 0x2e
+        .byte   0x1
+        .uleb128 0x31
+        .uleb128 0x13
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x64
+        .uleb128 0x13
+        .uleb128 0x1
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x24
+        .uleb128 0x5
+        .byte   0
+        .uleb128 0x31
+        .uleb128 0x13
+        .byte   0
+        .byte   0
+        .uleb128 0x25
+        .uleb128 0x2e
+        .byte   0
+        .uleb128 0x3f
+        .uleb128 0x19
+        .uleb128 0x3c
+        .uleb128 0x19
+        .uleb128 0x6e
+        .uleb128 0xe
+        .uleb128 0x3
+        .uleb128 0xe
+        .uleb128 0x6e
+        .uleb128 0xe
+        .byte   0
+        .byte   0
+        .byte   0
+        .section        .debug_loc,"",@progbits
+.Ldebug_loc0:
+.LLST1:
+        .quad   .LVL3
+        .quad   .LVL4
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL4
+        .quad   .LVL6
+        .value  0x1
+        .byte   0x53
+        .quad   .LVL6
+        .quad   .LVL7-1
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL7-1
+        .quad   .LFE8
+        .value  0x4
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x9f
+        .quad   0
+        .quad   0
+.LLST2:
+        .quad   .LVL3
+        .quad   .LVL4
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL4
+        .quad   .LVL5
+        .value  0x1
+        .byte   0x53
+        .quad   0
+        .quad   0
+.LLST0:
+        .quad   .LVL0
+        .quad   .LVL1
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL1
+        .quad   .LVL2-1
+        .value  0x3
+        .byte   0x75
+        .sleb128 -8
+        .byte   0x9f
+        .quad   .LVL2-1
+        .quad   .LFE6
+        .value  0x4
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x9f
+        .quad   0
+        .quad   0
+.LLST5:
+        .quad   .LVL11
+        .quad   .LVL13
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL13
+        .quad   .LVL15
+        .value  0x1
+        .byte   0x53
+        .quad   .LVL15
+        .quad   .LVL16-1
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL16-1
+        .quad   .LVL16
+        .value  0x4
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x9f
+        .quad   .LVL16
+        .quad   .LVL17-1
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL17-1
+        .quad   .LFE4
+        .value  0x4
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x9f
+        .quad   0
+        .quad   0
+.LLST6:
+        .quad   .LVL12
+        .quad   .LVL13
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL13
+        .quad   .LVL15
+        .value  0x1
+        .byte   0x53
+        .quad   .LVL15
+        .quad   .LVL16-1
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL16-1
+        .quad   .LVL16
+        .value  0x4
+        .byte   0xf3
+        .uleb128 0x1
+        .byte   0x55
+        .byte   0x9f
+        .quad   0
+        .quad   0
+.LLST7:
+        .quad   .LVL12
+        .quad   .LVL13
+        .value  0x1
+        .byte   0x55
+        .quad   .LVL13
+        .quad   .LVL14
+        .value  0x1
+        .byte   0x53
+        .quad   0
+        .quad   0
+.LLST3:
+        .quad   .LVL8
+        .quad   .LVL9
+        .value  0x1
+        .byte   0x57
+        .quad   0
+        .quad   0
+.LLST4:
+        .quad   .LVL9
+        .quad   .LVL10
+        .value  0x1
+        .byte   0x57
+        .quad   0
+        .quad   0
+        .section        .debug_aranges,"",@progbits
+        .long   0x4c
+        .value  0x2
+        .long   .Ldebug_info0
+        .byte   0x8
+        .byte   0
+        .value  0
+        .value  0
+        .quad   .Ltext0
+        .quad   .Letext0-.Ltext0
+        .quad   .LFB6
+        .quad   .LFE6-.LFB6
+        .quad   .LFB8
+        .quad   .LFE8-.LFB8
+        .quad   0
+        .quad   0
+        .section        .debug_ranges,"",@progbits
+.Ldebug_ranges0:
+        .quad   .LBB24
+        .quad   .LBE24
+        .quad   .LBB29
+        .quad   .LBE29
+        .quad   0
+        .quad   0
+        .quad   .Ltext0
+        .quad   .Letext0
+        .quad   .LFB6
+        .quad   .LFE6
+        .quad   .LFB8
+        .quad   .LFE8
+        .quad   0
+        .quad   0
+        .section        .debug_line,"",@progbits
+.Ldebug_line0:
+        .section        .debug_str,"MS",@progbits,1
+.LASF21:
+        .string "caller1()"
+.LASF16:
+        .string "_ZN6NormalD4Ev"
+.LASF3:
+        .string "_ZN6NormalC4ERKS_"
+.LASF9:
+        .string "GNU C++14 7.2.0 -mtune=generic -march=x86-64 -g -O2 -std=c++1z"
+.LASF22:
+        .string "_ZN6NormalC2Ev"
+.LASF17:
+        .string "__vtbl_ptr_type"
+.LASF1:
+        .string "foo_"
+.LASF0:
+        .string "_vptr.Normal"
+.LASF23:
+        .string "operator delete(void*, unsigned long)"
+.LASF13:
+        .string "~Foo"
+.LASF14:
+        .string "_ZN3FooD4Ev"
+.LASF11:
+        .string "/compiler-explorer"
+.LASF4:
+        .string "_ZN6NormalC4Ev"
+.LASF5:
+        .string "this"
+.LASF2:
+        .string "Normal"
+.LASF15:
+        .string "~Normal"
+.LASF10:
+        .string "/tmp/compiler-explorer-compiler118012-54-4arhbo.s5ady/example.cpp"
+.LASF6:
+        .string "__in_chrg"
+.LASF7:
+        .string "Normal::~Normal() [deleting destructor]"
+.LASF19:
+        .string "caller2(Normal*)"
+.LASF20:
+        .string "caller1"
+.LASF18:
+        .string "caller2"
+.LASF8:
+        .string "Normal::~Normal() [base object destructor]"
+.LASF12:
+        .string "_ZN3FooC4Ev"
+.LASF24:
+        .string "operator delete"
+        .ident  "GCC: (GCC-Explorer-Build) 7.2.0"
+        .section        .note.GNU-stack,"",@progbits

--- a/test/demangle-cases/bug-713.asm.demangle
+++ b/test/demangle-cases/bug-713.asm.demangle
@@ -23,8 +23,8 @@ Normal::~Normal() [base object destructor]:
         .cfi_endproc
 .LFE6:
         .size   Normal::~Normal() [base object destructor], .-Normal::~Normal() [base object destructor]
-        .weak   _ZN6NormalD1Ev
-        .set    _ZN6NormalD1Ev,Normal::~Normal() [base object destructor]
+        .weak   Normal::~Normal() [complete object destructor]
+        .set    Normal::~Normal() [complete object destructor],Normal::~Normal() [base object destructor]
         .section        .text.Normal::~Normal() [deleting destructor],"axG",@progbits,_ZN6NormalD5Ev,comdat
         .align 2
         .p2align 4,,15
@@ -171,7 +171,7 @@ typeinfo name for Normal:
         .type   typeinfo for Normal, @object
         .size   typeinfo for Normal, 16
 typeinfo for Normal:
-        .quad   _ZTVN10__cxxabiv117__class_type_infoE+16
+        .quad   vtable for __cxxabiv1::__class_type_info+16
         .quad   typeinfo name for Normal
         .weak   vtable for Normal
         .section        .rodata.vtable for Normal,"aG",@progbits,vtable for Normal,comdat
@@ -181,7 +181,7 @@ typeinfo for Normal:
 vtable for Normal:
         .quad   0
         .quad   typeinfo for Normal
-        .quad   _ZN6NormalD1Ev
+        .quad   Normal::~Normal() [complete object destructor]
         .quad   Normal::~Normal() [deleting destructor]
         .text
 .Letext0:

--- a/test/demangler-tests.js
+++ b/test/demangler-tests.js
@@ -39,6 +39,8 @@ const should = chai.should();
 const expect = chai.expect;
 const assert = chai.assert;
 
+const cppfiltpath = "c++filt";
+
 class DummyCompiler {
     exec(command, args, options) {
         return exec.execute(command, args, options);
@@ -50,7 +52,7 @@ describe('Basic demangling', function () {
         const result = {};
         result.asm = [{"text": "Hello, World!"}];
 
-        const demangler = new Demangler("c++filt", new DummyCompiler());
+        const demangler = new Demangler(cppfiltpath, new DummyCompiler());
 
         return Promise.all([
             demangler.process(result).then((output) => {
@@ -66,7 +68,7 @@ describe('Basic demangling', function () {
             {"text": "  ret"}
         ];
 
-        const demangler = new Demangler("c++filt", new DummyCompiler());
+        const demangler = new Demangler(cppfiltpath, new DummyCompiler());
 
         return Promise.all([
             demangler.process(result).then((output) => {
@@ -83,7 +85,7 @@ describe('Basic demangling', function () {
             {"text": "  mov eax, $_Z6squarei"}
         ];
 
-        const demangler = new Demangler("c++filt", new DummyCompiler());
+        const demangler = new Demangler(cppfiltpath, new DummyCompiler());
 
         return Promise.all([
             demangler.process(result).then((output) => {
@@ -107,7 +109,7 @@ describe('Basic demangling', function () {
             {"text": "  rep ret"}
         ];
 
-        const demangler = new Demangler("c++filt", new DummyCompiler());
+        const demangler = new Demangler(cppfiltpath, new DummyCompiler());
 
         return Promise.all([
             demangler.process(result).then((output) => {
@@ -124,7 +126,7 @@ describe('Basic demangling', function () {
             {"text": "        call     ??3@YAXPEAX_K@Z                ; operator delete"}
         ];
 
-        const demangler = new DemanglerCL("c++filt", new DummyCompiler());
+        const demangler = new DemanglerCL(cppfiltpath, new DummyCompiler());
         demangler.result = result;
         demangler.symbolstore = new SymbolStore();
         demangler.collectLabels();
@@ -143,7 +145,7 @@ describe('Basic demangling', function () {
             {"text": "        call     hello                ; operator delete"}
         ];
 
-        const demangler = new Demangler("c++filt", new DummyCompiler());
+        const demangler = new Demangler(cppfiltpath, new DummyCompiler());
         demangler.result = result;
         demangler.symbolstore = new SymbolStore();
         demangler.collectLabels();
@@ -162,7 +164,7 @@ describe('Basic demangling', function () {
             {"text": "   bl _ZN3FooC1Ev"}
         ];
 
-        const demangler = new Demangler("c++filt", new DummyCompiler());
+        const demangler = new Demangler(cppfiltpath, new DummyCompiler());
         demangler.result = result;
         demangler.symbolstore = new SymbolStore();
         demangler.collectLabels();
@@ -181,7 +183,7 @@ describe('Basic demangling', function () {
             {"text": "$LN3@caller2:"}
         ];
 
-        const demangler = new DemanglerCL("c++filt", new DummyCompiler());
+        const demangler = new DemanglerCL(cppfiltpath, new DummyCompiler());
         demangler.result = result;
         demangler.symbolstore = new SymbolStore();
         demangler.collectLabels();
@@ -213,7 +215,7 @@ function DoDemangleTest(root, filename) {
                     return {"text": line};
                 });
 
-                const demangler = new Demangler("c++filt", new DummyCompiler());
+                const demangler = new Demangler(cppfiltpath, new DummyCompiler());
                 resolve(demangler.process(resultIn).then((output) => {
                     output.should.deep.equal(resultOut);
                 }));

--- a/test/demangler-tests.js
+++ b/test/demangler-tests.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Patrick Quist
+// Copyright (c) 2018, Compiler Explorer Team
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/test/demangler-tests.js
+++ b/test/demangler-tests.js
@@ -29,7 +29,7 @@ const
     utils = require('../lib/utils'),
     chaiAsPromised = require('chai-as-promised'),
     SymbolStore = require('../lib/symbol-store').SymbolStore,
-    Demangler = require('../lib/demangler-cpp').DemanglerCPP,
+    Demangler = require('../lib/demangler-cpp').Demangler,
     logger = require('../lib/logger').logger;
 
 chai.use(chaiAsPromised);

--- a/test/demangler-tests.js
+++ b/test/demangler-tests.js
@@ -45,7 +45,7 @@ describe('Basic demangling', function () {
         const demangler = new Demangler("c++filt");
 
         return Promise.all([
-            demangler.Process(result).then((output) => {
+            demangler.process(result).then((output) => {
                 output.asm[0].text.should.equal("Hello, World!");
             })
         ]);
@@ -61,7 +61,7 @@ describe('Basic demangling', function () {
         const demangler = new Demangler("c++filt");
 
         return Promise.all([
-            demangler.Process(result).then((output) => {
+            demangler.process(result).then((output) => {
                 output.asm[0].text.should.equal("square(int):");
                 output.asm[1].text.should.equal("  ret");
             })
@@ -78,7 +78,7 @@ describe('Basic demangling', function () {
         const demangler = new Demangler("c++filt");
 
         return Promise.all([
-            demangler.Process(result).then((output) => {
+            demangler.process(result).then((output) => {
                 output.asm[0].text.should.equal("square(int):");
                 output.asm[1].text.should.equal("  mov eax, $square(int)");
             })
@@ -102,7 +102,7 @@ describe('Basic demangling', function () {
         const demangler = new Demangler("c++filt");
 
         return Promise.all([
-            demangler.Process(result).then((output) => {
+            demangler.process(result).then((output) => {
                 output.asm[0].text.should.equal("Normal::~Normal() [deleting destructor]:");
                 output.asm[1].text.should.equal("  callq operator delete(void*)");
                 output.asm[6].text.should.equal("  jmp operator delete(void*, unsigned long)");
@@ -131,7 +131,7 @@ function DoDemangleTest(root, filename) {
                 });
 
                 let demangler = new Demangler("c++filt");
-                resolve(demangler.Process(resultIn).then((output) => {
+                resolve(demangler.process(resultIn).then((output) => {
                     output.should.deep.equal(resultOut);
                 }));
             });

--- a/test/demangler-tests.js
+++ b/test/demangler-tests.js
@@ -1,0 +1,67 @@
+// Copyright (c) 2012-2018, Patrick Quist
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    SymbolStore = require('../lib/symbol-store').SymbolStore,
+    Demangler = require('../lib/demangler').Demangler,
+    logger = require('../lib/logger').logger;
+
+chai.use(chaiAsPromised);
+const should = chai.should();
+const expect = chai.expect;
+const assert = chai.assert;
+
+describe('Basic demangling', function () {
+    it('One line of asm', function () {
+        const result = {};
+        result.asm = [{"text": "Hello, World!"}];
+
+        const demangler = new Demangler("c++filt");
+
+        return Promise.all([
+            demangler.Process(result).then((output) => {
+                output.asm[0].text.should.equal("Hello, World!");
+            })
+        ]);
+    });
+
+    it('One label and some asm', function () {
+        const result = {};
+        result.asm = [
+            {"text": "_Z6squarei:"},
+            {"text": "  ret"}
+        ];
+
+        const demangler = new Demangler("c++filt");
+
+        return Promise.all([
+            demangler.Process(result).then((output) => {
+                output.asm[0].text.should.equal("square(int):");
+                output.asm[1].text.should.equal("  ret");
+            })
+        ]);
+    });
+});

--- a/test/demangler-tests.js
+++ b/test/demangler-tests.js
@@ -175,7 +175,7 @@ describe('Basic demangling', function () {
         );
     });
     
-    it('Should handle normal labels without PROC suffix', () => {
+    it('Should NOT handle normal labels without PROC suffix', () => {
         const result = {};
         result.asm = [
             {"text": "$LN3@caller2:"}
@@ -189,7 +189,6 @@ describe('Basic demangling', function () {
         const output = demangler.symbolstore.listSymbols();
         output.should.deep.equal(
             [
-                "$LN3@caller2"
             ]
         );
     });

--- a/test/demangler-tests.js
+++ b/test/demangler-tests.js
@@ -155,6 +155,25 @@ describe('Basic demangling', function () {
             ]
         );
     });
+
+    it('Should also support ARM branch instructions', () => {
+        const result = {};
+        result.asm = [
+            {"text": "   bl _ZN3FooC1Ev"}
+        ];
+
+        const demangler = new Demangler("c++filt", new DummyCompiler());
+        demangler.result = result;
+        demangler.symbolstore = new SymbolStore();
+        demangler.collectLabels();
+
+        const output = demangler.othersymbols.listSymbols();
+        output.should.deep.equal(
+            [
+                "_ZN3FooC1Ev"
+            ]
+        );
+    });
 });
 
 function DoDemangleTest(root, filename) {

--- a/test/demangler-tests.js
+++ b/test/demangler-tests.js
@@ -114,7 +114,7 @@ describe('Basic demangling', function () {
 function DoDemangleTest(root, filename) {
     return new Promise(function(resolve, reject) {
         fs.readFile(path.join(root, filename), function(err, dataIn) {
-            if (err) throw err;
+            if (err) reject(err);
 
             let resultIn = {"asm": []};
             
@@ -123,7 +123,7 @@ function DoDemangleTest(root, filename) {
             });
 
             fs.readFile(path.join(root, filename + ".demangle"), function(err, dataOut) {
-                if (err) throw err;
+                if (err) reject(err);
 
                 let resultOut = {"asm": []};
                 resultOut.asm = utils.splitLines(dataOut.toString()).map(function(line) {
@@ -131,9 +131,9 @@ function DoDemangleTest(root, filename) {
                 });
 
                 let demangler = new Demangler("c++filt");
-                demangler.Process(resultIn).then((output) => {
-                    resolve(output.should.deep.equal(resultOut));
-                });
+                resolve(demangler.Process(resultIn).then((output) => {
+                    output.should.deep.equal(resultOut);
+                }));
             });
         });
     });
@@ -142,17 +142,19 @@ function DoDemangleTest(root, filename) {
 describe('File demangling', function() {
     const testcasespath = __dirname + '/demangle-cases';
 
-    return new Promise(function(resolve, reject) {
-        fs.readdir(testcasespath, function(err, files) {
-            let testResults = [];
+    it('Does things', function() {
+        return new Promise(function(resolve, reject) {
+            fs.readdir(testcasespath, function(err, files) {
+                let testResults = [];
 
-            files.forEach((filename) => {
-                if (filename.endsWith(".asm")) {
-                    testResults.push(DoDemangleTest(testcasespath, filename));
-                }
+                files.forEach((filename) => {
+                    if (filename.endsWith(".asm")) {
+                        testResults.push(DoDemangleTest(testcasespath, filename));
+                    }
+                });
+
+                resolve(Promise.all(testResults));
             });
-
-            resolve(Promise.all(testResults));
         });
     });
 });

--- a/test/demangler-tests.js
+++ b/test/demangler-tests.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2018, Patrick Quist
+// Copyright (c) 2018, Patrick Quist
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@ const
     utils = require('../lib/utils'),
     chaiAsPromised = require('chai-as-promised'),
     SymbolStore = require('../lib/symbol-store').SymbolStore,
-    Demangler = require('../lib/demangler').Demangler,
+    Demangler = require('../lib/demangler-cpp').DemanglerCPP,
     logger = require('../lib/logger').logger;
 
 chai.use(chaiAsPromised);

--- a/test/demangler-tests.js
+++ b/test/demangler-tests.js
@@ -53,6 +53,7 @@ describe('Basic demangling', function () {
         result.asm = [{"text": "Hello, World!"}];
 
         const demangler = new Demangler(cppfiltpath, new DummyCompiler());
+        demangler.demanglerArguments = ['-n'];
 
         return Promise.all([
             demangler.process(result).then((output) => {
@@ -69,6 +70,7 @@ describe('Basic demangling', function () {
         ];
 
         const demangler = new Demangler(cppfiltpath, new DummyCompiler());
+        demangler.demanglerArguments = ['-n'];
 
         return Promise.all([
             demangler.process(result).then((output) => {
@@ -86,6 +88,7 @@ describe('Basic demangling', function () {
         ];
 
         const demangler = new Demangler(cppfiltpath, new DummyCompiler());
+        demangler.demanglerArguments = ['-n'];
 
         return Promise.all([
             demangler.process(result).then((output) => {
@@ -110,6 +113,7 @@ describe('Basic demangling', function () {
         ];
 
         const demangler = new Demangler(cppfiltpath, new DummyCompiler());
+        demangler.demanglerArguments = ['-n'];
 
         return Promise.all([
             demangler.process(result).then((output) => {
@@ -146,6 +150,7 @@ describe('Basic demangling', function () {
         ];
 
         const demangler = new Demangler(cppfiltpath, new DummyCompiler());
+        demangler.demanglerArguments = ['-n'];
         demangler.result = result;
         demangler.symbolstore = new SymbolStore();
         demangler.collectLabels();
@@ -165,6 +170,7 @@ describe('Basic demangling', function () {
         ];
 
         const demangler = new Demangler(cppfiltpath, new DummyCompiler());
+        demangler.demanglerArguments = ['-n'];
         demangler.result = result;
         demangler.symbolstore = new SymbolStore();
         demangler.collectLabels();
@@ -216,6 +222,7 @@ function DoDemangleTest(root, filename) {
                 });
 
                 const demangler = new Demangler(cppfiltpath, new DummyCompiler());
+                demangler.demanglerArguments = ['-n'];
                 resolve(demangler.process(resultIn).then((output) => {
                     output.should.deep.equal(resultOut);
                 }));

--- a/test/demangler-tests.js
+++ b/test/demangler-tests.js
@@ -174,6 +174,25 @@ describe('Basic demangling', function () {
             ]
         );
     });
+    
+    it('Should handle normal labels without PROC suffix', () => {
+        const result = {};
+        result.asm = [
+            {"text": "$LN3@caller2:"}
+        ];
+
+        const demangler = new DemanglerCL("c++filt", new DummyCompiler());
+        demangler.result = result;
+        demangler.symbolstore = new SymbolStore();
+        demangler.collectLabels();
+
+        const output = demangler.symbolstore.listSymbols();
+        output.should.deep.equal(
+            [
+                "$LN3@caller2"
+            ]
+        );
+    });
 });
 
 function DoDemangleTest(root, filename) {

--- a/test/pascal-tests.js
+++ b/test/pascal-tests.js
@@ -24,7 +24,7 @@
 
 const chai = require('chai');
 const chaiAsPromised = require("chai-as-promised");
-const PascalDemangler = require('../lib/pascal-support').demangler;
+const PascalDemangler = require('../lib/pascal-support').Demangler;
 const PascalCompiler = require('../lib/compilers/pascal');
 const CompilationEnvironment = require('../lib/compilation-env');
 const fs = require('fs-extra');

--- a/test/symbol-store-tests.js
+++ b/test/symbol-store-tests.js
@@ -27,7 +27,7 @@ const SymbolStore = require('../lib/symbol-store').SymbolStore;
 
 chai.should();
 
-describe('Basic examples', function () {
+describe('SymbolStore tests', function () {
     it('Empty', function () {
         const store = new SymbolStore();
         store.ListSymbols().length.should.equal(0);
@@ -82,5 +82,42 @@ describe('Basic examples', function () {
         const translations = store.ListTranslations();
         translations[0][0].should.equal("test123456");
         translations[1][0].should.equal("test123");
+    });
+
+    it('Exclude', function () {
+        const store1 = new SymbolStore();
+        store1.AddMany(["test123", "test123456", "test123"]);
+
+        const store2 = new SymbolStore();
+        store2.AddMany(["test123"]);
+
+        store1.Exclude(store2);
+        var translations = store1.ListTranslations();
+        translations.length.should.equal(1);
+        translations[0][0].should.equal("test123456");
+    });
+
+    it('SoftExclude', function () {
+        const store1 = new SymbolStore();
+        store1.AddMany(["test123", "test123456", "test123"]);
+
+        const store2 = new SymbolStore();
+        store2.AddMany(["est123"]);
+
+        store1.SoftExclude(store2);
+        var translations = store1.ListTranslations();
+        translations.length.should.equal(1);
+        translations[0][0].should.equal("test123456");
+    });
+    
+    it('Contains', function () {
+        const store = new SymbolStore();
+        store.AddMany(["test123", "test123456", "test123"]);
+
+        store.Contains("test123").should.equal(true);
+        store.Contains("test123456").should.equal(true);
+        store.Contains("test456").should.equal(false);
+
+        store.ListSymbols().length.should.equal(2);
     });
 });

--- a/test/symbol-store-tests.js
+++ b/test/symbol-store-tests.js
@@ -27,14 +27,14 @@ const SymbolStore = require('../lib/symbol-store').SymbolStore;
 
 chai.should();
 
-describe('SymbolStore tests', function () {
-    it('Empty', function () {
+describe('SymbolStore', function () {
+    it('should be empty initially', function () {
         const store = new SymbolStore();
         store.listSymbols().length.should.equal(0);
         store.listTranslations().length.should.equal(0);
     });
 
-    it('One item', function () {
+    it('should be able to add an item', function () {
         const store = new SymbolStore();
         store.add("test");
         store.listSymbols().length.should.equal(1);
@@ -47,7 +47,7 @@ describe('SymbolStore tests', function () {
         translations[0][1].should.equal("test");
     });
 
-    it('Duplicate items', function () {
+    it('should not contain duplicate items', function () {
         const store = new SymbolStore();
         store.add("test");
         store.add("test");
@@ -61,7 +61,7 @@ describe('SymbolStore tests', function () {
         translations[0][1].should.equal("test");
     });
 
-    it('Sorted items', function () {
+    it('should return a sorted list', function () {
         const store = new SymbolStore();
         store.add("test123");
         store.add("test123456");
@@ -73,7 +73,7 @@ describe('SymbolStore tests', function () {
         translations[1][0].should.equal("test123");
     });
 
-    it('Add-many', function () {
+    it('should be able to add an array of items', function () {
         const store = new SymbolStore();
         store.addMany(["test123", "test123456", "test123"]);
         store.listSymbols().length.should.equal(2);
@@ -84,7 +84,7 @@ describe('SymbolStore tests', function () {
         translations[1][0].should.equal("test123");
     });
 
-    it('Exclude', function () {
+    it('should be possible to exclude items in another store', function () {
         const store1 = new SymbolStore();
         store1.addMany(["test123", "test123456", "test123"]);
 
@@ -97,7 +97,7 @@ describe('SymbolStore tests', function () {
         translations[0][0].should.equal("test123456");
     });
 
-    it('SoftExclude', function () {
+    it('should be possible to exclude items that partially match', function () {
         const store1 = new SymbolStore();
         store1.addMany(["test123", "test123456", "test123"]);
 
@@ -110,7 +110,7 @@ describe('SymbolStore tests', function () {
         translations[0][0].should.equal("test123456");
     });
     
-    it('Contains', function () {
+    it('should be able to check contents', function () {
         const store = new SymbolStore();
         store.addMany(["test123", "test123456", "test123"]);
 

--- a/test/symbol-store-tests.js
+++ b/test/symbol-store-tests.js
@@ -30,94 +30,94 @@ chai.should();
 describe('SymbolStore tests', function () {
     it('Empty', function () {
         const store = new SymbolStore();
-        store.ListSymbols().length.should.equal(0);
-        store.ListTranslations().length.should.equal(0);
+        store.listSymbols().length.should.equal(0);
+        store.listTranslations().length.should.equal(0);
     });
 
     it('One item', function () {
         const store = new SymbolStore();
-        store.Add("test");
-        store.ListSymbols().length.should.equal(1);
-        store.ListTranslations().length.should.equal(1);
+        store.add("test");
+        store.listSymbols().length.should.equal(1);
+        store.listTranslations().length.should.equal(1);
 
-        store.ListSymbols()[0].should.equal("test");
+        store.listSymbols()[0].should.equal("test");
 
-        const translations = store.ListTranslations();
+        const translations = store.listTranslations();
         translations[0][0].should.equal("test");
         translations[0][1].should.equal("test");
     });
 
     it('Duplicate items', function () {
         const store = new SymbolStore();
-        store.Add("test");
-        store.Add("test");
-        store.ListSymbols().length.should.equal(1);
-        store.ListTranslations().length.should.equal(1);
+        store.add("test");
+        store.add("test");
+        store.listSymbols().length.should.equal(1);
+        store.listTranslations().length.should.equal(1);
 
-        store.ListSymbols()[0].should.equal("test");
+        store.listSymbols()[0].should.equal("test");
 
-        const translations = store.ListTranslations();
+        const translations = store.listTranslations();
         translations[0][0].should.equal("test");
         translations[0][1].should.equal("test");
     });
 
     it('Sorted items', function () {
         const store = new SymbolStore();
-        store.Add("test123");
-        store.Add("test123456");
-        store.ListSymbols().length.should.equal(2);
-        store.ListTranslations().length.should.equal(2);
+        store.add("test123");
+        store.add("test123456");
+        store.listSymbols().length.should.equal(2);
+        store.listTranslations().length.should.equal(2);
 
-        const translations = store.ListTranslations();
+        const translations = store.listTranslations();
         translations[0][0].should.equal("test123456");
         translations[1][0].should.equal("test123");
     });
 
     it('Add-many', function () {
         const store = new SymbolStore();
-        store.AddMany(["test123", "test123456", "test123"]);
-        store.ListSymbols().length.should.equal(2);
-        store.ListTranslations().length.should.equal(2);
+        store.addMany(["test123", "test123456", "test123"]);
+        store.listSymbols().length.should.equal(2);
+        store.listTranslations().length.should.equal(2);
 
-        const translations = store.ListTranslations();
+        const translations = store.listTranslations();
         translations[0][0].should.equal("test123456");
         translations[1][0].should.equal("test123");
     });
 
     it('Exclude', function () {
         const store1 = new SymbolStore();
-        store1.AddMany(["test123", "test123456", "test123"]);
+        store1.addMany(["test123", "test123456", "test123"]);
 
         const store2 = new SymbolStore();
-        store2.AddMany(["test123"]);
+        store2.addMany(["test123"]);
 
-        store1.Exclude(store2);
-        var translations = store1.ListTranslations();
+        store1.exclude(store2);
+        var translations = store1.listTranslations();
         translations.length.should.equal(1);
         translations[0][0].should.equal("test123456");
     });
 
     it('SoftExclude', function () {
         const store1 = new SymbolStore();
-        store1.AddMany(["test123", "test123456", "test123"]);
+        store1.addMany(["test123", "test123456", "test123"]);
 
         const store2 = new SymbolStore();
-        store2.AddMany(["est123"]);
+        store2.addMany(["est123"]);
 
-        store1.SoftExclude(store2);
-        var translations = store1.ListTranslations();
+        store1.softExclude(store2);
+        var translations = store1.listTranslations();
         translations.length.should.equal(1);
         translations[0][0].should.equal("test123456");
     });
     
     it('Contains', function () {
         const store = new SymbolStore();
-        store.AddMany(["test123", "test123456", "test123"]);
+        store.addMany(["test123", "test123456", "test123"]);
 
-        store.Contains("test123").should.equal(true);
-        store.Contains("test123456").should.equal(true);
-        store.Contains("test456").should.equal(false);
+        store.contains("test123").should.equal(true);
+        store.contains("test123456").should.equal(true);
+        store.contains("test456").should.equal(false);
 
-        store.ListSymbols().length.should.equal(2);
+        store.listSymbols().length.should.equal(2);
     });
 });


### PR DESCRIPTION
Should fix https://github.com/mattgodbolt/compiler-explorer/issues/713 and https://github.com/mattgodbolt/compiler-explorer/issues/515

Todo
- [x] Fix #713
- [x] Fix #515 
- [x] Don't break unmangling of symbols that aren't linked into the assembly
- [x] Refactor Pascal to use Demangler class
- [x] Refactor CL undname to use Demangler class
- [x] Test ARM asm
- [x] Test with Wine-CL

Check if it still works for
- [x] C++
- [x] Pascal
- [x] C
- [x] D
- [x] Rust
- n/a Go
- n/a Haskell
- n/a ispc
- [x] Swift
