### PR TITLE
Fix nav-bar Share overlapping other dropdowns

### DIFF
--- a/static/sharing.js
+++ b/static/sharing.js
@@ -124,13 +124,7 @@ function initShareButton(getLink, layout) {
         placement: 'bottom',
         trigger: 'manual'
     }).click(function () {
-        // load opposite state on click to prevent unnecessary popover rendering
-        if (getLink.data('bs.popover').tip().is(':visible')) {
-            getLink.popover('hide');
-        }
-        else {
-            getLink.popover('show');
-        }
+        getLink.popover('toggle');
     }).on('inserted.bs.popover', function () {
         ga.proxy('send', {
             hitType: 'event',

--- a/static/sharing.js
+++ b/static/sharing.js
@@ -124,7 +124,13 @@ function initShareButton(getLink, layout) {
         placement: 'bottom',
         trigger: 'manual'
     }).click(function () {
-        getLink.popover('show');
+        // load opposite state on click to prevent unnecessary popover rendering
+        if (getLink.data('bs.popover').tip().is(':visible')) {
+            getLink.popover('hide');
+        }
+        else {
+            getLink.popover('show');
+        }
     }).on('inserted.bs.popover', function () {
         ga.proxy('send', {
             hitType: 'event',

--- a/static/sharing.js
+++ b/static/sharing.js
@@ -184,7 +184,7 @@ function initShareButton(getLink, layout) {
 
     // Dismiss on any click that isn't either in the opening element, inside
     // the popover or on any alert
-    $(document).on('click.editable', function (e) {
+    $(document).on('mouseup', function (e) {
         var target = $(e.target);
         if (!target.is(getLink) && getLink.has(target).length === 0 && target.closest('.popover').length === 0)
             getLink.popover("hide");


### PR DESCRIPTION
Turns out `click.editable` isn't fired when another dropdown is clicked, meaning this callback is never called. When changed to `mouseup`, the callback is called and the Share menu is successfully closed.

Also, it looks like this could also be solved by specifiying the layout properly in `views/index.pug` (like the Other and Policies dropdowns are specified), but that seemed like a larger fix. Plus this got the job done :)

Fixes #1011 