### PR TITLE
Add Raspbian and FRC compilers to supported compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -259,7 +259,7 @@ compiler.zapcc190308.name=x86-64 Zapcc 190308
 
 ###############################
 # Cross GCC
-group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr:&riscv
+group.cross.compilers=&ppc:&mips:&msp:&gccarm:&avr:&riscv:&platspec
 group.cross.supportsBinary=true
 group.cross.groupName=Cross GCC
 group.cross.supportsExecute=false
@@ -367,6 +367,20 @@ compiler.armce820.name=ARM gcc 8.2 (WinCE)
 compiler.armce820.semver=8.2.0
 compiler.armce820.supportsBinary=false
 
+###############################
+# Platform Specific Cross Compilers
+group.platspec.compilers=frc2019:raspbian9
+group.platspec.groupName=Platform Specific Compilers
+group.platspec.isSemVer=true
+group.platspec.includeFlag=-I
+compiler.frc2019.exe=/opt/compiler-explorer/arm/frc2019-6.3.0/roborio/bin/arm-frc2019-linux-gnueabi-g++
+compiler.frc2019.name=FRC 2019
+compiler.frc2019.semver=6.3
+compiler.frc2019.objdumper=/opt/compiler-explorer/arm/frc2019-6.3.0/roborio/bin/arm-frc2019-linux-gnueabi-objdump
+compiler.raspbian9.exe=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbian9-linux-gnueabihf-g++
+compiler.raspbian9.name=Raspbian Stretch
+compiler.raspbian9.semver=6.3
+compiler.raspbian9.objdumper=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbian9-linux-gnueabihf-objdump
 
 ################################
 # GCC for MSP

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -193,7 +193,7 @@ compiler.cicc191.options=-x c -gcc-name=/opt/compiler-explorer/gcc-8.2.0/bin/gcc
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppc:&cmips:&cmsp:&cgccarm:&cavr
+group.ccross.compilers=&cppc:&cmips:&cmsp:&cgccarm:&cavr:&cplatspec
 group.ccross.supportsBinary=false
 group.ccross.groupName=Cross GCC
 
@@ -276,6 +276,20 @@ compiler.carmce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-min
 compiler.carmce820.name=ARM gcc 8.2 (WinCE)
 compiler.carmce820.semver=8.2.0
 
+###############################
+# Platform Specific Cross Compilers
+group.cplatspec.compilers=cfrc2019:craspbian9
+group.cplatspec.groupName=Platform Specific Compilers
+group.cplatspec.isSemVer=true
+group.cplatspec.includeFlag=-I
+compiler.cfrc2019.exe=/opt/compiler-explorer/arm/frc2019-6.3.0/roborio/bin/arm-frc2019-linux-gnueabi-gcc
+compiler.cfrc2019.name=FRC 2019
+compiler.cfrc2019.semver=6.3
+compiler.cfrc2019.objdumper=/opt/compiler-explorer/arm/frc2019-6.3.0/roborio/bin/arm-frc2019-linux-gnueabi-objdump
+compiler.craspbian9.exe=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbian9-linux-gnueabihf-gcc
+compiler.craspbian9.name=Raspbian Stretch
+compiler.craspbian9.semver=6.3
+compiler.craspbian9.objdumper=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbian9-linux-gnueabihf-objdump
 
 ################################
 # GCC for MSP


### PR DESCRIPTION
The main side of https://github.com/mattgodbolt/compiler-explorer-image/pull/215 and https://github.com/mattgodbolt/compiler-explorer-image/pull/213, with 213 needing to still be merged to get that compiler added. As discussed in the comments of https://github.com/mattgodbolt/compiler-explorer-image/pull/215, adding a new Platform Specific group to make is possible to add more platform specific compilers in the future, with potential things like Arduino.