### PR TITLE
Add POWER AT12.0 and clang compilers for C based off existing crossbuild-ng

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -66,3 +66,4 @@ From oldest to newest contributor, we would like to thank:
 - [Erik Little](https://github.com/nuclearace)
 - [Jülich Supercomputing Centre](https://github.com/FZJ-JSC)
 - [Niall Douglas](https://github.com/ned14)
+- [Daniel Black](https://github.com/grooverdan)

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -179,9 +179,21 @@ group.ccross.groupName=Cross GCC
 
 ###############################
 # GCC for PPC
-group.cppc.compilers=cppcg48:cppc64leg630
-group.cppc.groupName=PowerPC GCC
+group.cppc.compilers=cppcg48:cppc64leg630:cppc64leg8:cppc64g8:cppc64clang:cppc64leclang
+group.cppc.groupName=POWER Compilers
 group.cppc.isSemVer=true
+compiler.ppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-gcc
+compiler.ppc64leg8.name=power64le AT12.0 (gcc8)
+compiler.ppc64leg8.semver=(snapshot)
+compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gcc
+compiler.ppc64g8.name=power64 AT12.0 (gcc8)
+compiler.ppc64g8.semver=(snapshot)
+compiler.ppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.ppc64clang.name=powerpc64 clang (trunk)
+compiler.ppc64clang.options=-target powerpc64
+compiler.ppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang
+compiler.ppc64leclang.name=power64le clang (trunk)
+compiler.ppc64leclang.options=-target powerpc64le
 compiler.ppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-gcc
 compiler.ppcg48.name=PowerPC gcc 4.8.5
 compiler.ppcg48.semver=4.8.5


### PR DESCRIPTION
Using AT12.0 and clang in C language too since we have it compiled.

Thanks @mattgodbolt.
