### PR TITLE
fix #1047

### DIFF
--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -37,6 +37,7 @@ class AsmParser extends AsmRegex {
         this.dataDefn = /^\s*\.(string|asciz|ascii|[1248]?byte|short|x?word|long|quad|value|zero)/;
         this.fileFind = /^\s*\.file\s+(\d+)\s+"([^"]+)"(\s+"([^"]+)")?.*/;
         this.hasOpcodeRe = /^\s*[a-zA-Z]/;
+        this.hasNvccOpcodeRe = /^\s*[a-zA-Z|@]/;
         this.definesFunction = /^\s*\.type.*,\s*[@%]function$/;
         this.definesGlobal = /^\s*\.globa?l\s*([.a-zA-Z_][a-zA-Z0-9$_.]*)/;
         this.indentedLabelDef = /^\s*([.a-zA-Z_$][a-zA-Z0-9$_.]*):/;
@@ -67,7 +68,7 @@ class AsmParser extends AsmRegex {
         this.destRe = /\s([0-9a-f]+)\s+<([^>]+)>$/;
     }
 
-    hasOpcode(line) {
+    hasOpcode(line, inNvccCode) {
         // Remove any leading label definition...
         const match = line.match(this.labelDef);
         if (match) {
@@ -77,6 +78,9 @@ class AsmParser extends AsmRegex {
         line = line.split(/[#;]/, 1)[0];
         // Detect assignment, that's not an opcode...
         if (line.match(this.assignmentDef)) return false;
+        if(inNvccCode) {
+            return !!line.match(this.hasNvccOpcodeRe);
+        }
         return !!line.match(this.hasOpcodeRe);
     }
 
@@ -138,14 +142,14 @@ class AsmParser extends AsmRegex {
             match = line.match(labelFind);
             if (!match) return;
 
-            if (!filterDirectives || this.hasOpcode(line) || line.match(this.definesFunction)) {
+            if (!filterDirectives || this.hasOpcode(line,false) || line.match(this.definesFunction)) {
                 // Only count a label as used if it's used by an opcode, or else we're not filtering directives.
                 match.forEach(label => labelsUsed[label] = true);
             } else {
                 // If we have a current label, then any subsequent opcode or data definition's labels are referred to
                 // weakly by that label.
                 const isDataDefinition = !!line.match(this.dataDefn);
-                const isOpcode = this.hasOpcode(line);
+                const isOpcode = this.hasOpcode(line,false);
                 if (isDataDefinition || isOpcode) {
                     currentLabelSet.forEach(currentLabel => {
                         if (!weakUsages[currentLabel]) weakUsages[currentLabel] = [];
@@ -214,6 +218,7 @@ class AsmParser extends AsmRegex {
         let prevLabel = "";
 
         const commentOnly = /^\s*(((#|@|;|\/\/).*)|(\/\*.*\*\/))$/;
+        const commentOnlyNvcc = /^\s*(((#|;|\/\/).*)|(\/\*.*\*\/))$/;
         const sourceTag = /^\s*\.loc\s+(\d+)\s+(\d+).*/;
         const sourceStab = /^\s*\.stabn\s+(\d+),0,(\d+),.*/;
         const stdInLooking = /<stdin>|^-$|example\.[^/]+$|<source>/;
@@ -287,7 +292,12 @@ class AsmParser extends AsmRegex {
                 mayRemovePreviousLabel = true;
             }
 
-            if (filters.commentOnly && line.match(commentOnly)) return;
+            if (filters.commentOnly &&
+                ((line.match(commentOnly) && !inNvccCode) ||
+                (line.match(commentOnlyNvcc) && inNvccCode))
+            ){
+                return;
+            }
 
             if (inCustomAssembly > 0)
                 line = this.fixLabelIndentation(line);
@@ -325,7 +335,10 @@ class AsmParser extends AsmRegex {
             }
 
             line = utils.expandTabs(line);
-            result.push({text: AsmRegex.filterAsmLine(line, filters), source: this.hasOpcode(line) ? source : null});
+            result.push({
+                text: AsmRegex.filterAsmLine(line, filters),
+                source: this.hasOpcode(line, inNvccCode) ? source : null
+            });
         });
         return result;
     }

--- a/test/cases/nvcc-example.asm.directives.labels.comments.json
+++ b/test/cases/nvcc-example.asm.directives.labels.comments.json
@@ -99,6 +99,13 @@
     }
   },
   {
+    "text": "        @%p1 bra        BB0_2;",
+    "source": {
+      "file": "/tmp/moo.cu",
+      "line": 12
+    }
+  },
+  {
     "text": "",
     "source": null
   },

--- a/test/cases/nvcc-example.asm.directives.labels.comments.library.json
+++ b/test/cases/nvcc-example.asm.directives.labels.comments.library.json
@@ -99,6 +99,13 @@
     }
   },
   {
+    "text": "        @%p1 bra        BB0_2;",
+    "source": {
+      "file": "/tmp/moo.cu",
+      "line": 12
+    }
+  },
+  {
     "text": "",
     "source": null
   },


### PR DESCRIPTION
Hello everyone,

this PR attempts to fix #1047.
Without the changes introduced in this pull request "predicated instructions" in the disassembly are displayed as comments ( for more information, check https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#predicated-execution ). 

Even though this problem is now fixed on the parser side, and the code is correctly displayed in the output panel, it still has the "comment color" (green). From what I have gathered this problem is rooted in lib/languages.js :
```js
//...
cuda: {
        name: 'CUDA',
        monaco: 'cuda',
        extensions: ['.cu'],
        alias: ['nvcc']
    },
//...
```
The monaco editor does not seem to support this `cuda` setting out of the box, neither have I found any custom config for it. Maybe anyone could give me a hint on this?

Best Regards: Sebastian