### PR TITLE
Add LLVM IR view for LDC.

### DIFF
--- a/lib/compilers/ldc.js
+++ b/lib/compilers/ldc.js
@@ -26,12 +26,15 @@ const BaseCompiler = require('../base-compiler'),
     argumentParsers = require("./argument-parsers"),
     fs = require('fs-extra'),
     logger = require('./../logger').logger,
+    path = require('path'),
     semverParser = require('semver');
 
 class LDCCompiler extends BaseCompiler {
     constructor(info, env) {
         super(info, env);
         this.compiler.supportsIntel = true;
+        this.compiler.supportsIrView = true;
+        this.compiler.irArg = ['-output-ll'];
     }
 
     optionsForFilter(filters, outputFilename) {
@@ -79,6 +82,17 @@ class LDCCompiler extends BaseCompiler {
             return "";
         }
         return fs.readFileSync(astFilename, 'utf-8');
+    }
+
+    // Override the IR processing method for LDC because the output file is different from clang.
+    processIrOutput(output, filters) {
+        const irPath = this.getOutputFilename(path.dirname(output.inputFilename), this.outputFilebase).replace('.s', '.ll');
+        if (fs.existsSync(irPath)) {
+            const output = fs.readFileSync(irPath, 'utf-8');
+            // uses same filters as main compiler
+            return this.llvmIr.process(output, filters);
+        }
+        return output.stderr;
     }
 }
 


### PR DESCRIPTION
I think it'd be nicer if the BaseCompiler code would also check for `<outputfile>.ll` but for reviewing I added the special code to `ldc.js`.
What's a little unfortunate is that the command to generate the LLVM IR will also create the ASM `.s` file, so it will overwrite the one already generated (or will things go wrong when the two LDC invokes are both writing to it at the same time...?). We can disable writing to the `.s` file when creating LLVM IR (`-output-s=false`) but then we'd have to change the compiler flags because the LLVM IR will be written to the output filename specified in those compiler flags...