### PR TITLE
[OBSOLETE] Add sandbox support for nsjail

### DIFF
--- a/etc/config/execution.defaults.properties
+++ b/etc/config/execution.defaults.properties
@@ -5,3 +5,4 @@ wine=
 wineServer=
 winePrefix=/tmp/ce-wine-prefix
 firejail=firejail
+nsjail=nsjail

--- a/etc/nsjail/sandbox.cfg
+++ b/etc/nsjail/sandbox.cfg
@@ -1,0 +1,112 @@
+name: "compiler explorer user execution sandbox"
+
+mode: ONCE
+hostname: "ce"
+
+time_limit: 0
+max_cpus: 1
+
+log_level: FATAL
+
+rlimit_as: 102400 # 100 GiB
+rlimit_cpu_type: SOFT
+rlimit_fsize: 16 # 16 MiB
+rlimit_nofile: 10
+
+uidmap {
+    inside_id: "0"
+}
+
+gidmap {
+    inside_id: "0"
+}
+
+# must run following as root during system startup
+# cgcreate -a ubuntu:ubuntu -g memory,pids,cpu,net_cls:ce-sandbox
+cgroup_mem_parent: "ce-sandbox"
+cgroup_pids_parent: "ce-sandbox"
+cgroup_net_cls_parent: "ce-sandbox"
+cgroup_cpu_parent: "ce-sandbox"
+
+cgroup_mem_max: 209715200 # 200 MiB
+cgroup_pids_max: 4
+cgroup_cpu_ms_per_sec: 500
+
+mount {
+    src: "/lib"
+    dst: "/lib"
+    is_bind: true
+}
+
+mount {
+    src: "/usr/lib"
+    dst: "/usr/lib"
+    is_bind: true
+}
+
+mount {
+    src: "/lib64"
+    dst: "/lib64"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/lib32"
+    dst: "/lib32"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    dst: "/tmp"
+    fstype: "tmpfs"
+    options: "size=20971520,nr_inodes=100" # 20 MiB
+    rw: true
+    noexec: true
+    nodev: true
+    nosuid: true
+}
+
+mount {
+    dst: "/dev"
+    fstype: "tmpfs"
+}
+
+mount {
+    src: "/dev/null"
+    dst: "/dev/null"
+    rw: true
+    is_bind: true
+}
+
+mount {
+    src: "/dev/zero"
+    dst: "/dev/zero"
+    is_bind: true
+}
+
+mount {
+    src: "/dev/urandom"
+    dst: "/dev/random"
+    is_bind: true
+}
+
+mount {
+    src: "/dev/urandom"
+    dst: "/dev/urandom"
+    is_bind: true
+}
+
+mount {
+    dst: "/proc"
+    fstype: "proc"
+}
+
+mount {
+    src: "/opt/compiler-explorer"
+    dst: "/opt/compiler-explorer"
+    is_bind: true
+}
+
+# TODO: seccomp

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -139,6 +139,41 @@ function executeDirect(command, args, options, filenameTransform) {
     });
 }
 
+function withNsjailTimeout(args, options) {
+    if (options && options.timeoutMs) {
+        const ExtraWallClockLeewayMs = 1000;
+        return args.concat([
+            '--time_limit',
+            `${Math.round((options.timeoutMs + ExtraWallClockLeewayMs) / 1000)}`
+        ]);
+    }
+    return args;
+}
+
+function sandboxNsjail(command, args, options) {
+    logger.info("Sandbox execution via nsjail", {command, args});
+    const execPath = path.dirname(command);
+    const execName = path.basename(command);
+
+    const jailingOptions = withNsjailTimeout([
+        '--config', 'etc/nsjail/sandbox.cfg',
+        '--cwd', '/app',
+        '--bindmount', `${execPath}:/app`,
+    ]);
+
+    if (options.ldPath) {
+        jailingOptions.push(`--env=LD_LIBRARY_PATH=${options.ldPath}`);
+        delete options.ldPath;
+    }
+
+    return executeDirect(
+        execProps("nsjail"),
+        jailingOptions
+            .concat(['--', `./${execName}`])
+            .concat(args),
+        options);
+}
+
 // function msToFjTimeout(ms) {
 //     const totalSecs = Math.round(ms / 1000);
 //     return `${Math.floor(totalSecs / (60 * 60))}:${Math.floor(totalSecs / 60)}:${totalSecs % 60}`;
@@ -187,6 +222,7 @@ const sandboxDispatchTable = {
         logger.info("Sandbox execution (sandbox disabled)", {command, args});
         return executeDirect(command, args, options);
     },
+    nsjail: sandboxNsjail,
     firejail: sandboxFirejail
 };
 


### PR DESCRIPTION
You must compile [nsjail](https://github.com/google/nsjail) and manually put the resulting binary somewhere on your path - nsjail does not have a `make install` target.

Due to lack of seccomp policies I would not consider this ready to be deployed publicly - but it may be useful to have this temporarily deployed to beta to facilitate testing with all supported compilers.

# Notes
You must run the following as root after each system reboot to create the required cgroups before starting CE
```
cgcreate -a ubuntu:ubuntu -g memory,pids,cpu,net_cls:ce-sandbox
```

# TODO
- [ ] seccomp policies
- [ ] test with various languages to see if any runtimes get upset about lack of `/etc` and other directory structures
- [ ] execution support to allow compilers under nsjail
- [ ] figure out how wine will work under nsjail

# Test bench to explore sandbox environment
https://godbolt.org/z/a8eItT

Results running under nsjail locally
https://gist.github.com/apmorton/088daf802689fc55fcef0283d60cd8bc