### PR TITLE
fix typo in llvm.default.properties

### DIFF
--- a/etc/config/llvm.default.properties
+++ b/etc/config/llvm.default.properties
@@ -24,5 +24,5 @@ compiler.opt.supportsBinary=false
 compiler.opt.supportsExecute=false
 compiler.opt.groupName=LLVM optimizer
 compiler.opt.versionRe=LLVM version .*
-compiler.opt.exe=/usr/bin/pot
+compiler.opt.exe=/usr/bin/opt
 compiler.opt.name=opt


### PR DESCRIPTION
Just saw this while browsing the source code. I assume it was a typo?