### PR TITLE
Add arduino compilers, with uno and mega platform specifics

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -371,7 +371,7 @@ compiler.armce820.supportsBinary=false
 
 ###############################
 # Platform Specific Cross Compilers
-group.platspec.compilers=frc2019:raspbian9
+group.platspec.compilers=frc2019:raspbian9:arduinouno:arduinomega
 group.platspec.groupName=Platform Specific Compilers
 group.platspec.isSemVer=true
 group.platspec.includeFlag=-I
@@ -383,6 +383,16 @@ compiler.raspbian9.exe=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbi
 compiler.raspbian9.name=Raspbian Stretch
 compiler.raspbian9.semver=6.3
 compiler.raspbian9.objdumper=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbian9-linux-gnueabihf-objdump
+compiler.arduinouno.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
+compiler.arduinouno.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/standard -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
+compiler.arduinouno.name=Arduino Uno
+compiler.arduinouno.semver=5.4.0
+compiler.arduinouno.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+compiler.arduinouno.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
+compiler.arduinouno.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega2560 -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_MEGA2560 -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/mega -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
+compiler.arduinouno.name=Arduino Mega
+compiler.arduinouno.semver=5.4.0
+compiler.arduinouno.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
 
 ################################
 # GCC for MSP
@@ -401,7 +411,7 @@ compiler.msp430g621.semver=6.2.1
 
 ################################
 # GCC for AVR
-group.avr.compilers=avrg454:avrg464
+group.avr.compilers=avrg454:avrg464:avr540
 group.avr.groupName=AVR GCC
 group.avr.baseName=AVR gcc
 group.avr.isSemVer=true
@@ -412,6 +422,11 @@ compiler.avrg454.supportsBinary=false
 compiler.avrg464.exe=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-g++
 compiler.avrg464.semver=4.6.4
 compiler.avrg464.objdumper=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-objdump
+compiler.avr540.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
+compiler.avr540.alias=avr540
+compiler.avr540.semver=5.4.0
+compiler.avr540.supportsBinary=false
+compiler.avr540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
 
 ###############################
 # GCC for MIPS

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -371,7 +371,7 @@ compiler.armce820.supportsBinary=false
 
 ###############################
 # Platform Specific Cross Compilers
-group.platspec.compilers=frc2019:raspbian9:arduinouno:arduinomega
+group.platspec.compilers=frc2019:raspbian9:arduinouno189:arduinomega189
 group.platspec.groupName=Platform Specific Compilers
 group.platspec.isSemVer=true
 group.platspec.includeFlag=-I
@@ -383,16 +383,16 @@ compiler.raspbian9.exe=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbi
 compiler.raspbian9.name=Raspbian Stretch
 compiler.raspbian9.semver=6.3
 compiler.raspbian9.objdumper=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbian9-linux-gnueabihf-objdump
-compiler.arduinouno.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
-compiler.arduinouno.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/standard -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
-compiler.arduinouno.name=Arduino Uno
-compiler.arduinouno.semver=5.4.0
-compiler.arduinouno.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
-compiler.arduinouno.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
-compiler.arduinouno.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega2560 -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_MEGA2560 -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/mega -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
-compiler.arduinouno.name=Arduino Mega
-compiler.arduinouno.semver=5.4.0
-compiler.arduinouno.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+compiler.arduinouno189.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
+compiler.arduinouno189.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/standard -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
+compiler.arduinouno189.name=Arduino Uno (1.8.9)
+compiler.arduinouno189.semver=5.4.0
+compiler.arduinouno189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+compiler.arduinomega189.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
+compiler.arduinomega189.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega2560 -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_MEGA2560 -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/mega -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
+compiler.arduinomega189.name=Arduino Mega (1.8.9)
+compiler.arduinomega189.semver=5.4.0
+compiler.arduinomega189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
 
 ################################
 # GCC for MSP
@@ -411,7 +411,7 @@ compiler.msp430g621.semver=6.2.1
 
 ################################
 # GCC for AVR
-group.avr.compilers=avrg454:avrg464:avr540
+group.avr.compilers=avrg454:avrg464:avrg540
 group.avr.groupName=AVR GCC
 group.avr.baseName=AVR gcc
 group.avr.isSemVer=true
@@ -422,11 +422,11 @@ compiler.avrg454.supportsBinary=false
 compiler.avrg464.exe=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-g++
 compiler.avrg464.semver=4.6.4
 compiler.avrg464.objdumper=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-objdump
-compiler.avr540.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
-compiler.avr540.alias=avr540
-compiler.avr540.semver=5.4.0
-compiler.avr540.supportsBinary=false
-compiler.avr540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+compiler.avrg540.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
+compiler.avrg540.alias=avrg540
+compiler.avrg540.semver=5.4.0
+compiler.avrg540.supportsBinary=false
+compiler.avrg540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
 
 ###############################
 # GCC for MIPS

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -423,7 +423,6 @@ compiler.avrg464.exe=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-g++
 compiler.avrg464.semver=4.6.4
 compiler.avrg464.objdumper=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-objdump
 compiler.avrg540.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
-compiler.avrg540.alias=avrg540
 compiler.avrg540.semver=5.4.0
 compiler.avrg540.supportsBinary=false
 compiler.avrg540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -278,7 +278,7 @@ compiler.carmce820.semver=8.2.0
 
 ###############################
 # Platform Specific Cross Compilers
