### PR TITLE
Bump gcc toolchain to 8.2.0 for clang trunk

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -153,6 +153,7 @@ compiler.clang700.semver=7.0.0
 compiler.clang700.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
 compiler.clang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.clang_trunk.semver=(trunk)
+compiler.clang_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
 compiler.clang_concepts.exe=/opt/compiler-explorer/clang-concepts-trunk/bin/clang++
 compiler.clang_concepts.semver=(experimental concepts)
 compiler.clang_concepts.options=-std=c++2a -Xclang -fconcepts-ts -stdlib=libc++


### PR DESCRIPTION
As suggested by @mgehre - https://github.com/mattgodbolt/compiler-explorer/pull/1090#issuecomment-424933075, this bumps the gcc toolchain version for clang trunk to 8.2.0.
