### PR TITLE
Enable cfg for x86 LLVM based compilers and gcc.

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -493,7 +493,8 @@ class BaseCompiler {
                         .then(result => filters.demangle ? this.postProcessAsm(result, filters) : result)
                         .then(result => {
                             if (this.compiler.supportsCfg && backendOptions && backendOptions.produceCfg) {
-                                result.cfg = cfg.generateStructure(this.compiler.version, result.asm);
+                                result.cfg = cfg.generateStructure(this.compiler.compilerType,
+                                    this.compiler.version, result.asm);
                             }
                             return result;
                         })
@@ -566,6 +567,7 @@ class BaseCompiler {
     isCfgCompiler(compilerVersion) {
         return compilerVersion.includes("clang") ||
             compilerVersion.indexOf("g++") === 0 ||
+            compilerVersion.indexOf("gcc") === 0 ||
             compilerVersion.indexOf("gdc") === 0;
     }
 

--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -273,9 +273,17 @@ function makeEdges(asmArr, arrOfCanonicalBasicBlock, rules) {
     return edges;
 }
 
+function isLLVMBased(compilerType, version) {
+    return version.includes('clang') ||
+        version.includes('LLVM') ||
+        version.includes('rustc') ||
+        compilerType === 'swift' ||
+        compilerType === 'zig' ||
+        compilerType === 'ispc';
+}
 
-function generateCfgStructure(version, asmArr) {
-    const rules = (version.includes('clang') || version.includes('LLVM')) ? clangX86 : gccX86;
+function generateCfgStructure(compilerType, version, asmArr) {
+    const rules = isLLVMBased(compilerType, version) ? clangX86 : gccX86;
     const code = rules.filterData(asmArr);
     const funcs = splitToFunctions(code, rules.isFunctionEnd);
     if (!funcs.length) {

--- a/lib/compilers/ispc.js
+++ b/lib/compilers/ispc.js
@@ -28,6 +28,10 @@ class ISPCCompiler extends BaseCompiler {
     optionsForFilter(filters, outputFilename) {
         return ['--target=sse2-i32x4', '--emit-asm', '-g', '-o', this.filename(outputFilename)];
     }
+
+    isCfgCompiler(/*compilerVersion*/) {
+        return true;
+    }
 }
 
 module.exports = ISPCCompiler;

--- a/lib/compilers/rust.js
+++ b/lib/compilers/rust.js
@@ -45,6 +45,10 @@ class RustCompiler extends BaseCompiler {
         options = options.concat(['--crate-type', 'rlib']);
         return options;
     }
+
+    isCfgCompiler(/*compilerVersion*/) {
+        return true;
+    }
 }
 
 module.exports = RustCompiler;

--- a/lib/compilers/swift.js
+++ b/lib/compilers/swift.js
@@ -25,6 +25,9 @@
 const BaseCompiler = require('../base-compiler');
 
 class SwiftCompiler extends BaseCompiler {
+    isCfgCompiler(/*compilerVersion*/) {
+        return true;
+    }
 }
 
 module.exports = SwiftCompiler;

--- a/lib/compilers/zig.js
+++ b/lib/compilers/zig.js
@@ -84,6 +84,10 @@ class ZigCompiler extends BaseCompiler {
         const blacklist = /^(((--(cache-dir|name|output|verbose))|(-mllvm)).*)$/;
         return _.filter(userOptions, option => !blacklist.test(option));
     }
+
+    isCfgCompiler(/*compilerVersion*/) {
+        return true;
+    }
 }
 
 module.exports = ZigCompiler;

--- a/test/cfg-tests.js
+++ b/test/cfg-tests.js
@@ -38,7 +38,7 @@ function common(cases, filterArg, cfgArg) {
             const file = fs.readFileSync(filename, 'utf-8');
             if (file) {
                 const contents = JSON.parse(file);
-                assert.deepEqual(cfg.generateStructure(cfgArg, contents.asm), contents.cfg, `${filename}`);
+                assert.deepEqual(cfg.generateStructure('', cfgArg, contents.asm), contents.cfg, `${filename}`);
             }
         });
 }


### PR DESCRIPTION
Code for handling clang should more or less work with other LLVM based compilers like rust,swift, zig. 

Locally verified that it works with rust and zig. For swift and ispc was able to only check the asm output in compiler explorer due to compiler installation being more difficult.

Also enabled cfg for gcc, it should work the same as g++.