-group.cplatspec.compilers=cfrc2019:craspbian9
+group.cplatspec.compilers=cfrc2019:craspbian9:carduinouno:carduinomega
 group.cplatspec.groupName=Platform Specific Compilers
 group.cplatspec.isSemVer=true
 group.cplatspec.includeFlag=-I
@@ -290,6 +290,16 @@ compiler.craspbian9.exe=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspb
 compiler.craspbian9.name=Raspbian Stretch
 compiler.craspbian9.semver=6.3
 compiler.craspbian9.objdumper=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbian9-linux-gnueabihf-objdump
+compiler.arduinouno.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-gcc
+compiler.arduinouno.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/standard -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
+compiler.arduinouno.name=Arduino Uno
+compiler.arduinouno.semver=5.4.0
+compiler.arduinouno.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+compiler.arduinouno.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-gcc
+compiler.arduinouno.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega2560 -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_MEGA2560 -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/mega -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
+compiler.arduinouno.name=Arduino Mega
+compiler.arduinouno.semver=5.4.0
+compiler.arduinouno.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
 
 ################################
 # GCC for MSP
@@ -306,7 +316,7 @@ compiler.cmsp430g621.semver=6.2.1
 
 ################################
 # GCC for AVR
-group.cavr.compilers=cavrg454:cavrg464
+group.cavr.compilers=cavrg454:cavrg464:cavrg540
 group.cavr.groupName=AVR GCC
 group.cavr.baseName=AVR gcc
 group.cavr.isSemVer=true
@@ -314,6 +324,11 @@ compiler.cavrg454.exe=/opt/compiler-explorer/avr/gcc-4.5.4/bin/avr-gcc
 compiler.cavrg454.semver=4.5.4
 compiler.cavrg464.exe=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-gcc
 compiler.cavrg464.semver=4.6.4
+compiler.avrg540.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
+compiler.avrg540.alias=avrg540
+compiler.avrg540.semver=5.4.0
+compiler.avrg540.supportsBinary=false
+compiler.avrg540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
 
 ###############################
 # GCC for MIPS

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -324,11 +324,11 @@ compiler.cavrg454.exe=/opt/compiler-explorer/avr/gcc-4.5.4/bin/avr-gcc
 compiler.cavrg454.semver=4.5.4
 compiler.cavrg464.exe=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-gcc
 compiler.cavrg464.semver=4.6.4
-compiler.avrg540.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
-compiler.avrg540.alias=avrg540
-compiler.avrg540.semver=5.4.0
-compiler.avrg540.supportsBinary=false
-compiler.avrg540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+compiler.cavrg540.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
+compiler.cavrg540.alias=avrg540
+compiler.cavrg540.semver=5.4.0
+compiler.cavrg540.supportsBinary=false
+compiler.cavrg540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
 
 ###############################
 # GCC for MIPS

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -325,7 +325,6 @@ compiler.cavrg454.semver=4.5.4
 compiler.cavrg464.exe=/opt/compiler-explorer/avr/gcc-4.6.4/bin/avr-gcc
 compiler.cavrg464.semver=4.6.4
 compiler.cavrg540.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-g++
-compiler.cavrg540.alias=avrg540
 compiler.cavrg540.semver=5.4.0
 compiler.cavrg540.supportsBinary=false
 compiler.cavrg540.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -278,7 +278,7 @@ compiler.carmce820.semver=8.2.0
 
 ###############################
 # Platform Specific Cross Compilers
-group.cplatspec.compilers=cfrc2019:craspbian9:carduinouno:carduinomega
+group.cplatspec.compilers=cfrc2019:craspbian9:carduinouno189:carduinomega189
 group.cplatspec.groupName=Platform Specific Compilers
 group.cplatspec.isSemVer=true
 group.cplatspec.includeFlag=-I
@@ -290,16 +290,16 @@ compiler.craspbian9.exe=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspb
 compiler.craspbian9.name=Raspbian Stretch
 compiler.craspbian9.semver=6.3
 compiler.craspbian9.objdumper=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbian9-linux-gnueabihf-objdump
-compiler.arduinouno.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-gcc
-compiler.arduinouno.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/standard -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
-compiler.arduinouno.name=Arduino Uno
-compiler.arduinouno.semver=5.4.0
-compiler.arduinouno.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
-compiler.arduinouno.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-gcc
-compiler.arduinouno.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega2560 -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_MEGA2560 -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/mega -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
-compiler.arduinouno.name=Arduino Mega
-compiler.arduinouno.semver=5.4.0
-compiler.arduinouno.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+compiler.carduinouno189.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-gcc
+compiler.carduinouno189.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/standard -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
+compiler.carduinouno198.name=Arduino Uno (1.8.9)
+compiler.carduinouno189.semver=5.4.0
+compiler.carduinouno189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
+compiler.carduinomega189.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-gcc
+compiler.carduinomega189.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega2560 -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_MEGA2560 -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/mega -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
+compiler.carduinomega189.name=Arduino Mega (1.8.9)
+compiler.carduinomega189.semver=5.4.0
+compiler.carduinomega189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
 
 ################################
 # GCC for MSP


### PR DESCRIPTION
Depends on https://github.com/mattgodbolt/compiler-explorer-image/pull/223

Adds the 5.4.0 compiler from the arduino build, and platform specifics for arduino uno and arduino mega. These will allow #include <Arduino.h> as well for the platform specifics, with the proper things defined to make them work properly.