### PR TITLE
Add Intel syntax support for ELLCC. Fixes #1014

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -348,6 +348,7 @@ compiler.cl_new_arm64.semver=19.14.26423
 #################################
 # ELLCC
 group.ellcc.compilers=ellcc0133:ellcc0134:ellcc170716
+group.ellcc.intelAsm=-mllvm --x86-asm-syntax=intel
 group.ellcc.groupName=ELLCC
 group.ellcc.baseName=ellcc
 group.ellcc.isSemVer=true


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
ellcc supports the same set of options as Clang to emit Intel syntax output, so I've added the necessary line to enable Intel syntax support