### PR TITLE
Correct typo in /etc/config/c.amazon.properties

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -292,7 +292,7 @@ compiler.craspbian9.semver=6.3
 compiler.craspbian9.objdumper=/opt/compiler-explorer/arm/raspbian9-6.3.0/bin/arm-raspbian9-linux-gnueabihf-objdump
 compiler.carduinouno189.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-gcc
 compiler.carduinouno189.options=-std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10809 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/variants/standard -I/opt/compiler-explorer/avr/arduino-1.8.9/hardware/arduino/avr/cores/arduino
-compiler.carduinouno198.name=Arduino Uno (1.8.9)
+compiler.carduinouno189.name=Arduino Uno (1.8.9)
 compiler.carduinouno189.semver=5.4.0
 compiler.carduinouno189.objdumper=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-objdump
 compiler.carduinomega189.exe=/opt/compiler-explorer/avr/arduino-1.8.9/hardware/tools/avr/bin/avr-gcc


### PR DESCRIPTION
This changes "carduinouno198" to "carduinouno189" in the name line. The typo caused the ID to be displayed as the name on godbolt.org.

I didn't really test anything (I'm actually doing this entire thing from the Github website :stuck_out_tongue:), but I doubt I managed to break anything by correcting this typo
