### PR TITLE
OCaml: add compiler flag preventing binary creation

### DIFF
--- a/lib/compilers/ocaml.js
+++ b/lib/compilers/ocaml.js
@@ -29,7 +29,7 @@ const BaseCompiler = require('../base-compiler'),
 
 class OCamlCompiler extends BaseCompiler {
     optionsForFilter() {
-        return ['-S', '-g'];
+        return ['-S', '-g', '-c'];
     }
 
     getOutputFilename(dirPath) {


### PR DESCRIPTION
This should fix the linking error during the compilation.