### PR TITLE
Improve unexpected errors' logging

### DIFF
--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -297,8 +297,10 @@ class CompileHandler {
             },
             error => {
                 if (typeof (error) !== "string") {
-                    logger.error("Error during compilation: ", error);
-                    if (error.code) {
+                    if (error.stack) {
+                        logger.error("Error during compilation: ", error);
+                    } else if (error.code) {
+                        logger.error("Error during compilation: ", error.code);
                         if (typeof (error.stderr) === "string") {
                             error.stdout = utils.parseOutput(error.stdout);
                             error.stderr = utils.parseOutput(error.stderr);
@@ -306,6 +308,7 @@ class CompileHandler {
                         res.end(JSON.stringify(error));
                         return;
                     }
+
                     error = `Internal Compiler Explorer error: ${error.stack || error}`;
                 } else {
                     logger.error("Error during compilation: ", {error});

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -296,8 +296,8 @@ class CompileHandler {
                 }
             },
             error => {
-                logger.error("Error during compilation: ", {error});
                 if (typeof (error) !== "string") {
+                    logger.error("Error during compilation: ", error);
                     if (error.code) {
                         if (typeof (error.stderr) === "string") {
                             error.stdout = utils.parseOutput(error.stdout);
@@ -307,6 +307,8 @@ class CompileHandler {
                         return;
                     }
                     error = `Internal Compiler Explorer error: ${error.stack || error}`;
+                } else {
+                    logger.error("Error during compilation: ", {error});
                 }
                 res.end(JSON.stringify({code: -1, stderr: [{text: error}]}));
             });

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -307,6 +307,8 @@ class CompileHandler {
                         }
                         res.end(JSON.stringify(error));
                         return;
+                    } else {
+                        logger.error("Error during compilation: ", error);
                     }
 
                     error = `Internal Compiler Explorer error: ${error.stack || error}`;


### PR DESCRIPTION
When a node error occurs runtime, it will return an object with the error information but with .code
So check for stack first, that's obviously an internal error, else handle compiler errors, else etc