### PR TITLE
Add Support for RISC-V GCC and 64-bit RISC-V LLVM

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -198,12 +198,15 @@ compiler.clang_parmexpr.options=-std=c++2a -stdlib=libc++
 compiler.clang_parmexpr.notification=Experimental Parametric Expressions; see <a href="https://github.com/ricejasonf/parametric_expressions/blob/master/d1221.md" target="_blank" rel="noopener noreferrer">P1221<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
 # Clang for RISC-V
-group.rvclang.compilers=rv32clang
+group.rvclang.compilers=rv32clang:rv64clang
 group.rvclang.groupName=Clang RISC-V
 group.rvclang.supportsBinary=false
 compiler.rv32clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
-compiler.rv32clang.name=riscv32 clang (trunk)
-compiler.rv32clang.options=-target riscv32
+compiler.rv32clang.name=RISC-V rv32gc clang (trunk)
+compiler.rv32clang.options=-target riscv32 -march=rv32gc -mabi=ilp32
+compiler.rv64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.rv64clang.name=RISC-V rv64gc clang (trunk)
+compiler.rv64clang.options=-target riscv64 -march=rv64gc -mabi=lp64
 
 # icc for x86
 group.icc.compilers=icc1301:icc16:icc17:icc18:icc19:icc191

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -244,7 +244,7 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr
+group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr:&riscv
 group.cross.supportsBinary=false
 group.cross.groupName=Cross GCC
 
@@ -372,6 +372,15 @@ compiler.mips564.semver=5.4
 compiler.mips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
 compiler.mips564el.name=MIPS64 gcc 5.4 (el)
 compiler.mips564el.semver=5.4
+
+###############################
+# GCC for RISC-V
+group.riscv.compilers=riscv820
+group.riscv.groupName=RISC-V GCC
+group.riscv.isSemVer=true
+compiler.riscv820.exe=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
+compiler.riscv820.name=RISC-V gcc 8.2.0
+compiler.riscv820.semver=8.2.0
 
 ################################
 # Windows Compilers


### PR DESCRIPTION
I thought I'd come back and revisit this, as I wanted to play around with compiler-explorer today and noticed it still doesn't support RISC-V.  There are a handful of existing issues

https://github.com/mattgodbolt/compiler-explorer/issues/334 : Clang support, which has been partially resolved and should be fully resolved by this commit.
https://github.com/mattgodbolt/compiler-explorer/issues/965 : GCC support, which should be fully resolved by this commit.
https://github.com/mattgodbolt/compiler-explorer/pull/964 : An obsolete pull request only containing the GCC support, that I closed because crosstool-ng didn't support RISC-V at that time.
https://github.com/mattgodbolt/compiler-explorer-image/pull/176 : A pull request to add a RISC-V GCC 8.2.0 to the image.

There's a lot of information in there, but the short of it is that I think these three patches (two here, one in -image) should get us reasonable RISC-V support.