### PR TITLE
Allow caching of compiler version and argument information to improve startup time

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,6 @@
     "quote-props": ["error", "as-needed"]
   },
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 2017
   }
 }

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -73,3 +73,4 @@ From oldest to newest contributor, we would like to thank:
 - [Sebastian Staffa](https://github.com/Staff-d)
 - [Andreas Jonson](https://github.com/andjo403)
 - [Sam Clegg](https://github.com/sbc100)
+- [Austin Morton](https://github.com/apmorton)

--- a/app.js
+++ b/app.js
@@ -24,6 +24,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+const startTime = new Date();
+
 // Initialise options and properties. Don't load any handlers here; they
 // may need an initialised properties library.
 const nopt = require('nopt'),
@@ -286,6 +288,7 @@ aws.initConfig(awsProps)
                 _port = defArgs.port;
             }
             logger.info(`  Listening on http://${defArgs.hostname || 'localhost'}:${_port}/`);
+            logger.info(`  Startup duration: ${new Date() - startTime}ms`);
             logger.info("=======================================");
             server.listen(_port, defArgs.hostname);
         }

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -103,6 +103,22 @@ class BaseCompiler {
         return exec.execute(compiler, args, options);
     }
 
+    getCompilerCacheKey(compiler, args, options) {
+        return {mtime: this.mtime, compiler, args, options};
+    }
+
+    async execCompilerCached(compiler, args, options) {
+        const key = this.getCompilerCacheKey(compiler, args, options);
+        let result = await this.env.compilerCacheGet(key);
+        if (!result) {
+            result = await exec.execute(compiler, args, options);
+            if (result.okToCache)
+                this.env.compilerCachePut(key, result);
+        }
+
+        return result;
+    }
+
     getDefaultExecOptions() {
         return {
             timeoutMs: this.env.ceProps("compileTimeoutMs", 7500),
@@ -877,7 +893,7 @@ Please select another pass or change filters.`;
         const execOptions = this.getDefaultExecOptions();
         const versionFlag = this.compiler.versionFlag || '--version';
         execOptions.timeoutMs = 0; // No timeout for --version. A sort of workaround for slow EFS/NFS on the prod site
-        return this.exec(this.compiler.exe, [versionFlag], execOptions);
+        return this.execCompilerCached(this.compiler.exe, [versionFlag], execOptions);
     }
 
     initialise() {

--- a/lib/compilation-env.js
+++ b/lib/compilation-env.js
@@ -43,6 +43,8 @@ class CompilationEnvironment {
         this.cache = FromConfig.create(doCache === undefined || doCache ? this.ceProps('cacheConfig', '') : "");
         this.executableCache = FromConfig.create(doCache === undefined ||
             doCache ? this.ceProps('executableCacheConfig', '') : "");
+        this.compilerCache = FromConfig.create(doCache === undefined ||
+            doCache ? this.ceProps('compilerCacheConfig', '') : "");
         this.compileQueue = new Queue(this.ceProps("maxConcurrentCompiles", 1), Infinity);
         this.reportCacheEvery = this.ceProps("cacheReportEvery", 100);
         this.multiarch = null;
@@ -87,6 +89,20 @@ class CompilationEnvironment {
     cachePut(object, result, creator) {
         const key = BaseCache.hash(object);
         return this.cache.put(key, JSON.stringify(result), creator);
+    }
+
+    async compilerCacheGet(object) {
+        const key = BaseCache.hash(object);
+        const result = await this.compilerCache.get(key);
+        if (!result.hit) {
+            return null;
+        }
+        return JSON.parse(result.data);
+    }
+
+    compilerCachePut(object, result, creator) {
+        const key = BaseCache.hash(object);
+        return this.compilerCache.put(key, JSON.stringify(result), creator);
     }
 
     executableGet(object, destinationFolder) {

--- a/lib/compilers/argument-parsers.js
+++ b/lib/compilers/argument-parsers.js
@@ -66,7 +66,7 @@ class BaseParser {
     }
 
     static getOptions(compiler, helpArg) {
-        return compiler.exec(compiler.compiler.exe, [helpArg]).then(result => {
+        return compiler.execCompilerCached(compiler.compiler.exe, [helpArg]).then(result => {
             let options = {};
             if (result.code === 0) {
                 const optionFinder = /^\s*(--?[a-z0-9=+,[\]<>|-]*)\s*(.*)/i;
@@ -153,7 +153,7 @@ class ISPCParser extends BaseParser {
     }
 
     static getOptions(compiler, helpArg) {
-        return compiler.exec(compiler.compiler.exe, [helpArg]).then(result => {
+        return compiler.execCompilerCached(compiler.compiler.exe, [helpArg]).then(result => {
             let options = {};
             if (result.code === 0) {
                 const optionFinder = /^\s*\[(--?[a-z0-9=+,{}\s[\]<>|-]*)\]\s*(.*)/i;
@@ -231,7 +231,7 @@ class VCParser extends BaseParser {
     }
 
     static getOptions(compiler, helpArg) {
-        return compiler.exec(compiler.compiler.exe, [helpArg]).then(result => {
+        return compiler.execCompilerCached(compiler.compiler.exe, [helpArg]).then(result => {
             let options = {};
             if (result.code === 0) {
                 const optionFinder = /^\s*(\/[a-z0-9=:+#.,[\]{}<>|_-]*)\s*(.*)/i;

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -109,12 +109,9 @@ class CompileHandler {
                         logger.debug(`${compiler.id} is unchanged`);
                         return cached;
                     }
-                    return new this.factories[type](compiler, this.compilerEnv)
-                        .initialise()
-                        .then(compiler => {
-                            if (compiler) compiler.mtime = res.mtime;
-                            return compiler;
-                        });
+                    const compilerObj = new this.factories[type](compiler, this.compilerEnv);
+                    compilerObj.mtime = res.mtime;
+                    return compilerObj.initialise();
                 })
                 .catch(err => {
                     logger.warn(`Unable to stat ${compiler.id} compiler binary: `, err);

--- a/test/compilers/argument-parsers-tests.js
+++ b/test/compilers/argument-parsers-tests.js
@@ -43,6 +43,7 @@ function makeCompiler(stdout, stderr, code) {
     const env = new CompilationEnvironment(compilerProps);
     const compiler = new FakeCompiler({lang: languages['c++'].id, remote: true}, env);
     compiler.exec = () => Promise.resolve({code: code, stdout: stdout || "", stderr: stderr || ""});
+    compiler.execCompilerCached = compiler.exec;
     compiler.possibleArguments = new CompilerArguments("g82");
     return compiler;
 }


### PR DESCRIPTION
add something like the following to `compiler-explorer.local.properties`
```
compilerCacheConfig=OnDisk(./lib/storage/data/cache, 50)
```

Startup when the cache is empty is marginally slower, but subsequent startups can be an order of magnitude faster, because no compilers will be executed during startup.

With 70 compilers installed locally the reported startup time went from 11604ms to 1711ms.
With 3 compilers installed locally the reported startup time went from 1742ms to 1429ms.

Definitely useful during development, although in production the usefulness really depends on how fast S3 caching would be.  It may simply be faster to execute the compilers off EFS than to make several hundred round trips to S3.