### PR TITLE
Add the ability to specify environment variables (on windows)

### DIFF
--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -125,6 +125,19 @@ class CompilerFinder {
         const baseName = props("baseName", null);
         const semverVer = props("semver", "");
         const name = props("name", compilerName);
+        const envVars = (() => {
+            let envVarsString = props("envVars", "");
+            if (envVarsString === "") {
+                return [];
+            } else {
+                let arr = [];
+                for (const el of envVarsString.split(':')) {
+                    const [env, setting] = el.split('=');
+                    arr.push([env, setting]);
+                }
+                return arr;
+            }
+        })();
         const compilerInfo = {
             id: compilerName,
             exe: props("exe", compilerName),
@@ -149,6 +162,7 @@ class CompilerFinder {
             includeFlag: props("includeFlag", "-isystem"),
             includePath: props("includePath", ""),
             libPath: props("libPath", ""),
+            envVars: envVars,
             notification: props("notification", ""),
             isSemVer: isSemVer,
             semver: semverVer

--- a/lib/compilers/win32.js
+++ b/lib/compilers/win32.js
@@ -43,19 +43,19 @@ class Win32Compiler extends BaseCompiler {
         return false;
     }
 
-    setEnvVar(options, name, newVar) {
-        if (newVar) {
-            const oldVar = options.env[name] ? options.env[name] : "";
-            options.env[name] = newVar + oldVar;
-        }
-    }
-
     exec(compiler, args, options_) {
         let options = Object.assign({}, options_);
         options.env = Object.assign({}, options.env);
 
-        this.setEnvVar(options, 'INCLUDE', this.compiler.includePath);
-        this.setEnvVar(options, 'LIB', this.compiler.libPath);
+        if (this.compiler.includePath) {
+            options.env['INCLUDE'] = this.compiler.includePath;
+        }
+        if (this.compiler.libPath) {
+            options.env['LIB'] = this.compiler.libPath;
+        }
+        for (const [env, to] of this.compiler.envVars) {
+            options.env[env] = to;
+        }
 
         return super.exec(compiler, args, options);
     }

--- a/lib/compilers/wsl-vc.js
+++ b/lib/compilers/wsl-vc.js
@@ -63,7 +63,13 @@ class WslVcCompiler extends Win32VcCompiler {
         let options = Object.assign({}, options_);
         options.env = Object.assign({}, options.env);
 
-        this.setEnvVar(options, 'WSLENV', 'INCLUDE:LIB:');
+        let old_env = options.env['WSLENV'];
+        if (!old_env) {
+            old_env = '';
+        } else {
+            old_env = ':' + old_env;
+        }
+        options.env['WSLENV'] = 'INCLUDE:LIB' + old_env;
 
         return super.exec(compiler, args, options);
     }


### PR DESCRIPTION
Sometimes, it's important to be able to set environment variables for the VC++ compiler. This, specifically, is for experimental `-analyze` switches.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
