### PR TITLE
Change S3 endpoints to dualstack

### DIFF
--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -18,4 +18,4 @@ formatters=clangformat
 formatter.clangformat.name=clang-format
 formatter.clangformat.exe=/opt/compiler-explorer/clang-trunk/bin/clang-format
 formatter.clangformat.styles=Google:LLVM:Mozilla:Chromium:WebKit
-motdUrl=https://s3.amazonaws.com/compiler-explorer/motd/motd-prod.json
+motdUrl=https://s3.dualstack.us-east-1.amazonaws.com/compiler-explorer/motd/motd-prod.json

--- a/etc/config/compiler-explorer.beta.properties
+++ b/etc/config/compiler-explorer.beta.properties
@@ -1,4 +1,4 @@
 extraBodyClass=beta
 web-alias=/beta
 urlShortenService=google
-motdUrl=https://s3.amazonaws.com/compiler-explorer/motd/motd-beta.json
+motdUrl=https://s3.dualstack.us-east-1.amazonaws.com/compiler-explorer/motd/motd-beta.json


### PR DESCRIPTION
`s3.amazonaws.com` doesn't support IPv6. The corresponding dualstack endpoint is `s3.dualstack.us-east-1.amazonaws.com` (note that `s3.amazonaws.com` is actually in the us-east-1 region). Refer to [S3 dualstack documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/dual-stack-endpoints.html) and [the S3 endpoint list](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for more information.