### PR TITLE
Change the check for cfg-able compilers

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@ From oldest to newest contributor, we would like to thank:
 - [Brian Cain](https://github.com/androm3da)
 - [Alexander Monakov](https://github.com/amonakov)
 - [David Nadlinger](https://github.com/klickverbot)
+- [Marc Poulhiès](https://github.com/dkm)
 - [Carlos van Rooijen](https://github.com/CvRXX)
 - [Kaartic Sivaraam](https://github.com/sivaraam)
 - [Lilian A. Moraru](https://github.com/lilianmoraru)

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -610,9 +610,8 @@ class BaseCompiler {
 
     isCfgCompiler(compilerVersion) {
         return compilerVersion.includes("clang") ||
-            compilerVersion.indexOf("g++") === 0 ||
-            compilerVersion.indexOf("gcc") === 0 ||
-            compilerVersion.indexOf("gdc") === 0;
+            compilerVersion.match(/^([\w-]*-)?g((\+\+)|(cc)|(dc))/g) !== null;
+
     }
 
     processAstOutput(output) {

--- a/test/base-compiler-tests.js
+++ b/test/base-compiler-tests.js
@@ -64,6 +64,10 @@ describe('Basic compiler invariants', function () {
         compiler.isCfgCompiler("g++ (GCC-Explorer-Build) 8.0.1 20180223 (experimental)").should.equal(true);
         compiler.isCfgCompiler("g++ (GCC) 4.1.2").should.equal(true);
 
+        compiler.isCfgCompiler("foo-bar-g++ (GCC-Explorer-Build) 4.9.4").should.equal(true);
+        compiler.isCfgCompiler("foo-bar-gcc (GCC-Explorer-Build) 4.9.4").should.equal(true);
+        compiler.isCfgCompiler("foo-bar-gdc (GCC-Explorer-Build) 4.9.4").should.equal(true);
+
         compiler.isCfgCompiler("fake-for-test (Based on g++)").should.equal(false);
 
         compiler.isCfgCompiler("gdc (crosstool-NG 203be35 - 20160205-2.066.1-e95a735b97) 5.2.0").should.equal(true);


### PR DESCRIPTION
This allows cfg to work even for cross gcc (with names like `foo-bar-gcc`).
+ I'm adding my name in the contributors :)