### PR TITLE
WIP for generic doc

### DIFF
--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -158,6 +158,7 @@ class CompilerFinder {
         const isSemVer = props("isSemVer", false);
         const baseName = props("baseName", null);
         const semverVer = props("semver", "");
+	const docname = props("docname", null);
         const name = props("name", compilerName);
         const envVars = (() => {
             let envVarsString = props("envVars", "");
@@ -177,6 +178,7 @@ class CompilerFinder {
             exe: props("exe", compilerName),
             name: isSemVer && baseName ? `${baseName} ${semverVer}` : name,
             alias: props("alias"),
+	    docname: docname,
             options: props("options"),
             versionFlag: props("versionFlag"),
             versionRe: props("versionRe"),

--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -50,7 +50,7 @@ class ApiHandler {
         this.handle.get('/libraries', this.handleAllLibraries.bind(this));
 
         const asmDocsHandler = new AsmDocsApi.Handler();
-        this.handle.get('/asm/:opcode', asmDocsHandler.handle.bind(asmDocsHandler));
+        this.handle.get('/asm/x86-64/:opcode', asmDocsHandler.handle.bind(asmDocsHandler));
 
         this.handle.post('/compiler/:compiler/compile', compileHandler.handle.bind(compileHandler));
         this.handle.post('/popularArguments/:compiler', compileHandler.handlePopularArguments.bind(compileHandler));

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -338,6 +338,8 @@ Compiler.prototype.initCompiler = function (state) {
 };
 
 Compiler.prototype.initEditorActions = function () {
+    var docname = this.compiler.docname;
+
     this.outputEditor.addAction({
         id: 'viewsource',
         label: 'Scroll to source',
@@ -360,7 +362,7 @@ Compiler.prototype.initEditorActions = function () {
 
     this.outputEditor.addAction({
         id: 'viewasmdoc',
-        label: 'View x86-64 opcode doc',
+        label: 'View ' + docname + ' opcode doc',
         keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.F8],
         keybindingContext: null,
         contextMenuGroupId: 'help',
@@ -1388,7 +1390,7 @@ function getNumericToolTip(value) {
     return null;
 }
 
-function getAsmInfo(opcode) {
+function getAsmInfo(opcode, docname) {
     var cacheName = 'asm/' + opcode;
     var cached = OpcodeCache.get(cacheName);
     if (cached) {
@@ -1401,7 +1403,7 @@ function getAsmInfo(opcode) {
     return new Promise(function (resolve, reject) {
         $.ajax({
             type: 'GET',
-            url: window.location.origin + base + 'api/asm/' + opcode,
+            url: window.location.origin + base + 'api/asm/' + docname + '/' + opcode,
             dataType: 'json',  // Expected,
             contentType: 'text/plain',  // Sent
             success: function (result) {
@@ -1469,7 +1471,7 @@ Compiler.prototype.onMouseMove = function (e) {
                 _.some(lineTokens(this.outputEditor.getModel(), currentWord.range.startLineNumber), function (t) {
                     return t.offset + 1 === currentWord.startColumn && t.type === 'keyword.asm';
                 })) {
-                getAsmInfo(currentWord.word).then(_.bind(function (response) {
+                getAsmInfo(currentWord.word, this.compiler.docname).then(_.bind(function (response) {
                     if (!response) return;
                     this.decorations.asmToolTip = {
                         range: currentWord.range,
@@ -1504,7 +1506,7 @@ Compiler.prototype.onAsmToolTip = function (ed) {
             ' title="Opens in a new window"></small></sup></a>.';
     }
 
-    getAsmInfo(word.word).then(_.bind(function (asmHelp) {
+    getAsmInfo(word.word, this.compiler.docname).then(_.bind(function (asmHelp) {
         if (asmHelp) {
             this.alertSystem.alert(opcode + ' help', asmHelp.html + appendInfo(asmHelp.url), function () {
                 ed.focus();


### PR DESCRIPTION
This is still work in progress, but I could use some early review as my js level is still a bit low.

The goal is to be able to have different asm doc for different targets (x86-64, arm, etc).
The idea prototyped here is the following:
 - a compiler has a docname property that is a doc identifier
 - different doc backends can register different urls that use said identifier

Currently, everything is treated as x86-64 and I won't change this behavior at the beginning.
But compilers for x86-64 have the docname set to 'X86-64' and the asmDocs class now registers to '/api/asm/x86-64' instead of '/api/asm/'.

Internally, I have a backend for our processor that registers to '/api/asm/foo' and has its 'docname' property sets to 'foo', and it works.

This is still early and I'm showing here the initial code that works.

If that's not wanted here because there is no need for generic code where only 1 backend exists, I understand and will maintain this on my side.

Closes #395 #507
