### PR TITLE
Longtextdemanglefix

### DIFF
--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -144,6 +144,8 @@ class Demangler extends AsmRegex {
     }
 
     execDemangler(options) {
+        options.maxOutput = -1;
+
         return this.compiler.exec(
             this.demanglerExe,
             this.demanglerArguments,

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -82,7 +82,7 @@ function execute(command, args, options) {
         stream.on('data', data => {
             if (streams.truncated) return;
             const newLength = (streams[name].length + data.length);
-            if (newLength > maxOutput) {
+            if ((maxOutput !== -1) && (newLength > maxOutput)) {
                 streams[name] = streams[name] + data.slice(0, maxOutput - streams[name].length);
                 streams[name] += "\n[Truncated]";
                 streams.truncated = true;


### PR DESCRIPTION
Demangler output was truncated, so a lot of demangled labels were left out.

I tried adding the testcase, but that caused too much memory use in testing.

Demangling definitely is slow in these cases, but haven't found a way yet to speed it up.