### PR TITLE
Add "-g0" to the P1144 compiler's command line, until I figure out what's wrong with DWARF

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -184,7 +184,7 @@ compiler.clang_concepts.options=-std=c++2a -Xclang -fconcepts-ts -stdlib=libc++
 compiler.clang_concepts.notification=Highly experimental compiler. Bug reports welcomed at <a href="https://github.com/saarraz/clang-concepts/issues" target="_blank" rel="noopener noreferrer">github.com/saarraz/clang-concepts/issues <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_p1144.exe=/opt/compiler-explorer/clang-relocatable-trunk/bin/clang++
 compiler.clang_p1144.semver=(experimental P1144)
-compiler.clang_p1144.options=-std=c++2a -stdlib=libc++
+compiler.clang_p1144.options=-std=c++2a -stdlib=libc++ -g0
 compiler.clang_p1144.notification=Experimental __is_trivially_relocatable; see <a href="https://quuxplusone.github.io/draft/d1144-object-relocation.html" target="_blank" rel="noopener noreferrer">P1144 <sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 compiler.clang_autonsdmi.exe=/opt/compiler-explorer/clang-autonsdmi-trunk/bin/clang++
 compiler.clang_autonsdmi.semver=(experimental auto NSDMI)


### PR DESCRIPTION
https://godbolt.org/z/5cq08h

Adding `-g0` does break code-to-source matching, but I think that's better than segfaulting (and people can always add back `-g` manually).