### PR TITLE
Add option to toggle the availability of short links

### DIFF
--- a/app.js
+++ b/app.js
@@ -168,6 +168,7 @@ const compilerProps = new props.CompilerProps(languages, ceProps);
 const staticMaxAgeSecs = ceProps('staticMaxAgeSecs', 0);
 const maxUploadSize = ceProps('maxUploadSize', '1mb');
 const extraBodyClass = ceProps('extraBodyClass', '');
+const enableShort = ceProps('enableShort', true);
 const httpRoot = ceProps('httpRoot', '/');
 const httpRootDir = httpRoot.endsWith('/') ? httpRoot : (httpRoot + '/');
 
@@ -366,6 +367,7 @@ aws.initConfig(awsProps)
                     options.extraBodyClass = extraBodyClass;
                     options.httpRoot = httpRoot;
                     options.httpRootDir = httpRootDir;
+                    options.enableShort = enableShort;
                     options.require = function (path) {
                         if (isDevMode()) {
                             if (fs.existsSync('static/assets/' + path)) {
@@ -601,10 +603,14 @@ aws.initConfig(awsProps)
                     .use('/source', sourceHandler.handle.bind(sourceHandler))
                     .use('/api', apiHandler.handle)
                     .use('/g', oldGoogleUrlHandler)
-                    .get('/z/:id', storedStateHandler)
                     .get('/resetlayout/:id', storedStateHandlerResetLayout)
-                    .get('/clientstate/:clientstatebase64', unstoredStateHandler)
-                    .post('/shortener', storageHandler.handler.bind(storageHandler));
+                    .get('/clientstate/:clientstatebase64', unstoredStateHandler);
+
+                if (enableShort) {
+                    router
+                        .get('/z/:id', storedStateHandler)
+                        .post('/shortener', storageHandler.handler.bind(storageHandler));
+                }
                 if (!defArgs.doCache) {
                     logger.info("  with disabled caching");
                 }

--- a/app.js
+++ b/app.js
@@ -168,7 +168,7 @@ const compilerProps = new props.CompilerProps(languages, ceProps);
 const staticMaxAgeSecs = ceProps('staticMaxAgeSecs', 0);
 const maxUploadSize = ceProps('maxUploadSize', '1mb');
 const extraBodyClass = ceProps('extraBodyClass', '');
-const enableShort = ceProps('enableShort', true);
+const storageSolution = compilerProps.ceProps('storageSolution', 'local');
 const httpRoot = ceProps('httpRoot', '/');
 const httpRootDir = httpRoot.endsWith('/') ? httpRoot : (httpRoot + '/');
 
@@ -367,7 +367,7 @@ aws.initConfig(awsProps)
                     options.extraBodyClass = extraBodyClass;
                     options.httpRoot = httpRoot;
                     options.httpRootDir = httpRootDir;
-                    options.enableShort = enableShort;
+                    options.storageSolution = storageSolution;
                     options.require = function (path) {
                         if (isDevMode()) {
                             if (fs.existsSync('static/assets/' + path)) {
@@ -603,14 +603,11 @@ aws.initConfig(awsProps)
                     .use('/source', sourceHandler.handle.bind(sourceHandler))
                     .use('/api', apiHandler.handle)
                     .use('/g', oldGoogleUrlHandler)
+                    .get('/z/:id', storedStateHandler)
                     .get('/resetlayout/:id', storedStateHandlerResetLayout)
-                    .get('/clientstate/:clientstatebase64', unstoredStateHandler);
+                    .get('/clientstate/:clientstatebase64', unstoredStateHandler)
+                    .post('/shortener', storageHandler.handler.bind(storageHandler));
 
-                if (enableShort) {
-                    router
-                        .get('/z/:id', storedStateHandler)
-                        .post('/shortener', storageHandler.handler.bind(storageHandler));
-                }
                 if (!defArgs.doCache) {
                     logger.info("  with disabled caching");
                 }

--- a/lib/storage/storage-null.js
+++ b/lib/storage/storage-null.js
@@ -9,7 +9,7 @@ class StorageNull extends StorageBase {
         return Promise.resolve(item);
     }
 
-    findUniqueSubhash(hash) {
+    findUniqueSubhash() {
         return Promise.resolve({
             prefix: "null",
             uniqueSubHash: "null",
@@ -17,14 +17,14 @@ class StorageNull extends StorageBase {
         });
     }
 
-    expandId(id) {
+    expandId() {
         return Promise.resolve({
             config: "{}",
             specialMetadata: null
         });
     }
 
-    incrementViewCount(id) {
+    incrementViewCount() {
         return Promise.resolve();
     }
 }

--- a/lib/storage/storage-null.js
+++ b/lib/storage/storage-null.js
@@ -1,0 +1,31 @@
+const StorageBase = require('./storage').StorageBase;
+
+class StorageNull extends StorageBase {
+    constructor(compilerProps) {
+        super(compilerProps);
+    }
+
+    storeItem(item) {
+        return Promise.resolve(item);
+    }
+
+    findUniqueSubhash(hash) {
+        return Promise.resolve({
+            prefix: "null",
+            uniqueSubHash: "null",
+            alreadyPresent: true
+        });
+    }
+
+    expandId(id) {
+        return Promise.resolve({
+            config: "{}",
+            specialMetadata: null
+        });
+    }
+
+    incrementViewCount(id) {
+        return Promise.resolve();
+    }
+}
+module.exports = StorageNull;

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -9,7 +9,7 @@
                 button.btn.btn-outline-secondary.btn-sm.dropdown-toggle(data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false")
                   span.current Short
                 ul.dropdown-menu.sources
-                  if storageSolution != "null"
+                  if storageSolution !== "null"
                       button.dropdown-item.btn.btn-light.btn-sm(data-bind="Short")
                         | Short
                   button.dropdown-item.btn.btn-light.btn-sm(data-bind="Full")

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -9,8 +9,9 @@
                 button.btn.btn-outline-secondary.btn-sm.dropdown-toggle(data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false")
                   span.current Short
                 ul.dropdown-menu.sources
-                  button.dropdown-item.btn.btn-light.btn-sm(data-bind="Short")
-                    | Short
+                  if enableShort
+                      button.dropdown-item.btn.btn-light.btn-sm(data-bind="Short")
+                        | Short
                   button.dropdown-item.btn.btn-light.btn-sm(data-bind="Full")
                     | Full
                   button.dropdown-item.btn.btn-light.btn-sm(data-bind="Embed")

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -9,7 +9,7 @@
                 button.btn.btn-outline-secondary.btn-sm.dropdown-toggle(data-toggle="dropdown" type="button" aria-haspopup="true" aria-expanded="false")
                   span.current Short
                 ul.dropdown-menu.sources
-                  if enableShort
+                  if storageSolution != "null"
                       button.dropdown-item.btn.btn-light.btn-sm(data-bind="Short")
                         | Short
                   button.dropdown-item.btn.btn-light.btn-sm(data-bind="Full")


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->

This simply adds an `enableShort` option that enables/disables short links. The motivation behind this is that short links seem to be the only state feature, and disabling those will make compiler explorer stateless and very much possible to distribute across several machines, such as using Kubernetes.