### PR TITLE
Add "Analysis" class and llvm-mca as its first client

### DIFF
--- a/etc/config/analysis.amazon.properties
+++ b/etc/config/analysis.amazon.properties
@@ -1,0 +1,11 @@
+compilers=&llvm-mca
+
+group.llvm-mca.compilers=llvm-mcatrunk
+group.llvm-mca.groupName=LLVM Machine Code Analyzer
+group.llvm-mca.supportsBinary=false
+
+compiler.llvm-mcatrunk.name=llvm-mca (trunk)
+compiler.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
+# Sets both input and output to Intel variant
+compiler.llvm-mcatrunk.intelAsm=--x86-asm-syntax=intel -output-asm-variant=1
+

--- a/etc/config/analysis.defaults.properties
+++ b/etc/config/analysis.defaults.properties
@@ -1,0 +1,15 @@
+compilers=&llvm-mca
+compilerType=analysis
+supportsBinary=false
+objdumper=
+# TODO: We might want to set a demangler, to deal with pasted compiler output with mangled symbols
+demangler=
+
+group.llvm-mca.compilers=llvm-mcatrunk
+group.llvm-mca.groupName=LLVM Machine Code Analyzer
+group.llvm-mca.supportsBinary=false
+
+compiler.llvm-mcatrunk.name=llvm-mca (trunk)
+compiler.llvm-mcatrunk.exe=/usr/bin/llvm-mca
+# Sets both input and output to Intel variant
+compiler.llvm-mcatrunk.intelAsm=--x86-asm-syntax=intel -output-asm-variant=1

