### PR TITLE
Support DJGGP compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&clang:&rvclang:&cl:&cross:&ellcc:&zapcc:www.godbolt.ms@443
+compilers=&gcc86:&icc:&clang:&rvclang:&cl:&cross:&ellcc:&zapcc:www.godbolt.ms@443:&djggp
 defaultCompiler=g82
 demangler=/opt/compiler-explorer/gcc-8.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-8.2.0/bin/objdump
@@ -431,6 +431,24 @@ compiler.ellcc0134.alias=elcc0134
 
 
 #################################
+# DJGGP
+group.djggp.compilers=djggp494:djggp550:djggp640:djggp720
+group.djggp.groupName=DJGGP x86
+group.djggp.baseName=x86 djggp
+group.djggp.isSemVer=true
+group.djggp.demangler=
+group.djggp.supportsBinary=false
+compiler.djggp720.exe=/opt/compiler-explorer/djgpp-7.2.0/bin/i586-pc-msdosdjgpp-g++
+compiler.djggp720.semver=7.2.0
+compiler.djggp640.exe=/opt/compiler-explorer/djgpp-6.4.0/bin/i586-pc-msdosdjgpp-g++
+compiler.djggp640.semver=6.4.0
+compiler.djggp550.exe=/opt/compiler-explorer/djgpp-5.5.0/bin/i586-pc-msdosdjgpp-g++
+compiler.djggp550.semver=5.5.0
+compiler.djggp494.exe=/opt/compiler-explorer/djgpp-4.9.4/bin/i586-pc-msdosdjgpp-g++
+compiler.djggp494.semver=4.9.4
+
+
+#################################
 #################################
 # Installed libs
 libs=boost:brigand:kvasir:cmcstl2:ctbignum:gsl:expected_lite:nlohmann_json:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest
@@ -723,9 +741,10 @@ tools.llvm-mcatrunk.name=llvm-mca
 tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
 tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
-tools.llvm-mcatrunk.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new
+tools.llvm-mcatrunk.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new:djggp
 
 tools.pahole.name=pahole
 tools.pahole.exe=/opt/compiler-explorer/pahole/bin/pahole
 tools.pahole.type=postcompilation
 tools.pahole.class=pahole-tool
+tools.pahole.exclude=djggp


### PR DESCRIPTION
Closes #844

Seems to be GCC compatible, so it was pretty easy to add.
Haven't done binary support, so I have disabled that for now. (so including pahole)

I disabled MCA because it outputs 32bits asm (though it did work sometimes)
