### PR TITLE
Do not use system node by error

### DIFF
--- a/etc/scripts/find-node
+++ b/etc/scripts/find-node
@@ -9,7 +9,7 @@ find_node() {
     local SYS_NODE="$(which node 2>/dev/null)"
     local SYS_NODEJS="$(which nodejs 2>/dev/null)"
 
-    if test -x "${NODE}"; then
+    if test -x "${NODE}" -a -n "${NODE_DIR}"; then
         echo "${NODE}"
     elif test -x "${CE_NODE}"; then
         echo "${CE_NODE}"


### PR DESCRIPTION
If system's node is overriden by something in PATH, having NODE_DIR
empty will cause the script to still use node found in /bin/.
Only consider the first case if NODE_DIR is not empty.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
