### PR TITLE
CTRE with two different branches (for backward compatibility)

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -465,10 +465,12 @@ libs.blaze.versions.33.version=3.3
 libs.blaze.versions.33.path=/opt/compiler-explorer/libs/blaze/v3.3
 libs.ctre.name=CTRE
 libs.ctre.description=Compile Time Regular Expressions
-libs.ctre.versions=trunk
+libs.ctre.versions=trunk:v2
 libs.ctre.url=https://github.com/hanickadot/compile-time-regular-expressions
 libs.ctre.versions.trunk.version=trunk
-libs.ctre.versions.trunk.path=/opt/compiler-explorer/libs/ctre/include
+libs.ctre.versions.trunk.path=/opt/compiler-explorer/libs/ctre/master/include
+libs.ctre.versions.v2.version=v2
+libs.ctre.versions.v2.path=/opt/compiler-explorer/libs/ctre/v2/include
 libs.eigen.name=Eigen
 libs.eigen.versions=trunk:334
 libs.eigen.url=http://eigen.tuxfamily.org/index.php?title=Main_Page


### PR DESCRIPTION
I added new version (branch) of CTRE library (there will be another pull request in Image repo)
