### PR TITLE
Make llvm-mca available to Rust

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -1,6 +1,6 @@
 compilers=&rust
 objdumper=/opt/compiler-explorer/gcc-8.1.0/bin/objdump
-defaultCompiler=r1320
+defaultCompiler=r1330
 group.rust.compilers=r1330:r1320:r1310:r1300:r1290:r1280:r1271:r1270:r1260:r1250:r1240:r1230:r1220:r1210:r1200:r1190:r1180:r1170:r1160:r1151:r1140:r1130:r1120:r1110:r1100:r190:r180:r170:r160:r150:r140:r130:r120:r110:r100:nightly:beta
 group.rust.compilerType=rust
 group.rust.isSemVer=true
@@ -90,4 +90,9 @@ libs=
 #################################
 # Installed tools
 
-tools=
+tools=llvm-mcatrunk
+
+tools.llvm-mcatrunk.name=llvm-mca
+tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
+tools.llvm-mcatrunk.type=postcompilation
+tools.llvm-mcatrunk.class=llvm-mca-tool


### PR DESCRIPTION
This allows using llvm-mca with Rust directly.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
