### PR TITLE
nlohmann json: Remove version 2.1.1

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -413,12 +413,14 @@ libs.expected_lite.versions.010.path=/opt/compiler-explorer/libs/expected-lite/v
 libs.expected_lite.versions.trunk.version=trunk
 libs.expected_lite.versions.trunk.path=/opt/compiler-explorer/libs/expected-lite/trunk/include
 libs.nlohmann_json.name=nlohmann::json
-libs.nlohmann_json.versions=trunk:312
+libs.nlohmann_json.versions=trunk:312:211
 libs.nlohmann_json.url=https://github.com/nlohmann/json
 libs.nlohmann_json.versions.trunk.version=trunk
-libs.nlohmann_json.versions.312.version=3.1.2
 libs.nlohmann_json.versions.trunk.path=/opt/compiler-explorer/libs/nlohmann_json/trunk/single_include
+libs.nlohmann_json.versions.312.version=3.1.2
 libs.nlohmann_json.versions.312.path=/opt/compiler-explorer/libs/nlohmann_json/v3.1.2/single_include
+libs.nlohmann_json.versions.211.version=2.1.1
+libs.nlohmann_json.versions.211.path=/opt/compiler-explorer/libs/nlohmann_json/v2.1.1/src
 # OpenCV disabled for now, needs more installation work, any many more paths
 libs.opencv.name=OpenCV
 libs.opencv.versions=trunk

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -413,14 +413,12 @@ libs.expected_lite.versions.010.path=/opt/compiler-explorer/libs/expected-lite/v
 libs.expected_lite.versions.trunk.version=trunk
 libs.expected_lite.versions.trunk.path=/opt/compiler-explorer/libs/expected-lite/trunk/include
 libs.nlohmann_json.name=nlohmann::json
-libs.nlohmann_json.versions=trunk:312:211
+libs.nlohmann_json.versions=trunk:312
 libs.nlohmann_json.url=https://github.com/nlohmann/json
 libs.nlohmann_json.versions.trunk.version=trunk
 libs.nlohmann_json.versions.312.version=3.1.2
-libs.nlohmann_json.versions.211.version=2.1.1
 libs.nlohmann_json.versions.trunk.path=/opt/compiler-explorer/libs/nlohmann_json/trunk/single_include
 libs.nlohmann_json.versions.312.path=/opt/compiler-explorer/libs/nlohmann_json/v3.1.2/single_include
-libs.nlohmann_json.versions.211.path=/opt/compiler-explorer/libs/nlohmann_json/v2.1.1/single_include
 # OpenCV disabled for now, needs more installation work, any many more paths
 libs.opencv.name=OpenCV
 libs.opencv.versions=trunk


### PR DESCRIPTION
This is an old version which had a different directory structure
and as a result different include paths. Since this version is
quite old, I don't think it adds much value.
Removing it to avoid confusion among users.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
