### PR TITLE
Fix cuda disassembly code highlighting

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -70,3 +70,4 @@ From oldest to newest contributor, we would like to thank:
 - [Daniel Black](https://github.com/grooverdan)
 - [Gennadiy Civil](https://github.com/gennadiycivil)
 - [Paul Scharnofske](https://github.com/asynts)
+- [Sebastian Staffa](https://github.com/Staff-d)

--- a/lib/languages.js
+++ b/lib/languages.js
@@ -142,7 +142,8 @@ const languages = {
         name: 'CUDA',
         monaco: 'cuda',
         extensions: ['.cu'],
-        alias: ['nvcc']
+        alias: ['nvcc'],
+        monacoDisassembly: 'ptx'
     },
     zig: {
         name: 'Zig',

--- a/static/modes/asm-mode.js
+++ b/static/modes/asm-mode.js
@@ -119,5 +119,8 @@ function definition() {
     };
 }
 
+var def = definition();
 monaco.languages.register({id: 'asm'});
-monaco.languages.setMonarchTokensProvider('asm', definition());
+monaco.languages.setMonarchTokensProvider('asm', def);
+
+module.exports = def;

--- a/static/modes/ptx-mode.js
+++ b/static/modes/ptx-mode.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2019, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+'use strict';
+var $ = require('jquery');
+var asm = require('./asm-mode');
+
+function definition() {
+    var ptx = $.extend(true, {}, asm); // deep copy
+
+    // Redefine registers for ptx:
+    // Usually ptx registers are in the form "%[pr][0-9]+", but a bunch of magic registers does not follow
+    // this scheme (see https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers ).
+    // Thus the register-regex captures everything that starts with a '%'.
+    ptx.registers = /%[a-z0-9_\\.]+/;
+
+
+    // Redefine whitespaces, as asm interprets strings with a leading '@' as comments.
+    ptx.tokenizer.whitespace = [
+        [/[ \t\r\n]+/, 'white'],
+        [/\/\*/, 'comment', '@comment'],
+        [/\/\/.*$/, 'comment'],
+        [/[#;\\].*$/, 'comment']
+    ];
+
+    // Add predicated instructions to the list of root tokens. Search for an opcode next, which is also a root token.
+    ptx.tokenizer.root.push([/@%p[0-9]+/, {token: 'operator', next: '@root'}]);
+
+    return ptx;
+}
+
+monaco.languages.register({id: 'ptx'});
+monaco.languages.setMonarchTokensProvider('ptx', definition());

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -40,6 +40,7 @@ var local = require('../local');
 var Sentry = require('@sentry/browser');
 var Libraries = require('../libs-widget');
 require('../modes/asm-mode');
+require('../modes/ptx-mode');
 
 require('selectize');
 
@@ -104,7 +105,7 @@ function Compiler(hub, container, state) {
     this.outputEditor = monaco.editor.create(this.monacoPlaceholder[0], {
         scrollBeyondLastLine: false,
         readOnly: true,
-        language: 'asm',
+        language: languages[this.currentLangId].monacoDisassembly || 'asm',
         fontFamily: this.settings.editorsFFont,
         glyphMargin: !options.embedded,
         fixedOverflowWidgets: true,


### PR DESCRIPTION
This PR is a follow-up to #1293 

If have added a possibility to define a separate monaco language definition for the disassembly in the output pane via a `monacoDisassembly` key in `lib/languages.js`. Previously 'asm' was hardcoded, which is still the fallback value if no custom language definition is given.

The `cuda` language now uses a custom `ptx` monaco language for disassembled code, which highlights registers and predicated instructions correctly.

Best regards: Sebastian