### PR TITLE
Add defaultCompiler to api/languages, and add api/libraries

### DIFF
--- a/app.js
+++ b/app.js
@@ -293,6 +293,7 @@ aws.initConfig(awsProps)
                     clientOptionsHandler.setCompilers(compilers);
                     apiHandler.setCompilers(compilers);
                     apiHandler.setLanguages(languages);
+                    apiHandler.setOptions(clientOptionsHandler);
                 }
 
                 onCompilerChange(compilers);

--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -35,6 +35,7 @@ class ApiHandler {
         this.compilers = [];
         this.languages = [];
         this.usedLangIds = [];
+        this.options = null;
         this.storageHandler = storageHandler;
         this.handle = express.Router();
         this.handle.use((req, res, next) => {
@@ -45,6 +46,7 @@ class ApiHandler {
         this.handle.get('/compilers', this.handleCompilers.bind(this));
         this.handle.get('/compilers/:language', this.handleCompilers.bind(this));
         this.handle.get('/languages', this.handleLanguages.bind(this));
+        this.handle.get('/libraries/:language', this.handleLibraries.bind(this));
 
         const asmDocsHandler = new AsmDocsApi.Handler();
         this.handle.get('/asm/:opcode', asmDocsHandler.handle.bind(asmDocsHandler));
@@ -84,7 +86,14 @@ class ApiHandler {
     }
 
     handleLanguages(req, res) {
-        const availableLanguages = this.usedLangIds.map(val => this.languages[val]);
+        const availableLanguages = this.usedLangIds.map(val => {
+            let lang = this.languages[val];
+            let newLangObj = Object.assign({}, lang);
+            if (this.options) {
+                newLangObj.defaultCompiler = this.options.options.defaultCompiler[lang.id];
+            }
+            return newLangObj;
+        });
 
         if (req.accepts(['text', 'json']) === 'json') {
             res.set('Content-Type', 'application/json');
@@ -96,6 +105,48 @@ class ApiHandler {
             res.write(utils.padRight(title, maxLength) + ' | Name\n');
             res.end(availableLanguages.map(lang => utils.padRight(lang.id, maxLength) + ' | ' + lang.name)
                 .join("\n"));
+        }
+    }
+
+    handleLibraries(req, res, next) {
+        if (this.options) {
+            if (req.params.language) {
+                res.set('Content-Type', 'application/json');
+                const libsForLanguageObj = this.options.options.libs[req.params.language];
+                if (!libsForLanguageObj) {
+                    res.end(JSON.stringify([]));
+                    return;
+                }
+
+                const libsForLanguageArr = Object.keys(libsForLanguageObj).map((key) => {
+                    const item = libsForLanguageObj[key];
+                    const versionArr = Object.keys(item.versions).map((key) => {
+                        let versionObj = Object.assign({}, item.versions[key]);
+                        versionObj.id = key;
+                        return versionObj;
+                    });
+
+                    return {
+                        id: key,
+                        name: item.name,
+                        description: item.description,
+                        url: item.url,
+                        versions: versionArr
+                    };
+                });
+
+                res.end(JSON.stringify(libsForLanguageArr));
+            } else {
+                next({
+                    statusCode: 404,
+                    message: "Language is required"
+                });
+            }
+        } else {
+            next({
+                statusCode: 500,
+                message: "Internal error"
+            });
         }
     }
 
@@ -126,6 +177,10 @@ class ApiHandler {
 
     setLanguages(languages) {
         this.languages = languages;
+    }
+
+    setOptions(options) {
+        this.options = options;
     }
 }
 

--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -108,33 +108,33 @@ class ApiHandler {
         }
     }
 
+    getLibrariesAsArray(language) {
+        const libsForLanguageObj = this.options.options.libs[language];
+        if (!libsForLanguageObj) return [];
+
+        return Object.keys(libsForLanguageObj).map((key) => {
+            const item = libsForLanguageObj[key];
+            const versionArr = Object.keys(item.versions).map((key) => {
+                let versionObj = Object.assign({}, item.versions[key]);
+                versionObj.id = key;
+                return versionObj;
+            });
+
+            return {
+                id: key,
+                name: item.name,
+                description: item.description,
+                url: item.url,
+                versions: versionArr
+            };
+        });
+    }
+
     handleLibraries(req, res, next) {
         if (this.options) {
             if (req.params.language) {
                 res.set('Content-Type', 'application/json');
-                const libsForLanguageObj = this.options.options.libs[req.params.language];
-                if (!libsForLanguageObj) {
-                    res.end(JSON.stringify([]));
-                    return;
-                }
-
-                const libsForLanguageArr = Object.keys(libsForLanguageObj).map((key) => {
-                    const item = libsForLanguageObj[key];
-                    const versionArr = Object.keys(item.versions).map((key) => {
-                        let versionObj = Object.assign({}, item.versions[key]);
-                        versionObj.id = key;
-                        return versionObj;
-                    });
-
-                    return {
-                        id: key,
-                        name: item.name,
-                        description: item.description,
-                        url: item.url,
-                        versions: versionArr
-                    };
-                });
-
+                const libsForLanguageArr = this.getLibrariesAsArray(req.params.language);
                 res.end(JSON.stringify(libsForLanguageArr));
             } else {
                 next({

--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -108,23 +108,23 @@ class ApiHandler {
         }
     }
 
-    getLibrariesAsArray(language) {
-        const libsForLanguageObj = this.options.options.libs[language];
+    getLibrariesAsArray(languageId) {
+        const libsForLanguageObj = this.options.options.libs[languageId];
         if (!libsForLanguageObj) return [];
 
         return Object.keys(libsForLanguageObj).map((key) => {
-            const item = libsForLanguageObj[key];
-            const versionArr = Object.keys(item.versions).map((key) => {
-                let versionObj = Object.assign({}, item.versions[key]);
+            const language = libsForLanguageObj[key];
+            const versionArr = Object.keys(language.versions).map((key) => {
+                let versionObj = Object.assign({}, language.versions[key]);
                 versionObj.id = key;
                 return versionObj;
             });
 
             return {
                 id: key,
-                name: item.name,
-                description: item.description,
-                url: item.url,
+                name: language.name,
+                description: language.description,
+                url: language.url,
                 versions: versionArr
             };
         });


### PR DESCRIPTION
It hit me that the defaultCompiler was missing from the API calls, so I added it to the /languages call.
I also added a new /api/libraries/:language to fetch the available libraries and version.

One thing that surprised me somewhat is that the library id/version isn't actually sent along with the compilation command, but only -I"include path" is added to the userArguments. Which is fine for C++, but I can imagine things might change once other languages get libraries added as well.

It's something to think about.
