### PR TITLE
Prevent clang from creating unwanted temporary files

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -68,3 +68,4 @@ From oldest to newest contributor, we would like to thank:
 - [Niall Douglas](https://github.com/ned14)
 - [Daniel Black](https://github.com/grooverdan)
 - [Gennadiy Civil](https://github.com/gennadiycivil)
+- [Paul Scharnofske](https://github.com/asynts)

--- a/lib/compilers/argument-parsers.js
+++ b/lib/compilers/argument-parsers.js
@@ -118,9 +118,13 @@ class ClangParser extends BaseParser {
                 compiler.compiler.optArg = "-fsave-optimization-record";
                 compiler.compiler.supportsOptOutput = true;
             }
-            if (BaseParser.hasSupport(options, '-fcolor-diagnostics')) {
+            if (BaseParser.hasSupport(options, "-fcolor-diagnostics")) {
                 if (compiler.compiler.options) compiler.compiler.options += " ";
                 compiler.compiler.options += "-fcolor-diagnostics";
+            }
+            if (BaseParser.hasSupport(options, "-fno-crash-diagnostics")) {
+                if (compiler.compiler.options) compiler.compiler.options += " ";
+                compiler.compiler.options += "-fno-crash-diagnostics";
             }
             return compiler;
         });

--- a/test/compilers/argument-parsers-tests.js
+++ b/test/compilers/argument-parsers-tests.js
@@ -111,30 +111,15 @@ describe('clang parser', () => {
         });
     });
     it('should handle options', () => {
-        return parsers.Clang.parse(makeCompiler("-fsave-optimization-record\n-fcolor-diagnostics"))
+        return parsers.Clang.parse(makeCompiler("-fno-crash-diagnostics\n-fsave-optimization-record\n-fcolor-diagnostics"))
             .should.eventually.satisfy(result => {
                 return Promise.all([
                     result.compiler.supportsOptOutput.should.equals(true),
                     result.compiler.optArg.should.equals('-fsave-optimization-record'),
-                    result.compiler.options.should.equals('-fcolor-diagnostics')
-                ]);
-            });
-    });
-    it("should add '-fno-crash-diagnostics' and '-fcolor-diagnostics' when supported", () => {
-        const compiler = new FakeCompiler({});
-        compiler.possibleArguments = new CompilerArguments("fake");
-        compiler.exec = () => Promise.resolve({
-          code: 0,
-          stdout: "-O3\n-fno-crash-diagnostics\n-Wall\n",
-          stderr: ""
-        });
 
-        return parsers.Clang.parse(compiler)
-            .should.eventually.satisfy(result => {
-                return Promise.all([
-                    result.compiler.options.includes("-fno-crash-diagnostics").should.be.true,
-                    result.compiler.options.includes("-fcolor-diagnostics").should.be.false,
-                    result.compiler.options.includes("-Wall").should.be.false,
+                    result.compiler.options.should.include("-fcolor-diagnostics"),
+                    result.compiler.options.should.include("-fno-crash-diagnostics"),
+                    result.compiler.options.should.not.include("-fsave-optimization-record"),
                 ]);
             });
     });

--- a/test/compilers/argument-parsers-tests.js
+++ b/test/compilers/argument-parsers-tests.js
@@ -120,7 +120,7 @@ describe('clang parser', () => {
                 ]);
             });
     });
-    it("should add -fno-crash-diagnostics if supported", () => {
+    it("should add '-fno-crash-diagnostics' and '-fcolor-diagnostics' when supported", () => {
         const compiler = new FakeCompiler({});
         compiler.possibleArguments = new CompilerArguments("fake");
         compiler.exec = () => Promise.resolve({

--- a/test/compilers/argument-parsers-tests.js
+++ b/test/compilers/argument-parsers-tests.js
@@ -120,6 +120,24 @@ describe('clang parser', () => {
                 ]);
             });
     });
+    it("should add -fno-crash-diagnostics if supported", () => {
+        const compiler = new FakeCompiler({});
+        compiler.possibleArguments = new CompilerArguments("fake");
+        compiler.exec = () => Promise.resolve({
+          code: 0,
+          stdout: "-O3\n-fno-crash-diagnostics\n-Wall\n",
+          stderr: ""
+        });
+
+        return parsers.Clang.parse(compiler)
+            .should.eventually.satisfy(result => {
+                return Promise.all([
+                    result.compiler.options.includes("-fno-crash-diagnostics").should.be.true,
+                    result.compiler.options.includes("-fcolor-diagnostics").should.be.false,
+                    result.compiler.options.includes("-Wall").should.be.false,
+                ]);
+            });
+    });
 });
 
 describe('popular compiler arguments', () => {


### PR DESCRIPTION
Fixing #1273.

All compilers featured on https://godbolt.org support the command line option `-fno-crash-diagnostics` *except 3.0.0*.

### Note:

- There are a few compilers with "clang" in the name that I couldn't place, I left those untouched.
- I couldn't test the setup because I don't have all compilers installed on my machine.