--- a/examples/analysis/default.asm
+++ b/examples/analysis/default.asm
@@ -1,0 +1,6 @@
+code_snippet:
+    vpslldq xmm1, xmm0, 3
+    vaddps xmm0, xmm0, xmm1
+    vmulps xmm1, xmm0, xmm0
+    dec rcx
+    jne code_snippet

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -52,6 +52,12 @@ class BaseCompiler {
         if (!this.compiler.optArg) this.compiler.optArg = "";
         if (!this.compiler.supportsOptOutput) this.compiler.supportsOptOutput = false;
 
+        if (!this.compiler.disabledFilters)
+          this.compiler.disabledFilters = [];
+        else if (typeof this.compiler.disabledFilters == "string")
+          this.compiler.disabledFilters =
+              this.compiler.disabledFilters.split(',');
+
         this.writeFile = denodeify(fs.writeFile);
         this.readFile = denodeify(fs.readFile);
         this.stat = denodeify(fs.stat);

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -53,10 +53,9 @@ class BaseCompiler {
         if (!this.compiler.supportsOptOutput) this.compiler.supportsOptOutput = false;
 
         if (!this.compiler.disabledFilters)
-          this.compiler.disabledFilters = [];
+            this.compiler.disabledFilters = [];
         else if (typeof this.compiler.disabledFilters == "string")
-          this.compiler.disabledFilters =
-              this.compiler.disabledFilters.split(',');
+            this.compiler.disabledFilters = this.compiler.disabledFilters.split(',');
 
         this.writeFile = denodeify(fs.writeFile);
         this.readFile = denodeify(fs.readFile);

--- a/lib/compilers/analysis.js
+++ b/lib/compilers/analysis.js
@@ -1,0 +1,64 @@
+// Copyright (c) 2018, Filipe Cabecinhas
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const BaseCompiler = require('../base-compiler');
+
+// Plain compiler, which just runs the tool and returns whatever the output was
+class AnalysisTool extends BaseCompiler {
+    constructor(info, env) {
+        // Default is to disable all "cosmetic" filters
+        if (!info.disabledFilters)
+            info.disabledFilters = [ 'labels', 'directives', 'commentOnly', 'trim' ];
+        super(info, env);
+    }
+
+    supportsObjdump() { return false; }
+
+    getOutputFilenameArgs(filename) {
+        // TODO: Some tools might require an argument of the form -arg=filename
+        return [this.compiler.outputFilenameArg || '-o', filename];
+    }
+
+    optionsForFilter(filters, outputFilename) {
+        let options = this.getOutputFilenameArgs(outputFilename);
+        // Some tools might require more than one arg, so split(' ')
+        if (filters.intel) options = options.concat(this.compiler.intelAsm.split(' '));
+        return options;
+    }
+
+    getDefaultFilters() {
+        // Disable everything but intel syntax
+        return {
+            intel: true,
+            commentOnly: false,
+            directives: false,
+            labels: false,
+            optOutput: false
+        };
+    }
+}
+
+
+module.exports = AnalysisTool;
+

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -121,6 +121,13 @@ const languages = {
         monaco: 'asm',
         extensions: ['.asm'],
         alias: ['asm']
+    },
+    analysis: {
+        id: 'analysis',
+        name: 'Analysis',
+        monaco: 'asm',
+        extensions: ['.asm'],  // maybe add more? Change to a unique one?
+        alias: ['tool']
     }
 };
 

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -385,6 +385,12 @@ Compiler.prototype.getEffectiveFilters = function () {
     if (filters.execute && !this.compiler.supportsExecute) {
         delete filters.execute;
     }
+    var disabledFilters = this.compiler.disabledFilters;
+    disabledFilters.forEach(function (filter) {
+        if (filters[filter] && disabledFilters.includes(filter)) {
+            delete filters[filter];
+        }
+    });
     return filters;
 };
 
@@ -835,10 +841,16 @@ Compiler.prototype.updateButtons = function () {
     // Disable any of the options which don't make sense in binary mode.
     var noBinaryFiltersDisabled = !!filters.binary && !this.compiler.supportsFiltersInBinary;
     this.noBinaryFiltersButtons.prop('disabled', noBinaryFiltersDisabled);
+
+    this.filterLabelsButton.prop('disabled', this.compiler.disabledFilters.includes('labels'));
     formatFilterTitle(this.filterLabelsButton, this.filterLabelsTitle);
+    this.filterDirectivesButton.prop('disabled', this.compiler.disabledFilters.includes('directives'));
     formatFilterTitle(this.filterDirectivesButton, this.filterDirectivesTitle);
+    this.filterCommentsButton.prop('disabled', this.compiler.disabledFilters.includes('commentOnly'));
     formatFilterTitle(this.filterCommentsButton, this.filterCommentsTitle);
+    this.filterTrimButton.prop('disabled', this.compiler.disabledFilters.includes('trim'));
     formatFilterTitle(this.filterTrimButton, this.filterTrimTitle);
+
     // If its already open, we should turn it off.
     // The pane will update with error text
     // Otherwise we just disable the button.

--- a/static/compiler.js
+++ b/static/compiler.js
@@ -386,8 +386,8 @@ Compiler.prototype.getEffectiveFilters = function () {
         delete filters.execute;
     }
     var disabledFilters = this.compiler.disabledFilters;
-    disabledFilters.forEach(function (filter) {
-        if (filters[filter] && disabledFilters.includes(filter)) {
+    _.each(disabledFilters, function (filter) {
+        if (filters[filter]) {
             delete filters[filter];
         }
     });
@@ -842,13 +842,13 @@ Compiler.prototype.updateButtons = function () {
     var noBinaryFiltersDisabled = !!filters.binary && !this.compiler.supportsFiltersInBinary;
     this.noBinaryFiltersButtons.prop('disabled', noBinaryFiltersDisabled);
 
-    this.filterLabelsButton.prop('disabled', this.compiler.disabledFilters.includes('labels'));
+    this.filterLabelsButton.prop('disabled', this.compiler.disabledFilters.indexOf('labels') !== -1);
     formatFilterTitle(this.filterLabelsButton, this.filterLabelsTitle);
-    this.filterDirectivesButton.prop('disabled', this.compiler.disabledFilters.includes('directives'));
+    this.filterDirectivesButton.prop('disabled', this.compiler.disabledFilters.indexOf('directives') !== -1);
     formatFilterTitle(this.filterDirectivesButton, this.filterDirectivesTitle);
-    this.filterCommentsButton.prop('disabled', this.compiler.disabledFilters.includes('commentOnly'));
+    this.filterCommentsButton.prop('disabled', this.compiler.disabledFilters.indexOf('commentOnly') !== -1);
     formatFilterTitle(this.filterCommentsButton, this.filterCommentsTitle);
-    this.filterTrimButton.prop('disabled', this.compiler.disabledFilters.includes('trim'));
+    this.filterTrimButton.prop('disabled', this.compiler.disabledFilters.indexOf('trim') !== -1);
     formatFilterTitle(this.filterTrimButton, this.filterTrimTitle);
 
     // If its already open, we should turn it off.

--- a/test/analysis-tests.js
+++ b/test/analysis-tests.js
@@ -1,0 +1,73 @@
+// Copyright (c) 2018, Filipe Cabecinhas
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const AnalysisTool = require('../lib/compilers/analysis');
+const CompilationEnvironment = require('../lib/compilation-env');
+require('chai').should();
+
+const props = (key, deflt) => deflt;
+
+describe('Analysis tool definition', () => {
+  const ce = new CompilationEnvironment(props);
+  const info = {
+      exe: null,
+      remote: true,
+      lang: "analysis"
+  };
+  const a = new AnalysisTool(info, ce);
+
+  it('should have most filters disabled', () => {
+    a.compiler.disabledFilters.should.be.deep.equal(['labels', 'directives', 'commentOnly', 'trim']);
+  });
+
+  it('should default to most filters off', () => {
+    const filters = a.getDefaultFilters();
+    filters.intel.should.equal(true);
+    filters.commentOnly.should.equal(false);
+    filters.directives.should.equal(false);
+    filters.labels.should.equal(false);
+    filters.optOutput.should.equal(false);
+  });
+
+  it('should not support objdump', () => {
+    a.supportsObjdump().should.equal(false);
+  });
+
+  it('should support "-o output-file" by default', () => {
+    const opts = a.optionsForFilter({ commentOnly: false, labels: true }, 'output.txt');
+    opts.should.be.deep.equal(['-o', 'output.txt']);
+  });
+
+  it('should split if disabledFilters is a string', () => {
+    const info = {
+        exe: null,
+        remote: true,
+        lang: "analysis",
+        disabledFilters: 'labels,directives'
+    };
+    const a = new AnalysisTool(info, ce);
+    a.compiler.disabledFilters.should.be.deep.equal(['labels', 'directives']);
+  });
+});
+


### PR DESCRIPTION
Fixes https://github.com/mattgodbolt/compiler-explorer/issues/861
This is a first pass, and I basically had to poke at the UI to make it "work" well enough. For now I'm filtering the "cosmetic" types of filters so they don't run on analysis tools.

Is there a way to pre-populate the "compiler options" field, so I can add something like -mcpu=btver2? Otherwise the default might not output anything.

I tried to add as little code as possible, but do ask for changes if you'd prefer to have this done some other way. (For example, I couldn't make the buttons "inactive" easily, so I just filter the options out in getEffectiveFilters)

Thanks a lot for gcc-explorer!

 Filipe