### PR TITLE
(RFC) Add RISC-V Support

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -191,7 +191,7 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr
+group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr:%riscv
 group.cross.needsMulti=false
 group.cross.supportsBinary=false
 group.cross.groupName=Cross GCC
@@ -287,6 +287,18 @@ compiler.mips564.semver=5.4
 compiler.mips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
 compiler.mips564el.name=MIPS64 gcc 5.4 (el)
 compiler.mips564el.semver=5.4
+
+###############################
+# GCC for RISC-V
+group.riscv.compilers=riscv730:riscv810
+groups.riscv.groupName=RISC-V GCC
+group.riscv.isSemVer=true
+compiler.riscv730.exe=/opt/compiler/explorer/riscv/gcc-7.3.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.riscv730.name=RISC-V gcc 7.3.0
+compiler.riscv730.semver=7.3.0
+compiler.riscv810.exe=/opt/compiler/explorer/riscv/gcc-8.1.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.riscv810.name=RISC-V gcc 8.1.0
+compiler.riscv810.semver=8.1.0
 
 ################################
 # Windows Compilers


### PR DESCRIPTION
RISC-V is an open standard ISA that's maintained by the non-profit
RISC-V orginization, which has over 100 members today.  More information
can be found at https://riscv.org/ .  Our GCC port is pretty solid as of
7.3.0 -- we recently got more packages built in our Debian port than
IA64 has, for example!

This patch adds support for the RISC-V ISA via GCC 7.3.0 and 8.1.0.
I've tested this via "make check", but I'm afraid that doesn't actually
do anything for this patch so it's not a meaningful test.

We've got a RISC-V setup running already https://cx.rv8.io/, but we'd
love to be part of the official compiler explorer site.

> Note:
> This is more of an RFC than an actual suggested patch, as I can't figure
> out how to add RISC-V to the list of installed cross compilers on the
> official site.  Our GNU toolchain is all upstream, so it should just be
> a matter of adding "riscv64-unknown-linux-gnu" to a list of target
> tuples somewhere.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
