### PR TITLE
Add pahole as compiler tool

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -656,7 +656,7 @@ libs.cnl.versions.trunk.path=/opt/compiler-explorer/libs/cnl/include
 #################################
 # Installed tools
 
-tools=clangtidytrunk:llvm-mcatrunk
+tools=clangtidytrunk:llvm-mcatrunk:pahole
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
 tools.clangtidytrunk.name=clang-tidy
@@ -670,3 +670,8 @@ tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
 tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new
+
+tools.pahole.name=pahole
+tools.pahole.exe=/opt/compiler-explorer/pahole/bin/pahole
+tools.pahole.type=postcompilation
+tools.pahole.class=pahole-tool

--- a/lib/tooling/pahole-tool.js
+++ b/lib/tooling/pahole-tool.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2018, Compiler Explorer Team
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+const
+    BaseTool = require('./base-tool'),
+    fs = require('fs-extra');
+
+class PaholeTool extends BaseTool {
+    constructor(toolInfo, env) {
+        super(toolInfo, env);
+    }
+
+    runTool(sourcefile, args, compilerExe, outputFilename, options, filters, asm) {
+        if(!filters.binary)
+        {
+            // Pahole needs a compiled file in order to process it
+            var compiledFile = outputFilename.replace("output.s", "output.o");
+            var compilerOptions = [
+                "-c",
+                outputFilename,
+                "-o",
+                compiledFile,
+            ];
+            console.log(compilerOptions);
+            this.exec(compilerExe, compilerOptions);
+            return super.runTool(compiledFile, args)
+        }
+        return super.runTool(outputFilename, args);
+    }
+}
+
+module.exports = PaholeTool;

--- a/lib/tooling/pahole-tool.js
+++ b/lib/tooling/pahole-tool.js
@@ -42,8 +42,9 @@ class PaholeTool extends BaseTool {
                 "-o",
                 compiledFile,
             ];
-            this.exec(compilerExe, compilerOptions);
-            return super.runTool(compiledFile, args);
+            this.exec(compilerExe, compilerOptions).then(result => {
+                return super.runTool(compiledFile, args);
+            });
         }
         return super.runTool(outputFilename, args);
     }

--- a/lib/tooling/pahole-tool.js
+++ b/lib/tooling/pahole-tool.js
@@ -24,6 +24,7 @@
 "use strict";
 
 const
+    utils = require('../utils'),
     BaseTool = require('./base-tool');
 
 class PaholeTool extends BaseTool {
@@ -34,17 +35,12 @@ class PaholeTool extends BaseTool {
     runTool(sourcefile, args, compilerExe, outputFilename, option, filters) {
         if(!filters.binary)
         {
-            // Pahole needs a compiled file in order to process it
-            var compiledFile = outputFilename.replace("output.s", "output.o");
-            var compilerOptions = [
-                "-c",
-                outputFilename,
-                "-o",
-                compiledFile,
-            ];
-            this.exec(compilerExe, compilerOptions).then(result => {
-                return super.runTool(compiledFile, args);
-            });
+            return {
+                id: this.tool.id,
+                name: this.tool.name,
+                code: 0,
+                stdout: utils.parseOutput("Pahole requires a binary output")
+            };
         }
         return super.runTool(outputFilename, args);
     }

--- a/lib/tooling/pahole-tool.js
+++ b/lib/tooling/pahole-tool.js
@@ -24,15 +24,14 @@
 "use strict";
 
 const
-    BaseTool = require('./base-tool'),
-    fs = require('fs-extra');
+    BaseTool = require('./base-tool');
 
 class PaholeTool extends BaseTool {
     constructor(toolInfo, env) {
         super(toolInfo, env);
     }
 
-    runTool(sourcefile, args, compilerExe, outputFilename, options, filters, asm) {
+    runTool(sourcefile, args, compilerExe, outputFilename, option, filters) {
         if(!filters.binary)
         {
             // Pahole needs a compiled file in order to process it
@@ -43,9 +42,8 @@ class PaholeTool extends BaseTool {
                 "-o",
                 compiledFile,
             ];
-            console.log(compilerOptions);
             this.exec(compilerExe, compilerOptions);
-            return super.runTool(compiledFile, args)
+            return super.runTool(compiledFile, args);
         }
         return super.runTool(outputFilename, args);
     }

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -690,6 +690,8 @@ Compiler.prototype.onToolOpened = function (compilerId, toolSettings) {
             this.clangtidyToolButton.prop('disabled', true);
         } else if (toolId === "llvm-mcatrunk") {
             this.llvmmcaToolButton.prop('disabled', true);
+        } else if (toolId === "pahole") {
+            this.paholeToolButton.prop('disabled', true);
         }
 
         this.compile(false, toolSettings);
@@ -703,6 +705,8 @@ Compiler.prototype.onToolClosed = function (compilerId, toolSettings) {
             this.clangtidyToolButton.prop('disabled', !this.supportsTool(toolId));
         } else if (toolId === "llvm-mcatrunk") {
             this.llvmmcaToolButton.prop('disabled', !this.supportsTool(toolId));
+        } else if (toolId === "pahole") {
+            this.paholeToolButton.prop('disabled', !this.supportsTool(toolId));
         }
     }
 };
@@ -930,9 +934,11 @@ Compiler.prototype.initToolButton = function (togglePannerAdder, button, toolId)
 Compiler.prototype.initToolButtons = function (togglePannerAdder) {
     this.clangtidyToolButton = this.domRoot.find('.view-clangtidytool');
     this.llvmmcaToolButton = this.domRoot.find('.view-llvmmcatool');
+    this.paholeToolButton = this.domRoot.find('.view-pahole');
 
     this.initToolButton(togglePannerAdder, this.clangtidyToolButton, "clangtidytrunk");
     this.initToolButton(togglePannerAdder, this.llvmmcaToolButton, "llvm-mcatrunk");
+    this.initToolButton(togglePannerAdder, this.paholeToolButton, "pahole");
 };
 
 Compiler.prototype.updateButtons = function () {
@@ -978,6 +984,8 @@ Compiler.prototype.updateButtons = function () {
         !(this.supportsTool("clangtidytrunk") && !this.isToolActive(activeTools, "clangtidytrunk")));
     this.llvmmcaToolButton.prop('disabled',
         !(this.supportsTool("llvm-mcatrunk") && !this.isToolActive(activeTools, "llvm-mcatrunk")));
+    this.paholeToolButton.prop('disabled',
+        !(this.supportsTool("pahole") && !this.isToolActive(activeTools, "pahole")));
 };
 
 Compiler.prototype.onFontScale = function () {

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -126,6 +126,9 @@
           button.dropdown-item.btn.btn-light.btn-sm.view-llvmmcatool(title="LLVM MCA")
             span.fas.fa-cog
             | &nbsp;LLVM MCA
+          button.dropdown-item.btn.btn-light.btn-sm.view-pahole(title="Pahole")
+            span.fas.fa-cog
+            | &nbsp;Pahole
     .monaco-placeholder
     .bottom-bar.bg-light
       if !embedded


### PR DESCRIPTION
This PR adds the great [Pahole](https://linux.die.net/man/1/pahole) tool, a tool that shows the layout of data structures inside elf files, to Compiler Explorer as a compiler tool.

![image](https://user-images.githubusercontent.com/5001005/48389551-52b74d80-e6d4-11e8-8dbd-45742dee0d49.png)

Depends on [compiler-explorer-image PR 138](https://github.com/mattgodbolt/compiler-explorer-image/pull/138)