### PR TITLE
Golang show "Stdout" in output

### DIFF
--- a/lib/compilers/golang.js
+++ b/lib/compilers/golang.js
@@ -23,7 +23,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 const BaseCompiler = require('../base-compiler'),
-    _ = require('underscore');
+    _ = require('underscore'),
+    utils = require('../utils');
 
 class GolangCompiler extends BaseCompiler {
     convertNewGoL(code) {
@@ -59,9 +60,17 @@ class GolangCompiler extends BaseCompiler {
         })).join("\n");
     }
 
+    extractLogging(stdout) {
+        const reLogging = /^\/(.*):([0-9]*):([0-9]*):\s(.*)/i;
+        return stdout.filter(obj => obj.text.match(reLogging)).
+            map(obj => obj.text).
+            join('\n');
+    }
+
     postProcess(result) {
+        const logging = this.extractLogging(result.stdout);
         result.asm = this.convertNewGoL(result.stdout);
-        result.stdout = [];
+        result.stdout = utils.parseOutput(logging, result.inputFilename);
         return Promise.resolve(result);
     }
 

--- a/lib/compilers/golang.js
+++ b/lib/compilers/golang.js
@@ -61,7 +61,7 @@ class GolangCompiler extends BaseCompiler {
     }
 
     extractLogging(stdout) {
-        const reLogging = /^\/(.*):([0-9]*):([0-9]*):\s(.*)/i;
+        const reLogging = /^<source>:([0-9]*):([0-9]*):\s(.*)/i;
         return stdout.filter(obj => obj.text.match(reLogging)).
             map(obj => obj.text).
             join('\n');


### PR DESCRIPTION
Related to https://github.com/mattgodbolt/compiler-explorer/issues/1142

With this change you can set the GL GO arguments to -m -l, and the escape analysis will show up in the output window.

It was previously filtered out.
