### PR TITLE
enable binary mode for crosscompilers where possible

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -258,8 +258,9 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 ###############################
 # Cross GCC
 group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr:&riscv
-group.cross.supportsBinary=false
+group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
+group.cross.supportsExecute=false
 
 ###############################
 # GCC for PPC
@@ -269,21 +270,27 @@ group.ppc.isSemVer=true
 compiler.ppcg48.exe=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-g++
 compiler.ppcg48.name=PowerPC gcc 4.8.5
 compiler.ppcg48.semver=4.8.5
+compiler.ppcg48.objdumper=/opt/compiler-explorer/powerpc/gcc-4.8.5/bin/powerpc-unknown-linux-gnu-objdump
 compiler.ppc64leg630.exe=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg630.name=power64le gcc 6.3.0
 compiler.ppc64leg630.semver=6.3.0
+compiler.ppc64leg630.objdumper=/opt/compiler-explorer/powerpc64le/gcc-6.3.0/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64leg8.exe=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-g++
 compiler.ppc64leg8.name=power64le AT12.0
 compiler.ppc64leg8.semver=(snapshot)
+compiler.ppc64leg8.objdumper=/opt/compiler-explorer/powerpc64le/gcc-at12/powerpc64le-unknown-linux-gnu/bin/powerpc64le-unknown-linux-gnu-objdump
 compiler.ppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-g++
 compiler.ppc64g8.name=power64 AT12.0
 compiler.ppc64g8.semver=(snapshot)
+compiler.ppc64g8.objdumper=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-objdump
 compiler.ppc64clang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.ppc64clang.name=powerpc64 clang (trunk)
 compiler.ppc64clang.options=-target powerpc64
+compiler.ppc64clang.supportsBinary=false
 compiler.ppc64leclang.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.ppc64leclang.name=power64le clang (trunk)
 compiler.ppc64leclang.options=-target powerpc64le
+compiler.ppc64leclang.supportsBinary=false
 
 ###############################
 # GCC for ARM
@@ -297,51 +304,66 @@ compiler.aarchg54.exe=/opt/compiler-explorer/arm64/gcc-5.4.0/aarch64-unknown-lin
 compiler.aarchg54.name=ARM64 gcc 5.4 (linux)
 compiler.aarchg54.alias=aarchg48
 compiler.aarchg54.semver=5.4
+compiler.aarchg54.objdumper=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.armhfg54.exe=/opt/compiler-explorer/arm/gcc-5.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.armhfg54.name=ARM gcc 5.4 (linux)
 compiler.armhfg54.alias=armhfg482
 compiler.armhfg54.semver=5.4
+compiler.armhfg54.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.arm541.exe=/opt/compiler-explorer/gcc-arm-none-eabi-5_4-2016q3/bin/arm-none-eabi-g++
 compiler.arm541.name=ARM gcc 5.4.1 (none)
 compiler.arm541.semver=5.4.1
+compiler.arm541.supportsBinary=false
 compiler.armg454.exe=/opt/compiler-explorer/arm/gcc-4.5.4/bin/arm-unknown-linux-gnueabi-g++
 compiler.armg454.alias=armg453
 compiler.armg454.name=ARM gcc 4.5.4 (linux)
 compiler.armg454.semver=4.5.4
+compiler.armg454.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.armg464.exe=/opt/compiler-explorer/arm/gcc-4.6.4/bin/arm-unknown-linux-gnueabi-g++
 compiler.armg464.alias=armg463
 compiler.armg464.name=ARM gcc 4.6.4 (linux)
 compiler.armg464.semver=4.6.4
+compiler.armg464.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.armg630.exe=/opt/compiler-explorer/arm/gcc-6.3.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
 compiler.armg630.name=ARM gcc 6.3.0 (linux)
 compiler.armg630.semver=6.3.0
+compiler.armg630.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.arm710.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-7-2017-q4-major/bin/arm-none-eabi-g++
 compiler.arm710.name=ARM gcc 7.2.1 (none)
 compiler.arm710.semver=7.2.1
+compiler.arm710.supportsBinary=false
 compiler.arm64g630.exe=/opt/compiler-explorer/arm64/gcc-6.3.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-g++
 compiler.arm64g630.name=ARM64 gcc 6.3.0 (linux)
 compiler.arm64g630.semver=6.3.0
