### PR TITLE
Avoid 0X.. property values to be parsed as ints

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -60,7 +60,7 @@ function get(base, property, defaultValue) {
 function toProperty(prop) {
     if (prop === 'true' || prop === 'yes') return true;
     if (prop === 'false' || prop === 'no') return false;
-    if (prop.match(/^-?[0-9]+$/)) return parseInt(prop);
+    if (prop.match(/^-?(0|[1-9][0-9]*)$/)) return parseInt(prop);
     if (prop.match(/^-?[0-9]*\.[0-9]+$/)) return parseFloat(prop);
     return prop;
 }

--- a/test/example-config/cases.test.properties
+++ b/test/example-config/cases.test.properties
@@ -18,3 +18,5 @@ falsePropertyFalse=false
 stringPropertyNo=No
 stringPropertyFalse=False
 badLineIfYouSeeThisWithAnErrorItsOk
+001string=001
+0985string=0985

--- a/test/properties-test.js
+++ b/test/properties-test.js
@@ -46,6 +46,12 @@ describe('Properties', () => {
     it('Handles empty properties as empty strings', () => {
         should.equal(casesProps("emptyProperty"), "");
     });
+    it('Handles bad numbers properties as strings', () => {
+        should.equal(casesProps("001string"), "001");
+    });
+    it('Handles bad numbers properties as strings', () => {
+        should.equal(casesProps("0985string"), "0985");
+    });
     it('Ignores commented out properties', () => {
         should.equal(casesProps("commentedProperty"), undefined);
     });


### PR DESCRIPTION
It might break 3rd party configs in some obscure way, but after looking
at how it might happen, I can't see obvious reasons not to implement it

This is a PR as opposed to a direct commit so I get the opportunity to get called out if I'm breaking something unintended

Fixes expected-lite (#935) not working properly