### PR TITLE
Always try to attach gccdump info

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -296,6 +296,11 @@ class BaseCompiler {
                             .then(([asmResult, astResult, gccDumpResult]) => {
                                 asmResult.dirPath = dirPath;
                                 asmResult.compilationOptions = options;
+
+                                if (this.compiler.supportsGccDump && gccDumpResult) {
+                                    asmResult.gccDumpOutput = gccDumpResult;
+                                }
+
                                 if (asmResult.code !== 0) {
                                     asmResult.asm = "<Compilation failed>";
                                     return asmResult;
@@ -311,10 +316,6 @@ class BaseCompiler {
                                 if (astResult) {
                                     asmResult.hasAstOutput = true;
                                     asmResult.astOutput = astResult;
-                                }
-
-                                if (this.compiler.supportsGccDump && gccDumpResult) {
-                                    asmResult.gccDumpOutput = gccDumpResult;
                                 }
 
                                 return this.checkOutputFileAndDoPostProcess(asmResult, outputFilename, filters);

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -296,7 +296,7 @@ class BaseCompiler {
                             .then(([asmResult, astResult, gccDumpResult]) => {
                                 asmResult.dirPath = dirPath;
                                 asmResult.compilationOptions = options;
-
+                                // Here before the check to ensure dump reports even on failure cases
                                 if (this.compiler.supportsGccDump && gccDumpResult) {
                                     asmResult.gccDumpOutput = gccDumpResult;
                                 }


### PR DESCRIPTION
Even if the compiler crashes, the gcc dump files can be useful (to say
the least). Try to attach the dumps inconditionnaly of the error
state.

fixes #913