### PR TITLE
Binary support for MSVC

### DIFF
--- a/docs/WindowsNative.md
+++ b/docs/WindowsNative.md
@@ -56,7 +56,42 @@ and you should be done!
 You only have to run `yarn install` the first time;
 every time after that, you should just be able to run `yarn start`.
 
-### Current Limitations
 
-  - Execution support doesn't yet exist
-  - Binary disassembly doesn't work yet
+### Setting up binary mode and execution
+
+To create executables with Visual C++, it's required to install the Windows SDK.
+
+You can find the Windows 10 SDK [here](https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk)
+
+When you've installed the SDK, you'll need to setup the library and include paths in Compilers Explorer.
+Make sure that in the previously discussed c++.local.properties you have added at least:
+ * to includePath
+   - Windows Kits/10/include/*version*/ucrt
+   - Windows Kits/10/include/*version*/shared
+   - Windows Kits/10/include/*version*/um
+ * to libPath (for the x64 compiler)
+   - Windows Kits/10/Lib/*version*/um/x64
+   - Windows Kits/10/Lib/*version*/ucrt/x64
+   - VC installation path/lib/x64
+
+If needed, you can set in your properties file: ```supportsExecute=true```
+
+#### Binary mode
+
+For binary mode, you will need a Windows version of Objdump. There are various
+versions of MingW available that will offer binutils including objdump.
+
+The version of objdump that we have tested with is shipped with MingW-64,
+you can find it for download [here](https://sourceforge.net/projects/mingw-w64/)
+
+When you use the installer for MingW-64, make sure you select the right architecture during installation.
+
+When you use the zipped version, after unzipping you will need to add the bin folder to your Windows PATHS environment variable.
+
+When you have everything installed, you can add to your properties file the following:
+```
+supportsBinary=true
+objdumper=mingw path/mingw64/x86_64-w64-mingw32/bin/objdump.exe
+```
+
+*Note that the 32 bit version of MingW does not support 64 bit binaries.*

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -327,6 +327,7 @@ group.cl.versionRe=^Microsoft \(R\) C/C\+\+.*$
 group.cl.demangler=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64/undname.exe
 group.cl.demanglerClassFile=./demangler-win32
 group.cl.supportsBinary=false
+group.cl.objdumper=
 group.cl.isSemVer=true
 group.cl19.groupName=MSVC 2017
 group.cl19.compilers=cl19_64:cl19_32:cl19_arm

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -326,6 +326,7 @@ group.cl.versionFlag=/?
 group.cl.versionRe=^Microsoft \(R\) C/C\+\+.*$
 group.cl.demangler=/opt/compiler-explorer/windows/19.10.25017/lib/native/bin/amd64/undname.exe
 group.cl.demanglerClassFile=./demangler-win32
+group.cl.supportsBinary=false
 group.cl.isSemVer=true
 group.cl19.groupName=MSVC 2017
 group.cl19.compilers=cl19_64:cl19_32:cl19_arm

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -269,6 +269,7 @@ group.ccl.versionFlag=/?
 group.ccl.versionRe=^Microsoft \(R\) C/C\+\+.*$
 group.ccl.isSemVer=true
 group.ccl.supportsBinary=false
+group.ccl.objdumper=
 group.ccl19.groupName=MSVC 2017
 group.ccl19.compilers=ccl19_64:ccl19_32:ccl19_arm
 group.ccl19.options=/I/opt/compiler-explorer/windows/10.0.10240.0/ucrt/ /I/opt/compiler-explorer/windows/19.10.25017/lib/native/include/ /TC

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -268,6 +268,7 @@ group.ccl.includeFlag=/I
 group.ccl.versionFlag=/?
 group.ccl.versionRe=^Microsoft \(R\) C/C\+\+.*$
 group.ccl.isSemVer=true
+group.ccl.supportsBinary=false
 group.ccl19.groupName=MSVC 2017
 group.ccl19.compilers=ccl19_64:ccl19_32:ccl19_arm
 group.ccl19.options=/I/opt/compiler-explorer/windows/10.0.10240.0/ucrt/ /I/opt/compiler-explorer/windows/19.10.25017/lib/native/include/ /TC

--- a/lib/asm-parser-vc.js
+++ b/lib/asm-parser-vc.js
@@ -30,6 +30,7 @@ const AsmParserBase = require('./asm-parser'),
 class AsmParser extends AsmParserBase {
     constructor(compilerProps) {
         super(compilerProps);
+        this.asmBinaryParser = new AsmParserBase(compilerProps);
         this.miscDirective = /^\s*(include|INCLUDELIB|TITLE|\.|THUMB|ARM64|TTL|END$)/;
         this.localLabelDef = /^([a-zA-Z$_]+) =/;
         this.commentOnly = /^;/;
@@ -84,6 +85,10 @@ class AsmParser extends AsmParserBase {
     }
 
     processAsm(asm, filters) {
+        if (filters.binary) {
+            return this.asmBinaryParser.processAsm(asm, filters);
+        }
+
         const getFilenameFromComment = line => {
             const matches = line.match(this.filenameComment);
             if (!matches) {
@@ -100,10 +105,6 @@ class AsmParser extends AsmParserBase {
                 return parseInt(matches[1]);
             }
         };
-
-        if (filters.binary) {
-            logger.error("Binary mode should be disabled with the Visual C++ assembler parser");
-        }
 
         const asmLines = utils.splitLines(asm);
         // note: VC doesn't output unused labels, afaict

--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -308,13 +308,17 @@ class AsmParser extends AsmRegex {
 
     processBinaryAsm(asm, filters) {
         const result = [];
-        const asmLines = asm.split("\n");
+        let asmLines = asm.split("\n");
         let source = null;
         let func = null;
 
         // Handle "error" documents.
         if (asmLines.length === 1 && asmLines[0][0] === '<') {
             return [{text: asmLines[0], source: null}];
+        }
+
+        if (filters.preProcessBinaryAsmLines !== undefined) {
+            asmLines = filters.preProcessBinaryAsmLines(asmLines);
         }
 
         asmLines.forEach(line => {

--- a/lib/compilers/win32-vc.js
+++ b/lib/compilers/win32-vc.js
@@ -35,16 +35,6 @@ class Win32VcCompiler extends Win32Compiler {
     getArgumentParser() {
         return argumentParsers.Base;
     }
-
-    optionsForFilter(filters, outputFilename) {
-        return [
-            '/nologo',
-            '/FA',
-            '/c',
-            '/Fa' + this.filename(outputFilename),
-            '/Fo' + this.filename(outputFilename + '.obj')
-        ];
-    }
 }
 
 module.exports = Win32VcCompiler;

--- a/lib/compilers/win32.js
+++ b/lib/compilers/win32.js
@@ -25,7 +25,8 @@
 "use strict";
 
 const BaseCompiler = require('../base-compiler'),
-    temp = require('temp');
+    temp = require('temp'),
+    PELabelReconstructor = require("../pe32-support").labelReconstructor;
 
 class Win32Compiler extends BaseCompiler {
     newTempDir() {
@@ -40,7 +41,54 @@ class Win32Compiler extends BaseCompiler {
     }
 
     supportsObjdump() {
-        return false;
+        return true;
+    }
+
+    objdump(outputFilename, result, maxSize, intelAsm, demangle) {
+        outputFilename = outputFilename + '.exe';
+
+        let args = ["-d", outputFilename];
+        if (intelAsm) args = args.concat(["-M", "intel"]);
+        return this.exec(this.compiler.objdumper, args, {maxOutput: 0})
+           .then((objResult) => {
+               if (objResult.code !== 0) {
+                   result.asm = "<No output: objdump returned " + objResult.code + ">";
+               } else {
+                   result.asm = objResult.stdout;
+               }
+
+               return result;
+           });
+    }
+
+    optionsForFilter(filters, outputFilename) {
+        if (filters.binary) {
+            const mapFilename = outputFilename + '.map';
+
+            filters.preProcessBinaryAsmLines = (asmLines) => {
+                const reconstructor = new PELabelReconstructor(asmLines, mapFilename, false, "vs");
+                reconstructor.run("output.s.obj");
+
+                return reconstructor.asmLines;
+            };
+
+            return [
+                '/nologo',
+                '/FA',
+                '/Fa' + this.filename(outputFilename),
+                '/Fo' + this.filename(outputFilename + '.obj'),
+                '/Fm' + this.filename(mapFilename),
+                '/Fe' + this.filename(outputFilename + '.exe')
+            ];
+        } else {
+            return [
+                '/nologo',
+                '/FA',
+                '/c',
+                '/Fa' + this.filename(outputFilename),
+                '/Fo' + this.filename(outputFilename + '.obj'),
+            ];
+        }
     }
 
     exec(compiler, args, options_) {

--- a/lib/compilers/win32.js
+++ b/lib/compilers/win32.js
@@ -26,6 +26,7 @@
 
 const BaseCompiler = require('../base-compiler'),
     temp = require('temp'),
+    path = require('path'),
     PELabelReconstructor = require("../pe32-support").labelReconstructor;
 
 class Win32Compiler extends BaseCompiler {
@@ -44,21 +45,25 @@ class Win32Compiler extends BaseCompiler {
         return true;
     }
 
-    objdump(outputFilename, result, maxSize, intelAsm, demangle) {
-        outputFilename = outputFilename + '.exe';
+    getExecutableFilename(dirPath, outputFilebase) {
+        return this.getOutputFilename(dirPath, outputFilebase) + ".exe";
+    }
+
+    objdump(outputFilename, result, maxSize, intelAsm) {
+        outputFilename = this.getExecutableFilename(path.dirname(outputFilename), "output");
 
         let args = ["-d", outputFilename];
         if (intelAsm) args = args.concat(["-M", "intel"]);
         return this.exec(this.compiler.objdumper, args, {maxOutput: 0})
-           .then((objResult) => {
-               if (objResult.code !== 0) {
-                   result.asm = "<No output: objdump returned " + objResult.code + ">";
-               } else {
-                   result.asm = objResult.stdout;
-               }
+            .then((objResult) => {
+                if (objResult.code !== 0) {
+                    result.asm = "<No output: objdump returned " + objResult.code + ">";
+                } else {
+                    result.asm = objResult.stdout;
+                }
 
-               return result;
-           });
+                return result;
+            });
     }
 
     optionsForFilter(filters, outputFilename) {
@@ -78,7 +83,7 @@ class Win32Compiler extends BaseCompiler {
                 '/Fa' + this.filename(outputFilename),
                 '/Fo' + this.filename(outputFilename + '.obj'),
                 '/Fm' + this.filename(mapFilename),
-                '/Fe' + this.filename(outputFilename + '.exe')
+                '/Fe' + this.filename(this.getExecutableFilename(path.dirname(outputFilename), "output"))
             ];
         } else {
             return [

--- a/lib/compilers/win32.js
+++ b/lib/compilers/win32.js
@@ -42,7 +42,7 @@ class Win32Compiler extends BaseCompiler {
     }
 
     supportsObjdump() {
-        return true;
+        return false;
     }
 
     getExecutableFilename(dirPath, outputFilebase) {

--- a/lib/compilers/win32.js
+++ b/lib/compilers/win32.js
@@ -41,10 +41,6 @@ class Win32Compiler extends BaseCompiler {
         });
     }
 
-    supportsObjdump() {
-        return false;
-    }
-
     getExecutableFilename(dirPath, outputFilebase) {
         return this.getOutputFilename(dirPath, outputFilebase) + ".exe";
     }

--- a/lib/compilers/wine-vc.js
+++ b/lib/compilers/wine-vc.js
@@ -24,8 +24,8 @@
 
 const BaseCompiler = require('../base-compiler'),
     AsmParser = require('../asm-parser-vc'),
-    argumentParsers = require("./argument-parsers");
-
+    argumentParsers = require("./argument-parsers")
+    PELabelReconstructor = require("../pe32-support").labelReconstructor;
 
 class WineVcCompiler extends BaseCompiler {
     constructor(info, env) {
@@ -52,23 +52,59 @@ class WineVcCompiler extends BaseCompiler {
     }
 
     supportsObjdump() {
-        return false;
+        return true;
     }
 
     getArgumentParser() {
         return argumentParsers.Base;
     }
 
-    optionsForFilter(filters, outputFilename) {
-        return [
-            '/nologo',
-            '/FA',
-            '/c',
-            '/Fa' + this.filename(outputFilename),
-            '/Fo' + this.filename(outputFilename + '.obj')
-        ];
+    objdump(outputFilename, result, maxSize, intelAsm, demangle) {
+        outputFilename = outputFilename + '.exe';
+
+        let args = ["-d", outputFilename];
+        if (intelAsm) args = args.concat(["-M", "intel"]);
+        return this.exec(this.compiler.objdumper, args, {maxOutput: 0})
+           .then((objResult) => {
+               if (objResult.code !== 0) {
+                   result.asm = "<No output: objdump returned " + objResult.code + ">";
+               } else {
+                   result.asm = objResult.stdout;
+               }
+
+               return result;
+           });
     }
 
+    optionsForFilter(filters, outputFilename) {
+        if (filters.binary) {
+            const mapFilename = outputFilename + '.map';
+
+            filters.preProcessBinaryAsmLines = (asmLines) => {
+                const reconstructor = new PELabelReconstructor(asmLines, mapFilename, false, "vs");
+                reconstructor.run("output.s.obj");
+
+                return reconstructor.asmLines;
+            };
+
+            return [
+                '/nologo',
+                '/FA',
+                '/Fa' + this.filename(outputFilename),
+                '/Fo' + this.filename(outputFilename + '.obj'),
+                '/Fm' + this.filename(mapFilename),
+                '/Fe' + this.filename(outputFilename + '.exe')
+            ];
+        } else {
+            return [
+                '/nologo',
+                '/FA',
+                '/c',
+                '/Fa' + this.filename(outputFilename),
+                '/Fo' + this.filename(outputFilename + '.obj'),
+            ];
+        }
+    }
 }
 
 module.exports = WineVcCompiler;

--- a/lib/compilers/wine-vc.js
+++ b/lib/compilers/wine-vc.js
@@ -53,7 +53,7 @@ class WineVcCompiler extends BaseCompiler {
     }
 
     supportsObjdump() {
-        return true;
+        return false;
     }
 
     getArgumentParser() {

--- a/lib/compilers/wine-vc.js
+++ b/lib/compilers/wine-vc.js
@@ -52,10 +52,6 @@ class WineVcCompiler extends BaseCompiler {
         return 'Z:' + fn;
     }
 
-    supportsObjdump() {
-        return false;
-    }
-
     getArgumentParser() {
         return argumentParsers.Base;
     }

--- a/lib/compilers/wine-vc.js
+++ b/lib/compilers/wine-vc.js
@@ -24,7 +24,8 @@
 
 const BaseCompiler = require('../base-compiler'),
     AsmParser = require('../asm-parser-vc'),
-    argumentParsers = require("./argument-parsers")
+    argumentParsers = require("./argument-parsers"),
+    path = require('path'),
     PELabelReconstructor = require("../pe32-support").labelReconstructor;
 
 class WineVcCompiler extends BaseCompiler {
@@ -59,21 +60,25 @@ class WineVcCompiler extends BaseCompiler {
         return argumentParsers.Base;
     }
 
-    objdump(outputFilename, result, maxSize, intelAsm, demangle) {
-        outputFilename = outputFilename + '.exe';
+    getExecutableFilename(dirPath, outputFilebase) {
+        return this.getOutputFilename(dirPath, outputFilebase) + ".exe";
+    }
+
+    objdump(outputFilename, result, maxSize, intelAsm) {
+        outputFilename = this.getExecutableFilename(path.dirname(outputFilename), "output");
 
         let args = ["-d", outputFilename];
         if (intelAsm) args = args.concat(["-M", "intel"]);
         return this.exec(this.compiler.objdumper, args, {maxOutput: 0})
-           .then((objResult) => {
-               if (objResult.code !== 0) {
-                   result.asm = "<No output: objdump returned " + objResult.code + ">";
-               } else {
-                   result.asm = objResult.stdout;
-               }
+            .then((objResult) => {
+                if (objResult.code !== 0) {
+                    result.asm = "<No output: objdump returned " + objResult.code + ">";
+                } else {
+                    result.asm = objResult.stdout;
+                }
 
-               return result;
-           });
+                return result;
+            });
     }
 
     optionsForFilter(filters, outputFilename) {
@@ -93,7 +98,7 @@ class WineVcCompiler extends BaseCompiler {
                 '/Fa' + this.filename(outputFilename),
                 '/Fo' + this.filename(outputFilename + '.obj'),
                 '/Fm' + this.filename(mapFilename),
-                '/Fe' + this.filename(outputFilename + '.exe')
+                '/Fe' + this.filename(this.getExecutableFilename(path.dirname(outputFilename), "output"))
             ];
         } else {
             return [

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -84,7 +84,7 @@ function execute(command, args, options) {
         stream.on('data', data => {
             if (streams.truncated) return;
             const newLength = (streams[name].length + data.length);
-            if ((maxOutput !== -1) && (newLength > maxOutput)) {
+            if ((maxOutput !== 0) && (newLength > maxOutput)) {
                 streams[name] = streams[name] + data.slice(0, maxOutput - streams[name].length);
                 streams[name] += "\n[Truncated]";
                 streams.truncated = true;

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -84,7 +84,7 @@ function execute(command, args, options) {
         stream.on('data', data => {
             if (streams.truncated) return;
             const newLength = (streams[name].length + data.length);
-            if ((maxOutput !== 0) && (newLength > maxOutput)) {
+            if ((maxOutput > 0) && (newLength > maxOutput)) {
                 streams[name] = streams[name] + data.slice(0, maxOutput - streams[name].length);
                 streams[name] += "\n[Truncated]";
                 streams.truncated = true;

--- a/lib/map-file-vs.js
+++ b/lib/map-file-vs.js
@@ -1,0 +1,110 @@
+// Copyright (c) 2018, Compiler Explorer Team
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+var fs = require("fs"),
+    utils = require("./utils"),
+    MapFileReader = require("./map-file").MapFileReader;
+
+class MapFileReaderVS extends MapFileReader {
+    /**
+     * constructor
+     * @param {string} mapFilename 
+     */
+    constructor(mapFilename) {
+        super(mapFilename);
+
+        this.regexVsNames = /^\s([0-9a-f]*):([0-9a-f]*)\s*([a-z0-9?$_@.]*)\s*([0-9a-f]*)(\sf\si\s*|\sf\s*|\s*)([a-z0-9\-._<>:]*)$/i;
+        this.regexVSLoadAddress = /\sPreferred load address is ([0-9a-f]*)/i;
+        this.regexVsCodeSegment = /^\s([0-9a-f]*):([0-9a-f]*)\s*([0-9a-f]*)H\s*\.text\$mn\s*CODE.*/i;
+    }
+
+    /**
+     * 
+     * @param {string} line 
+     */
+    tryReadingPreferredAddress(line) {
+        const matches = line.match(this.regexVSLoadAddress);
+        if (matches) {
+            this.preferredLoadAddress = parseInt(matches[1], 16);
+        }
+    }
+
+    /**
+     * Tries to match the given line to code segment information
+     *  Matches in order:
+     *   1. segment offset info
+     *   2. code segment delphi map
+     *   3. icode segment delphi map
+     *   4. code segment vs map
+     * @param {string} line 
+     */
+    tryReadingCodeSegmentInfo(line) {
+        var codesegmentObject = false;
+
+        const matches = line.match(this.regexVsCodeSegment);
+        if (matches) {
+            codesegmentObject = this.addressToObject(matches[1], matches[2]);
+            codesegmentObject.id = this.segments.length + 1;
+            codesegmentObject.segmentLength = parseInt(matches[3], 16);
+            codesegmentObject.unitName = false;
+
+            this.segments.push(codesegmentObject);
+        }
+    }
+
+    /**
+     * Try to match information about the address where a symbol is
+     * @param {string} line 
+     */
+    tryReadingNamedAddress(line) {
+        var symbolObject = false;
+
+        const matches = line.match(this.regexVsNames);
+        if (matches && (matches.length >= 7) && (matches[4] !== "")) {
+            var addressWithOffset = parseInt(matches[4], 16);
+            symbolObject = {
+                segment: matches[1],
+                addressWithoutOffset: parseInt(matches[2], 16),
+                addressInt: addressWithOffset,
+                address: addressWithOffset.toString(16),
+                displayName: matches[3],
+                unitName: matches[6],
+                isStaticSymbol: false
+            };
+            this.namedAddresses.push(symbolObject);
+
+            this.setSegmentOffset(symbolObject.segment, symbolObject.addressInt - symbolObject.addressWithoutOffset);
+
+            var segment = this.getSegmentInfoAddressWithoutOffsetIsIn(
+                symbolObject.segment,
+                symbolObject.addressWithoutOffset);
+            if (segment && !segment.unitName) {
+                segment.unitName = matches[6];
+            }
+        }
+    }
+}
+
+exports.MapFileReader = MapFileReaderVS;

--- a/lib/map-file-vs.js
+++ b/lib/map-file-vs.js
@@ -23,9 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 "use strict";
 
-var fs = require("fs"),
-    utils = require("./utils"),
-    MapFileReader = require("./map-file").MapFileReader;
+const MapFileReader = require("./map-file").MapFileReader;
 
 class MapFileReaderVS extends MapFileReader {
     /**

--- a/lib/map-file.js
+++ b/lib/map-file.js
@@ -28,7 +28,10 @@ var fs = require("fs"),
 
 class MapFileReader {
     /**
-     * constructor
+     * constructor of MapFileReader
+     *  Note that this is a base class and should be overriden. (see for example map-file-vs.js)
+     *  Note that this base class retains and uses state,
+     *   so when you want to read a new file you need to instantiate a new object.
      * @param {string} mapFilename 
      */
     constructor(mapFilename) {
@@ -48,7 +51,7 @@ class MapFileReader {
     }
 
     /**
-     * 
+     * The function to call to load a map file (not async)
      */
     run() {
         if (this.mapFilename) {
@@ -90,7 +93,6 @@ class MapFileReader {
             }
         }
 
-        // default
         return this.preferredLoadAddress + parseInt(segment, 16) * this.segmentMultiplier;
     }
 
@@ -122,7 +124,6 @@ class MapFileReader {
             }
         }
 
-        // else, add it
         this.segmentOffsets.push({
             segment: segment,
             addressInt: address,
@@ -321,12 +322,8 @@ class MapFileReader {
     }
 
     /**
-     * Tries to match the given line to code segment information
-     *  Matches in order:
-     *   1. segment offset info
-     *   2. code segment delphi map
-     *   3. icode segment delphi map
-     *   4. code segment vs map
+     * Tries to match the given line to code segment information.
+     *  Implementation specific, so this base function is empty
      * @param {string} line 
      */
     tryReadingCodeSegmentInfo(line) {
@@ -370,6 +367,9 @@ class MapFileReader {
         return false;
     }
 
+    /**
+     * Tries to reconstruct segments information from contiguous named addresses
+     */
     reconstructSegmentsFromNamedAddresses() {
         let currentUnit = false;
         let addressStart = 0;
@@ -377,7 +377,6 @@ class MapFileReader {
             const symbolObject = this.namedAddresses[idxSymbol];
 
             if (symbolObject.addressInt < this.preferredLoadAddress) continue;
-            //if (symbolObject.isStaticSymbol) continue;
 
             if (!currentUnit) {
                 addressStart = symbolObject.addressInt;
@@ -408,6 +407,11 @@ class MapFileReader {
         }
     }
 
+    /**
+     * Returns an array of objects with address range information for a given unit (filename)
+     *  [{startAddress: int, startAddressHex: string, endAddress: int, endAddressHex: string}]
+     * @param {string} unitName 
+     */
     getReconstructedUnitAddressSpace(unitName) {
         let addressSpace = [];
 
@@ -478,6 +482,9 @@ class MapFileReader {
         this.reconstructSegmentsFromNamedAddresses();
     }
 
+    /**
+     * Reads the actual mapfile from disk synchronously and load it into this class
+     */
     loadMap() {
         const data = fs.readFileSync(this.mapFilename);
 

--- a/lib/map-file.js
+++ b/lib/map-file.js
@@ -318,7 +318,7 @@ class MapFileReader {
      * Try to match information about the address where a symbol is
      * @param {string} line 
      */
-    tryReadingNamedAddress(line) {
+    tryReadingNamedAddress() {
     }
 
     /**
@@ -326,7 +326,7 @@ class MapFileReader {
      *  Implementation specific, so this base function is empty
      * @param {string} line 
      */
-    tryReadingCodeSegmentInfo(line) {
+    tryReadingCodeSegmentInfo() {
     }
 
     /**
@@ -347,7 +347,7 @@ class MapFileReader {
      * 
      * @param {string} line 
      */
-    tryReadingPreferredAddress(line) {
+    tryReadingPreferredAddress() {
     }
 
     /**
@@ -355,7 +355,7 @@ class MapFileReader {
      * @param {string} line 
      * @returns {boolean}
      */
-    tryReadingLineNumbers(line) {
+    tryReadingLineNumbers() {
         return false;
     }
 
@@ -363,7 +363,7 @@ class MapFileReader {
      * 
      * @param {string} line 
      */
-    isStartOfLineNumbers(line) {
+    isStartOfLineNumbers() {
         return false;
     }
 

--- a/lib/map-file.js
+++ b/lib/map-file.js
@@ -1,0 +1,488 @@
+// Copyright (c) 2018, Compiler Explorer Team
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+var fs = require("fs"),
+    utils = require("./utils");
+
+class MapFileReader {
+    /**
+     * constructor
+     * @param {string} mapFilename 
+     */
+    constructor(mapFilename) {
+        this.mapFilename = mapFilename;
+        this.preferredLoadAddress = 0x400000;
+        this.segmentMultiplier = 0x1000;
+        this.segmentOffsets = [];
+        this.segments = [];
+        this.isegments = [];
+        this.namedAddresses = [];
+        this.entryPoint = "";
+
+        this.lineNumbers = [];
+        this.reconstructedSegments = [];
+
+        this.regexEntryPoint = /^\sentry point at\s*([0-9a-f]*):([0-9a-f]*)$/i;
+    }
+
+    /**
+     * 
+     */
+    run() {
+        if (this.mapFilename) {
+            this.loadMap();
+        }
+    }
+
+    /**
+     * 
+     * @param {(string|boolean)} segment 
+     * @param {number} address 
+     * @returns {(Object|boolean)} 
+     */
+    getLineInfoByAddress(segment, address) {
+        for (var idx = 0; idx < this.lineNumbers.length; idx++) {
+            var lineInfo = this.lineNumbers[idx];
+            if (!segment && (lineInfo.addressInt === address)) {
+                return lineInfo;
+            } else if ((segment === lineInfo.segment) && (lineInfo.addressWithoutOffset === address)) {
+                return lineInfo;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} segment 
+     * @returns {number} 
+     */
+    getSegmentOffset(segment) {
+        if (this.segmentOffsets.length > 0) {
+            for (let idx = 0; idx < this.segmentOffsets.length; idx++) {
+                const info = this.segmentOffsets[idx];
+                if (info.segment === segment) {
+                    return info.addressInt;
+                }
+            }
+        }
+
+        // default
+        return this.preferredLoadAddress + parseInt(segment, 16) * this.segmentMultiplier;
+    }
+
+    /**
+     * 
+     * @param {string} segment 
+     * @param {number} address 
+     */
+    setSegmentOffset(segment, address) {
+        let info = false;
+        let idx = 0;
+
+        for (idx = 0; idx < this.segments.length; idx++) {
+            info = this.segments[idx];
+            if (info.segment === segment) {
+                this.segments[idx].addressInt = address;
+                this.segments[idx].address = address.toString(16);
+            }
+        }
+
+        if (this.segmentOffsets.length > 0) {
+            for (idx = 0; idx < this.segmentOffsets.length; idx++) {
+                info = this.segmentOffsets[idx];
+                if (info.segment === segment) {
+                    this.segmentOffsets[idx].addressInt = address;
+                    this.segmentOffsets[idx].address = address.toString(16);
+                    return;
+                }
+            }
+        }
+
+        // else, add it
+        this.segmentOffsets.push({
+            segment: segment,
+            addressInt: address,
+            address: address.toString(16),
+            segmentLength: 0
+        });
+    }
+
+    /**
+     * 
+     * @param {string} unitName 
+     * @returns {(Object|boolean)} 
+     */
+    getSegmentInfoByUnitName(unitName) {
+        for (let idx = 0; idx < this.segments.length; idx++) {
+            const info = this.segments[idx];
+            if (info.unitName === unitName) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} unitName 
+     * @returns {(Object|boolean)} 
+     */
+    getICodeSegmentInfoByUnitName(unitName) {
+        for (let idx = 0; idx < this.isegments.length; idx++) {
+            const info = this.isegments[idx];
+            if (info.unitName === unitName) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} unitName 
+     * @returns {number} 
+     */
+    getSegmentIdByUnitName(unitName) {
+        const info = this.getSegmentInfoByUnitName(unitName);
+        if (info) {
+            return info.id;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Get Segment info for exact address
+     * @param {(string|boolean)} segment
+     * @param {number} address
+     * @returns {(Object|boolean)} 
+     */
+    getSegmentInfoByStartingAddress(segment, address) {
+        for (let idx = 0; idx < this.segments.length; idx++) {
+            const info = this.segments[idx];
+            if (!segment && (info.addressInt === address)) {
+                return info;
+            } else if ((info.segment === segment) && (info.addressWithoutOffset === address)) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get Segment info for the segment where the given address is in
+     * @param {(string|boolean)} segment 
+     * @param {number} address 
+     * @returns {(Object|boolean)} 
+     */
+    getSegmentInfoAddressIsIn(segment, address) {
+        for (let idx = 0; idx < this.segments.length; idx++) {
+            const info = this.segments[idx];
+            if (!segment && (address >= info.addressInt) && (address < (info.addressInt + info.segmentLength))) {
+                return info;
+            } else if ((segment === info.segment) &&
+                       (address >= info.addressWithoutOffset) &&
+                       (address < (info.addressWithoutOffset + info.segmentLength))) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+    
+    /**
+     * Get Segment info for the segment where the given address is in
+     * @param {string} segment 
+     * @param {number} address 
+     * @returns {(Object|boolean)} 
+     */
+    getSegmentInfoAddressWithoutOffsetIsIn(segment, address) {
+        for (let idx = 0; idx < this.segments.length; idx++) {
+            const info = this.segments[idx];
+            if ((segment === info.segment) &&
+                (address >= info.addressWithoutOffset) &&
+                (address < (info.addressWithoutOffset + info.segmentLength))) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} segment 
+     * @param {number} address 
+     * @returns {(Object|boolean)} 
+     */
+    getSymbolAt(segment, address) {
+        for (let idx = 0; idx < this.namedAddresses.length; idx++) {
+            const info = this.namedAddresses[idx];
+            if (!segment && (info.addressInt === address)) {
+                return info;
+            } else if ((segment === info.segment) && (info.addressWithoutOffset === address)) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} segment
+     * @param {number} address
+     * @returns {(Object|boolean)}
+     */
+    getSymbolBefore(segment, address) {
+        let maxNamed = false;
+
+        for (let idx = 0; idx < this.namedAddresses.length; idx++) {
+            const info = this.namedAddresses[idx];
+            if (!segment && (info.addressInt <= address)) {
+                if (!maxNamed || (info.addressInt > maxNamed.addressInt)) {
+                    maxNamed = info;
+                }
+            } else if ((segment === info.segment) && (info.addressWithoutOffset <= address)) {
+                if (!maxNamed || (info.addressInt > maxNamed.addressInt)) {
+                    maxNamed = info;
+                }
+            }
+        }
+
+        return maxNamed;
+    }
+
+    /**
+     *
+     * @param {string} name 
+     * @returns {(Object|boolean)} 
+     */
+    getSymbolInfoByName(name) {
+        for (let idx = 0; idx < this.namedAddresses.length; idx++) {
+            const info = this.namedAddresses[idx];
+            if (info.displayName === name) {
+                return info;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} segment 
+     * @param {string} address 
+     */
+    addressToObject(segment, address) {
+        const addressWithoutOffset = parseInt(address, 16);
+        const addressWithOffset = this.getSegmentOffset(segment) + addressWithoutOffset;
+
+        return {
+            segment: segment,
+            addressWithoutOffset: addressWithoutOffset,
+            addressInt: addressWithOffset,
+            address: addressWithOffset.toString(16)
+        };
+    }
+
+    /**
+     * Try to match information about the address where a symbol is
+     * @param {string} line 
+     */
+    tryReadingNamedAddress(line) {
+    }
+
+    /**
+     * Tries to match the given line to code segment information
+     *  Matches in order:
+     *   1. segment offset info
+     *   2. code segment delphi map
+     *   3. icode segment delphi map
+     *   4. code segment vs map
+     * @param {string} line 
+     */
+    tryReadingCodeSegmentInfo(line) {
+    }
+
+    /**
+     * 
+     * @param {string} line 
+     */
+    tryReadingEntryPoint(line) {
+        const matches = line.match(this.regexEntryPoint);
+        if (matches) {
+            this.entryPoint = {
+                segment: matches[1],
+                addressWithoutOffset: matches[2]
+            };
+        }
+    }
+
+    /**
+     * 
+     * @param {string} line 
+     */
+    tryReadingPreferredAddress(line) {
+    }
+
+    /**
+     * Retreives line number references from supplied Map line
+     * @param {string} line 
+     * @returns {boolean}
+     */
+    tryReadingLineNumbers(line) {
+        return false;
+    }
+
+    /**
+     * 
+     * @param {string} line 
+     */
+    isStartOfLineNumbers(line) {
+        return false;
+    }
+
+    reconstructSegmentsFromNamedAddresses() {
+        let currentUnit = false;
+        let addressStart = 0;
+        for (let idxSymbol = 0; idxSymbol < this.namedAddresses.length; ++idxSymbol) {
+            const symbolObject = this.namedAddresses[idxSymbol];
+
+            if (symbolObject.addressInt < this.preferredLoadAddress) continue;
+            //if (symbolObject.isStaticSymbol) continue;
+
+            if (!currentUnit) {
+                addressStart = symbolObject.addressInt;
+                currentUnit = symbolObject.unitName;
+            } else if ((symbolObject.unitName !== currentUnit)) {
+                const segmentLen = symbolObject.addressInt - addressStart;
+
+                this.reconstructedSegments.push({
+                    addressInt: addressStart,
+                    address: addressStart.toString(16),
+                    endAddress: (addressStart + segmentLen).toString(16),
+                    segmentLength: segmentLen,
+                    unitName: currentUnit
+                });
+
+                addressStart = symbolObject.addressInt;
+                currentUnit = symbolObject.unitName;
+            }
+
+            if (idxSymbol === this.namedAddresses.length - 1) {
+                this.reconstructedSegments.push({
+                    addressInt: addressStart,
+                    address: addressStart.toString(16),
+                    segmentLength: -1,
+                    unitName: symbolObject.unitName
+                });
+            }
+        }
+    }
+
+    getReconstructedUnitAddressSpace(unitName) {
+        let addressSpace = [];
+
+        for (let idxSegment = 0; idxSegment < this.reconstructedSegments.length; ++idxSegment) {
+            const segment = this.reconstructedSegments[idxSegment];
+            if (segment.unitName === unitName) {
+                addressSpace.push({
+                    startAddress: segment.addressInt,
+                    startAddressHex: segment.addressInt.toString(16),
+                    endAddress: segment.addressInt + segment.segmentLength,
+                    endAddressHex: (segment.addressInt + segment.segmentLength).toString(16)
+                });
+            }
+        }
+
+        return addressSpace;
+    }
+
+    /**
+     * 
+     * @param {array of objects} spaces
+     * @param {object} address 
+     */
+    isWithinAddressSpace(spaces, address) {
+        for (let idxSpace = 0; idxSpace < spaces.length; ++idxSpace) {
+            const spaceAddress = spaces[idxSpace];
+
+            if ((address >= spaceAddress.startAddress) && (address < spaceAddress.endAddress)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Retreives information from Map file contents
+     * @param {string} contents 
+     */
+    loadMapFromString(contents) {
+        const mapLines = utils.splitLines(contents);
+        
+        let readLineNumbersMode = false;
+
+        let lineIdx = 0;
+        while (lineIdx < mapLines.length) {
+            const line = mapLines[lineIdx];
+
+            if (!readLineNumbersMode) {
+                this.tryReadingPreferredAddress(line);
+                this.tryReadingEntryPoint(line);
+                this.tryReadingCodeSegmentInfo(line);
+                this.tryReadingNamedAddress(line);
+
+                if (this.isStartOfLineNumbers(line)) {
+                    readLineNumbersMode = true;
+                    lineIdx++;
+                }
+            } else {
+                if (!this.tryReadingLineNumbers(line)) {
+                    readLineNumbersMode = false;
+                }
+            }
+
+            lineIdx++;
+        }
+
+        this.reconstructSegmentsFromNamedAddresses();
+    }
+
+    loadMap() {
+        const data = fs.readFileSync(this.mapFilename);
+
+        this.loadMapFromString(data.toString());
+    }
+}
+
+exports.MapFileReader = MapFileReader;

--- a/lib/pe32-support.js
+++ b/lib/pe32-support.js
@@ -1,0 +1,251 @@
+// Copyright (c) 2018, Compiler Explorer Team
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+var fs = require('fs');
+
+class PELabelReconstructor {
+    /**
+     * 
+     * @param {Array} asmLines 
+     * @param {string} mapFilename 
+     * @param {boolean} dontLabelUnmappedAddresses 
+     * @param {function} callback 
+     */
+    constructor(asmLines, mapFilename, dontLabelUnmappedAddresses, compilerName) {
+        this.asmLines = asmLines;
+        this.addressesToLabel = [];
+        this.dontLabelUnmappedAddresses = dontLabelUnmappedAddresses;
+
+        this.addressRegex = /^\s*([0-9a-f]*):/i;
+        this.jumpRegex = /(\sj[a-z]*)(\s*)0x([0-9a-f]*)/i;
+        this.callRegex = /(\scall)(\s*)0x([0-9a-f]*)/i;
+        this.int3Regex = /\tcc\s*\tint3\s*$/i;
+
+        this.compilerName = compilerName;
+        this.mapFileReader = null;
+        this.mapFilename = mapFilename;
+    }
+
+    /**
+     * Start reconstructing labels using the mapfile and remove unneccessary assembly
+     * @param {string} unitName 
+     */
+    run(unitName) {
+        let MapFileReader = require('./map-file-' + this.compilerName).MapFileReader;
+        this.mapFileReader = new MapFileReader(this.mapFilename);
+        this.mapFileReader.run();
+
+        this.deleteEverythingBut(unitName);
+        this.shortenInt3s();
+    
+        this.collectJumpsAndCalls();
+        this.insertLabels();
+    }
+
+    /**
+     * Remove any alignment NOP/int3 opcodes and replace them by a single line "..."
+     */
+    shortenInt3s() {
+        let lineIdx = 0;
+        let inInt3 = false;
+
+        while (lineIdx < this.asmLines.length) {
+            const line = this.asmLines[lineIdx];
+
+            if (line.match(this.int3Regex)) {
+                if (inInt3) {
+                    this.asmLines.splice(lineIdx, 1);
+                    lineIdx--;
+                } else {
+                    inInt3 = true;
+                    this.asmLines[lineIdx] = "...";
+                }
+            } else {
+                inInt3 = false;
+            }
+
+            lineIdx++;
+        }
+    }
+
+    /**
+     * Remove any assembly or data that isn't part of the given unit
+     * @param {string} unitName 
+     */
+    deleteEverythingBut(unitName) {
+        // todo: deletion by reconstructed addresses is a VS specific technique, delphi mapping is more precise and doesnt need reconstruction
+
+        let unitAddressSpaces = this.mapFileReader.getReconstructedUnitAddressSpace(unitName);
+
+        for (let idx = 0; idx < this.mapFileReader.reconstructedSegments.length; idx++) {
+            const info = this.mapFileReader.reconstructedSegments[idx];
+            if (info.unitName !== unitName) {
+                if (info.segmentLength > 0) {
+                    if (!this.mapFileReader.isWithinAddressSpace(unitAddressSpaces, info.addressInt)) {
+                        this.deleteLinesBetweenAddresses(info.addressInt, info.addressInt + info.segmentLength);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * 
+     * @param {number} beginAddress 
+     * @param {number} endAddress 
+     */
+    deleteLinesBetweenAddresses(beginAddress, endAddress) {
+        let startIdx = -1;
+        let linesRemoved = false;
+        let lineIdx = 0;
+
+        while (lineIdx < this.asmLines.length) {
+            const line = this.asmLines[lineIdx];
+
+            const matches = line.match(this.addressRegex);
+            if (matches) {
+                const lineAddr = parseInt(matches[1], 16);
+                if ((startIdx === -1) && (lineAddr >= beginAddress)) {
+                    startIdx = lineIdx;
+                    if (line.endsWith("<CODE>:") || line.endsWith("<.text>:") || line.endsWith("<.itext>:")) {
+                        startIdx++;
+                    }
+                } else if (endAddress && (lineAddr >= endAddress)) {
+                    this.asmLines.splice(startIdx, lineIdx - startIdx - 1);
+                    linesRemoved = true;
+                    break;
+                }
+            }
+
+            lineIdx++;
+        }
+
+        if (!linesRemoved && (startIdx !== -1)) {
+            this.asmLines.splice(startIdx, this.asmLines.length - startIdx);
+        }
+    }
+
+    /**
+     * Replaces an address used in a jmp or call instruction by its label.
+     *  Does not replace an address if it has an offset.
+     * @param {int} lineIdx 
+     * @param {regex} regex 
+     */
+    addAddressAsLabelAndReplaceLine(lineIdx, regex) {
+        const line = this.asmLines[lineIdx];
+        let matches = line.match(regex);
+        if (matches) {
+            const address = matches[3];
+            if (!address.includes('+') && !address.includes('-')) {
+                let labelName = "L" + address;
+                const namedAddr = this.mapFileReader.getSymbolAt(false, parseInt(address, 16));
+                if (namedAddr) {
+                    labelName = namedAddr.displayName;
+                }
+
+                if (!this.dontLabelUnmappedAddresses || namedAddr) {
+                    this.addressesToLabel.push(address);
+
+                    this.asmLines[lineIdx] = line.replace(regex, " " + matches[1] + matches[2] + labelName);
+                }
+            }
+        }
+    }
+
+    /**
+     * Collects addresses that are referred to by the assembly, through jump and call instructions
+     */
+    collectJumpsAndCalls() {
+        for (let lineIdx = 0; lineIdx < this.asmLines.length; lineIdx++) {
+            this.addAddressAsLabelAndReplaceLine(lineIdx, this.jumpRegex);
+            this.addAddressAsLabelAndReplaceLine(lineIdx, this.callRegex);
+        }
+    }
+
+    /**
+     * Injects labels into the assembly where addresses are referred to
+     *  if an address doesn't have a mapped name, it is called <Laddress>
+     */
+    insertLabels() {
+        const sourceFileId = this.mapFileReader.getSegmentIdByUnitName("output");
+
+        let currentSegment = false;
+
+        let lineIdx = 0;
+        while (lineIdx < this.asmLines.length) {
+            const line = this.asmLines[lineIdx];
+
+            const matches = line.match(this.addressRegex);
+            if (matches) {
+                const addressStr = matches[1];
+                const address = parseInt(addressStr, 16);
+
+                const segmentInfo = this.mapFileReader.getSegmentInfoByStartingAddress(false, address);
+                if (segmentInfo) {
+                    currentSegment = segmentInfo;
+                }
+
+                let namedAddr = false;
+                let labelLine = false;
+
+                const isReferenced = this.addressesToLabel.indexOf(addressStr);
+                if (isReferenced !== -1) {
+                    labelLine = matches[1] + " <L" + addressStr + ">:";
+
+                    namedAddr = this.mapFileReader.getSymbolAt(false, address);
+                    if (namedAddr) {
+                        labelLine = matches[1] + " <" + namedAddr.displayName + ">:";
+                    }
+                    
+                    if (!this.dontLabelUnmappedAddresses || namedAddr) {
+                        this.asmLines.splice(lineIdx, 0, labelLine);
+                        lineIdx++;
+                    }
+                } else {
+                    // we might have missed the reference to this address,
+                    //  but if it's listed as a symbol, we should still label it.
+                    // todo: the call might be in <.itext>, should we include that part of the assembly?
+                    namedAddr = this.mapFileReader.getSymbolAt(false, address);
+                    if (namedAddr) {
+                        labelLine = matches[1] + " <" + namedAddr.displayName + ">:";
+
+                        this.asmLines.splice(lineIdx, 0, labelLine);
+                        lineIdx++;
+                    }
+                }
+
+                const lineInfo = this.mapFileReader.getLineInfoByAddress(false, address);
+                if (lineInfo && currentSegment.unitName.startsWith("output")) {
+                    this.asmLines.splice(lineIdx, 0, "/" + sourceFileId + ":" + lineInfo.lineNumber);
+                    lineIdx++;
+                }
+            }
+            
+            lineIdx++;
+        }
+    }
+}
+
+exports.labelReconstructor = PELabelReconstructor;

--- a/lib/pe32-support.js
+++ b/lib/pe32-support.js
@@ -23,8 +23,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 "use strict";
 
-var fs = require('fs');
-
 class PELabelReconstructor {
     /**
      * 
@@ -95,7 +93,8 @@ class PELabelReconstructor {
      * @param {string} unitName 
      */
     deleteEverythingBut(unitName) {
-        // todo: deletion by reconstructed addresses is a VS specific technique, delphi mapping is more precise and doesnt need reconstruction
+        // todo: deletion by reconstructed addresses is a VS specific technique,
+        //  delphi mapping is more precise and doesnt need reconstruction
 
         let unitAddressSpaces = this.mapFileReader.getReconstructedUnitAddressSpace(unitName);
 


### PR DESCRIPTION
Support for Binary mode for MSVC via objdump.

Requirements for binary mode are that the LIB environment variable contains the paths to at least (replace various version numbers):
* C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.14.26428/**lib**/x64
* C:/Program Files (x86)/Windows Kits/10/Lib/10.0.17134.0/**um**/x64
* C:/Program Files (x86)/Windows Kits/10/Lib/10.0.17134.0/**ucrt**/x64

But since it requires the Windows SDK kit, it's not possible (afaik) to run it on the Amazon servers, so I disabled that for now.

So this PR is more of a heads up for @ubsan 

On Windows I have tested this with the objdump.exe from this mingw binary package: https://sourceforge.net/projects/mingw-w64/

Note that it isn't possible to show line colouring, as the VS map file does not export that information.
