### PR TITLE
Add fortran cross compilers and powerpc64{,le} gfortran

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gfortran_86:&ifort
+compilers=&gfortran_86:&ifort:&cross
 defaultCompiler=gfortran82
 demangler=/opt/compiler-explorer/gcc-8.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-8.1.0/bin/objdump
@@ -88,6 +88,24 @@ compiler.ifort18.exe=/opt/compiler-explorer/intel-2018.0.033/bin/ifort
 compiler.ifort18.semver=18.0.0
 compiler.ifort19.exe=/opt/compiler-explorer/intel-2019/bin/ifort
 compiler.ifort19.semver=19.0.0
+
+###############################
+# Cross Fortran
+group.cross.compilers=&ppc
+group.cross.supportsBinary=false
+group.cross.groupName=Cross Fortran
+
+###############################
+# GCC for PPC
+group.ppc.compilers=ppc64leg8:ppc64g8
+group.ppc.groupName=POWER Compilers
+group.ppc.isSemVer=true
+compiler.ppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gfortran
+compiler.ppc64leg8.name=power64le Advance Toolchain 12.0 (gcc branch ibm/gcc-8-branch)
+compiler.ppc64leg8.semver=(snapshot)
+compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
+compiler.ppc64g8.name=power64 Advance Toolchain 12.0 (gcc branch ibm/gcc-8-branch)
+compiler.ppc64g8.semver=(snapshot)
 
 #################################
 #################################


### PR DESCRIPTION
passes `make check`.

As requested by @dbroemmel 