### PR TITLE
Adding Fortran specific compiler script to enable .mod files.

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -2,6 +2,7 @@ compilers=&gfortran_86
 defaultCompiler=gfortran81
 demangler=/opt/compiler-explorer/gcc-8.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-8.1.0/bin/objdump
+compilerType=fortran
 
 ###############################
 # GCC for x86
@@ -67,5 +68,7 @@ compiler.gfortran73.exe=/opt/compiler-explorer/gcc-7.3.0/bin/gfortran
 compiler.gfortran73.name=x86-64 gfortran 7.3
 compiler.gfortran81.exe=/opt/compiler-explorer/gcc-8.1.0/bin/gfortran
 compiler.gfortran81.name=x86-64 gfortran 8.1
+compiler.gfortran82.exe=/opt/compiler-explorer/gcc-8.2.0/bin/gfortran
+compiler.gfortran82.name=x86-64 gfortran 8.2
 compiler.gfortransnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gfortran
 compiler.gfortransnapshot.name=x86-64 gfortran (trunk)

--- a/etc/config/fortran.defaults.properties
+++ b/etc/config/fortran.defaults.properties
@@ -3,6 +3,7 @@ compilers=&gfortran_86
 defaultCompiler=gfortran
 demangler=c++filt
 objdumper=objdump
+compilerType = fortran
 
 ###############################
 # GCC for x86

--- a/etc/config/fortran.defaults.properties
+++ b/etc/config/fortran.defaults.properties
@@ -3,7 +3,7 @@ compilers=&gfortran_86
 defaultCompiler=gfortran
 demangler=c++filt
 objdumper=objdump
-compilerType = fortran
+compilerType=fortran
 
 ###############################
 # GCC for x86

--- a/lib/compilers/fortran.js
+++ b/lib/compilers/fortran.js
@@ -1,0 +1,46 @@
+// Copyright (c) 2017, Rubén Rincón
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+const BaseCompiler = require('../base-compiler'),
+    path = require('path'),
+    utils = require('../utils');
+
+class FortranCompiler extends BaseCompiler {
+    runCompiler(compiler, options, inputFilename, execOptions) {
+        if (!execOptions) {
+            execOptions = this.getDefaultExecOptions();
+        }
+        // switch working directory of compiler to /tmp/... to be able to generate .mod files
+        execOptions.customCwd = path.dirname(inputFilename);
+
+        return this.exec(compiler, options, execOptions).then(result => {
+            result.inputFilename = inputFilename;
+            result.stdout = utils.parseOutput(result.stdout, inputFilename);
+            result.stderr = utils.parseOutput(result.stderr, inputFilename);
+            return result;
+        });
+    }
+}
+
+module.exports = FortranCompiler;

--- a/lib/compilers/fortran.js
+++ b/lib/compilers/fortran.js
@@ -1,4 +1,5 @@
-// Copyright (c) 2017, Rubén Rincón
+// Copyright (c) 2018, Forschungzentrum Juelich GmbH
+//                     Juelich Supercomputing Centre
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -31,7 +32,8 @@ class FortranCompiler extends BaseCompiler {
         if (!execOptions) {
             execOptions = this.getDefaultExecOptions();
         }
-        // switch working directory of compiler to /tmp/... to be able to generate .mod files
+        // Switch working directory of compiler to temp directory that also holds the source.
+        // This makes it possible to generate .mod files.
         execOptions.customCwd = path.dirname(inputFilename);
 
         return this.exec(compiler, options, execOptions).then(result => {


### PR DESCRIPTION
As suggest by @partouf this adds a compiler specific script for Fortran, moving compilation to the temp directory which holds the source. Doing this will enable the compiler to generate .mod files if needs be. 

This should fix #1123.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
