### PR TITLE
[WIP] Filter non function symbols in CFG based on section.

### DIFF
--- a/lib/cfg.js
+++ b/lib/cfg.js
@@ -31,13 +31,46 @@ const InstructionType_notRetInst = 2;
 const InstructionType_retInst = 3;
 
 // deal with typeinfo name for, typeinfo for, vtable for
-const isFunctionName = x => x.text.trim().indexOf('.') !== 0 && !x.text.includes(' for ');
+const isFunctionName = x => x.text.trim().indexOf('.') !== 0;
+
+function getAsmDirective(txt) {
+    const pattern = /^\s*(\.[^L ]\S*)/;
+    const match = txt.match(pattern);
+    if (match !== null) {
+        return match[1];
+    }
+    return null;
+}
+
+function filterTextSection(data) {
+    var useCurrentSection = true;
+    var result = [];
+    for (var i in data) {
+        var x = data[i];
+        var directive = getAsmDirective(x.text);
+        if (directive != null) {
+            if (directive === ".text" || directive === ".data") {
+                useCurrentSection = directive === ".text";
+            } else if (directive === ".section") {
+                // Only patttern match for now.
+                // Extracting section name would require adjusting demangling code
+                // as demangled name could contain various symbols including ','.
+                useCurrentSection = /\.section\s*"?\.text/.test(x.text);
+            } else if (useCurrentSection) {
+                result.push(x);
+            }
+        } else if (useCurrentSection) {
+            result.push(x);
+        }
+    }
+    return result;
+}
 
 const gccX86 = {
     filterData: asmArr => {
         const jmpLabelRegex = /\.L\d+:/;
         const isCode = x => x && x.text && (x.source !== null || jmpLabelRegex.test(x.text) || isFunctionName(x));
-        return _.chain(asmArr)
+        return _.chain(filterTextSection(asmArr))
             .map(_.clone)
             .filter(isCode)
             .value();
@@ -70,7 +103,7 @@ const clangX86 = {
             return x;
         };
 
-        return _.chain(asmArr)
+        return _.chain(filterTextSection(asmArr))
             .map(_.clone)
             .filter(isCode)
             .map(removeComments)


### PR DESCRIPTION
Fixes #1249.

Should help with rust and swift code which often contain " for " in demangled function names. This could also help with some instances of "attempt to create duplicate ID" #926.