### PR TITLE
Msvc in C compilers list

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -164,7 +164,6 @@ group.ccl.compilerType=Wine-CL
 group.ccl.includeFlag=/I
 group.ccl.versionFlag=/?
 group.ccl.versionRe=^Microsoft \(R\) C/C\+\+.*$
-group.ccl.demangler=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64/undname.exe
 group.ccl.isSemVer=true
 group.ccl19.groupName=MSVC 2017
 group.ccl19.compilers=ccl19_64:ccl19_32:ccl19_arm

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&ppci:&cicc
+compilers=&cgcc86:&cclang:&ppci:&cicc:&ccl
 defaultCompiler=cg81
 demangler=/opt/compiler-explorer/gcc-8.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-8.1.0/bin/objdump
@@ -155,3 +155,55 @@ compiler.cicc17.options=-x c -gcc-name=/opt/compiler-explorer/gcc-5.1.0/bin/gcc
 compiler.cicc18.exe=/opt/compiler-explorer/intel-2018.0.033/bin/icc
 compiler.cicc18.semver=18.0.0
 compiler.cicc18.options=-x c -gcc-name=/opt/compiler-explorer/gcc-6.3.0/bin/gcc
+
+################################
+# Windows Compilers
+group.ccl.compilers=&ccl19:&ccl19_2015_u3:&ccl_new
+group.ccl.needsMulti=false
+group.ccl.compilerType=Wine-CL
+group.ccl.includeFlag=/I
+group.ccl.versionFlag=/?
+group.ccl.versionRe=^Microsoft \(R\) C/C\+\+.*$
+group.ccl.demangler=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64/undname.exe
+group.ccl.isSemVer=true
+group.ccl19.groupName=MSVC 2017
+group.ccl19.compilers=ccl19_64:ccl19_32:ccl19_arm
+group.ccl19.options=/I/opt/compiler-explorer/windows/10.0.10240.0/ucrt/ /I/opt/compiler-explorer/windows/19.10.25017/lib/native/include/ /TC
+compiler.ccl19_64.exe=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64/cl.exe
+compiler.ccl19_64.name=x86-64 MSVC 19 2017 RTW
+compiler.ccl19_64.semver=19.10.25017
+compiler.ccl19_32.exe=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64_x86/cl.exe
+compiler.ccl19_32.name=x86 MSVC 19 2017 RTW
+compiler.ccl19_32.semver=19.10.25017
+compiler.ccl19_arm.exe=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64_arm/cl.exe
+compiler.ccl19_arm.name=ARM MSVC 2017 RTW
+compiler.ccl19_arm.semver=19.10.25017
+
+group.ccl19_2015_u3.groupName=MSVC 2015
+group.ccl19_2015_u3.compilers=ccl19_2015_u3_64:ccl19_2015_u3_32:ccl19_2015_u3_arm
+group.ccl19_2015_u3.options=/I/opt/compiler-explorer/windows/10.0.10240.0/ucrt/ /I/opt/compiler-explorer/windows/19.00.24210/include/ /TC
+compiler.ccl19_2015_u3_64.exe=/opt/compiler-explorer/windows/19.00.24210/bin/amd64/cl.exe
+compiler.ccl19_2015_u3_64.name=x86-64 MSVC 19 2015 U3
+compiler.ccl19_2015_u3_64.semver=19.00.24210
+compiler.ccl19_2015_u3_32.exe=/opt/compiler-explorer/windows/19.00.24210/bin/amd64_x86/cl.exe
+compiler.ccl19_2015_u3_32.name=x86 MSVC 19 2015 U3
+compiler.ccl19_2015_u3_32.semver=19.00.24210
+compiler.ccl19_2015_u3_arm.exe=/opt/compiler-explorer/windows/19.00.24210/bin/amd64_arm/cl.exe
+compiler.ccl19_2015_u3_arm.name=ARM MSVC 2015 U3
+compiler.ccl19_2015_u3_arm.semver=19.00.24210
+
+group.ccl_new.groupName=MSVC Pre
+group.ccl_new.compilers=ccl_new_64:ccl_new_32:ccl_new_arm32:ccl_new_arm64
+group.ccl_new.options=/I/opt/compiler-explorer/windows/10.0.10240.0/ucrt/ /I/opt/compiler-explorer/windows/19.14.26423/include/ /TC
+compiler.ccl_new_64.exe=/opt/compiler-explorer/windows/19.14.26423/bin/Hostx64/x64/cl.exe
+compiler.ccl_new_64.name=x86-64 MSVC Pre 2018
+compiler.ccl_new_64.semver=19.14.26423
+compiler.ccl_new_32.exe=/opt/compiler-explorer/windows/19.14.26423/bin/Hostx64/x86/cl.exe
+compiler.ccl_new_32.name=x86 MSVC Pre 2018
+compiler.ccl_new_32.semver=19.14.26423
+compiler.ccl_new_arm32.exe=/opt/compiler-explorer/windows/19.14.26423/bin/Hostx64/arm/cl.exe
+compiler.ccl_new_arm32.name=ARM MSVC Pre 2018
+compiler.ccl_new_arm32.semver=19.14.26423
+compiler.ccl_new_arm64.exe=/opt/compiler-explorer/windows/19.14.26423/bin/Hostx64/arm64/cl.exe
+compiler.ccl_new_arm64.name=ARM64 MSVC Pre 2018
+compiler.ccl_new_arm64.semver=19.14.26423


### PR DESCRIPTION
As stated on #969, msvc supports adding `/TC` to compile as C, so we add them there for ease of use

Closes #969 