+compiler.arm64g630.objdumper=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.armg640.exe=/opt/compiler-explorer/arm/gcc-6.4.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
 compiler.armg640.name=ARM gcc 6.4
 compiler.armg640.semver=6.4.0
+compiler.armg640.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.armg730.exe=/opt/compiler-explorer/arm/gcc-7.3.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
 compiler.armg730.name=ARM gcc 7.3
 compiler.armg730.semver=7.3.0
+compiler.armg730.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.armg820.exe=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
 compiler.armg820.name=ARM gcc 8.2
 compiler.armg820.semver=8.2.0
+compiler.armg820.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.arm64g640.exe=/opt/compiler-explorer/arm64/gcc-6.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g640.name=ARM64 gcc 6.4
 compiler.arm64g640.semver=6.4.0
+compiler.arm64g640.objdumper=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.arm64g730.exe=/opt/compiler-explorer/arm64/gcc-7.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g730.name=ARM64 gcc 7.3
 compiler.arm64g730.semver=7.3.0
+compiler.arm64g730.objdumper=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.arm64g820.exe=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
 compiler.arm64g820.name=ARM64 gcc 8.2
 compiler.arm64g820.semver=8.2.0
+compiler.arm64g820.objdumper=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.armce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-g++
 compiler.armce820.name=ARM gcc 8.2 (WinCE)
 compiler.armce820.semver=8.2.0
+compiler.armce820.supportsBinary=false
 
 
 ################################
@@ -350,6 +372,7 @@ group.msp.compilers=msp430g453:msp430g530:msp430g621
 group.msp.groupName=MSP GCC
 group.msp.baseName=MSP430 gcc
 group.msp.isSemVer=true
+group.msp.supportsBinary=false
 compiler.msp430g453.exe=/opt/compiler-explorer/msp430/gcc-4.5.3/bin/msp430-g++
 compiler.msp430g453.alias=/usr/bin/msp430-g++
 compiler.msp430g453.semver=4.5.3
@@ -367,8 +390,10 @@ group.avr.isSemVer=true
 compiler.avrg454.exe=/opt/compiler-explorer/avr/gcc-4.5.4/bin/avr-g++
 compiler.avrg454.alias=avrg453
 compiler.avrg454.semver=4.5.4
+compiler.avrg454.supportsBinary=false
 compiler.avrg464.exe=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-g++
 compiler.avrg464.semver=4.6.4
+compiler.avrg464.objdumper=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-objdump
 
 ###############################
 # GCC for MIPS
@@ -378,15 +403,19 @@ group.mips.isSemVer=true
 compiler.mips5.exe=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-g++
 compiler.mips5.name=MIPS gcc 5.4
 compiler.mips5.semver=5.4
+compiler.mips5.objdumper=/opt/compiler-explorer/mips/gcc-5.4.0/mips-unknown-linux-gnu/bin/mips-unknown-linux-gnu-objdump
 compiler.mips5el.exe=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/bin/mipsel-unknown-linux-gnu-g++
 compiler.mips5el.name=MIPS gcc 5.4 (el)
 compiler.mips5el.semver=5.4
+compiler.mips5el.objdumper=/opt/compiler-explorer/mipsel/gcc-5.4.0/mipsel-unknown-linux-gnu/mipsel-unknown-linux-gnu/bin/objdump
 compiler.mips564.exe=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-g++
 compiler.mips564.name=MIPS64 gcc 5.4
 compiler.mips564.semver=5.4
+compiler.mips564.objdumper=/opt/compiler-explorer/mips64/gcc-5.4.0/mips64-unknown-linux-gnu/bin/mips64-unknown-linux-gnu-objdump
 compiler.mips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-g++
 compiler.mips564el.name=MIPS64 gcc 5.4 (el)
 compiler.mips564el.semver=5.4
+compiler.mips564el.objdumper=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-objdump
 
 ###############################
 # GCC for RISC-V
@@ -396,6 +425,7 @@ group.riscv.isSemVer=true
 compiler.riscv820.exe=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-g++
 compiler.riscv820.name=RISC-V gcc 8.2.0
 compiler.riscv820.semver=8.2.0
+compiler.riscv820.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-objdump
 
 ################################
 # Windows Compilers


### PR DESCRIPTION
Fixes #1418

Enabled and tested binary mode for all cross compilers
* Didn't test the WinCE one
* Some had problems linking, so I disabled it (risc-v, msp, ppc clang)
