### PR TITLE
Ensure clicking reload forces a recompile on the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,13 @@ To specify a compilation request as a JSON document, post it as the appropriate
     }
 }
 ``` 
+
 The filters are a JSON object with `true`/`false` values. If not supplied,
  defaults are used. If supplied, the filters are used as-is.
  The `compilerOptions` is used to pass extra arguments to the back end, and is
  probably not useful for most REST users.
+
+To force a cache bypass, set `bypassCache` in the root of the request to `true`.
 
 A text compilation request has the source as the body of the post, and uses
  query parameters to pass the options and filters. Filters are supplied as a

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -230,11 +230,12 @@ class BaseCompiler {
     checkOutputFileAndDoPostProcess(asmResult, outputFilename, filters) {
         return this.stat(outputFilename)
             .then(stat => asmResult.asmSize = stat.size)
-            .catch(() => {})
+            .catch(() => {
+            })
             .then(() => this.postProcess(asmResult, outputFilename, filters));
     }
 
-    compile(source, options, backendOptions, filters) {
+    compile(source, options, backendOptions, filters, bypassCache) {
         const optionsError = this.checkOptions(options);
         if (optionsError) return Promise.reject(optionsError);
         const sourceError = this.checkSource(source);
@@ -246,8 +247,8 @@ class BaseCompiler {
         }
 
         const key = {compiler: this.compiler, source, options, backendOptions, filters};
-
-        return this.env.cacheGet(key)
+        const cacheGet = bypassCache ? Promise.resolve(null) : this.env.cacheGet(key);
+        return cacheGet
             .then((result) => {
                 if (result) return result;
 

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -154,12 +154,14 @@ class CompileHandler {
     }
 
     parseRequest(req, compiler) {
-        let source, options, backendOptions, filters;
+        let source, options, backendOptions, filters, bypassCache = false;
         // IF YOU MODIFY ANYTHING HERE PLEASE UPDATE THE DOCUMENTATION!
         if (req.is('json')) {
             // JSON-style request
             const requestOptions = req.body.options;
             source = req.body.source;
+            if (req.body.bypassCache)
+                bypassCache = true;
             options = requestOptions.userArguments;
             backendOptions = requestOptions.compilerOptions;
             filters = requestOptions.filters || compiler.getDefaultFilters();
@@ -186,7 +188,7 @@ class CompileHandler {
             .map(x => typeof(x) === "string" ? x : x.pattern))
             .compact()
             .value();
-        return {source, options, backendOptions, filters};
+        return {source, options, backendOptions, filters, bypassCache};
     }
 
     handle(req, res, next) {
@@ -194,7 +196,7 @@ class CompileHandler {
         if (!compiler) {
             return next();
         }
-        const {source, options, backendOptions, filters} = this.parseRequest(req, compiler);
+        const {source, options, backendOptions, filters, bypassCache} = this.parseRequest(req, compiler);
         const remote = compiler.getRemote();
         if (remote) {
             // Undo any routing that was done to get here (i.e. /api/* path has been removed)
@@ -215,7 +217,7 @@ class CompileHandler {
             return _.pluck(array || [], 'text').join("\n");
         }
 
-        compiler.compile(source, options, backendOptions, filters)
+        compiler.compile(source, options, backendOptions, filters, bypassCache)
             .then(result => {
                 if (req.accepts(['text', 'json']) === 'json') {
                     res.set('Content-Type', 'application/json');

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -399,7 +399,7 @@ Compiler.prototype.getEffectiveFilters = function () {
     return filters;
 };
 
-Compiler.prototype.compile = function () {
+Compiler.prototype.compile = function (bypassCache) {
     if (this.deferCompiles) {
         this.needsCompile = true;
         return;
@@ -434,6 +434,7 @@ Compiler.prototype.compile = function () {
             options: options,
             lang: this.currentLangId
         };
+        if (bypassCache) request.bypassCache = true;
         if (!this.compiler) {
             this.onCompileResponse(request, errorResult('<Please select a compiler>'), false);
         } else {
@@ -950,7 +951,7 @@ Compiler.prototype.initCallbacks = function () {
 
     this.compileClearCache.on('click', _.bind(function () {
         this.compilerService.cache.reset();
-        this.compile();
+        this.compile(true);
     }, this));
 
     // Dismiss the popover on escape.


### PR DESCRIPTION
Recompile even if three's a backend cache too. Will mean we can enable file/s3 caching on the backends.