### PR TITLE
Alternative UI layout for Executor pane

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -351,6 +351,7 @@ class BaseCompiler {
                 dirResult.inputFilename, this.getDefaultExecOptions())
                 .then(result => {
                     result.executableFilename = outputFilename;
+                    result.compilationOptions = compilerArguments;
                     return result;
                 });
         });

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -165,6 +165,16 @@ Executor.prototype.updateAndCalcTopBarHeight = function () {
         this.hideable.show();
     }
 
+    if (!this.panelCompilation.hasClass('d-none')) {
+        topBarHeight += this.panelCompilation.outerHeight(true);
+    }
+    if (!this.panelArgs.hasClass('d-none')) {
+        topBarHeight += this.panelArgs.outerHeight(true);
+    }
+    if (!this.panelStdin.hasClass('d-none')) {
+        topBarHeight += this.panelStdin.outerHeight(true);
+    }
+
     return topBarHeight;
 };
 
@@ -433,6 +443,14 @@ Executor.prototype.initButtons = function (state) {
 
     this.hideable = this.domRoot.find('.hideable');
     this.statusIcon = this.domRoot.find('.status-icon');
+
+    this.panelCompilation = this.domRoot.find('.panel-compilation');
+    this.panelArgs = this.domRoot.find('.panel-args');
+    this.panelStdin = this.domRoot.find('.panel-stdin');
+
+    this.toggleCompilation = this.domRoot.find('.toggle-compilation');
+    this.toggleArgs = this.domRoot.find('.toggle-args');
+    this.toggleStdin = this.domRoot.find('.toggle-stdin');
 };
 
 Executor.prototype.onLibsChanged = function () {
@@ -466,6 +484,18 @@ Executor.prototype.initListeners = function () {
     this.eventHub.on('resize', this.resize, this);
 
     this.eventHub.on('languageChange', this.onLanguageChange, this);
+};
+
+Executor.prototype.togglePanel = function (button, panel) {
+    if (panel.hasClass('d-none')) {
+        panel.removeClass('d-none');
+        button.addClass('active');
+    } else {
+        panel.addClass('d-none');
+        button.removeClass('active');
+    }
+
+    this.resize();
 };
 
 Executor.prototype.initCallbacks = function () {
@@ -505,6 +535,18 @@ Executor.prototype.initCallbacks = function () {
         if (e.which === 27) {
             this.libsButton.popover('hide');
         }
+    }, this));
+
+    this.toggleCompilation.on('click', _.bind(function () {
+        this.togglePanel(this.toggleCompilation, this.panelCompilation);
+    }, this));
+
+    this.toggleArgs.on('click', _.bind(function() {
+        this.togglePanel(this.toggleArgs, this.panelArgs)
+    }, this));
+
+    this.toggleStdin.on('click', _.bind(function() {
+        this.togglePanel(this.toggleStdin, this.panelStdin);
     }, this));
 
     // Dismiss on any click that isn't either in the opening element, inside

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -173,7 +173,11 @@
 
   #executor
     .top-bar.btn-toolbar.bg-light(role="toolbar")
-      button.btn.btn-light.btn-sm.toggle-compilation
+      include font-size
+        button.btn.btn-light.btn-sm.show-libs.dropdown-toggle(title="Include libs" aria-label="Toggle libraries dropdown" aria-pressed="false" aria-haspopup="true")
+          span.fas.fa-book
+          span.hideable &nbsp;Libraries
+      button.btn.btn-light.btn-sm.toggle-compilation.active
         span.fas.fa-cogs
         span.hideable &nbsp;Compilation
       button.btn.btn-light.btn-sm.toggle-args
@@ -182,14 +186,10 @@
       button.btn.btn-light.btn-sm.toggle-stdin
         span.fas.fa-sign-in-alt
         span.hideable &nbsp;Stdin
-      button.btn.btn-light.btn-sm.toggle-stdout.active
+      button.btn.btn-light.btn-sm.toggle-stdout.active.disabled
         span.fas.fa-sign-out-alt
         span.hideable &nbsp;Stdout
-      include font-size
-      button.btn.btn-light.btn-sm.show-libs.dropdown-toggle(title="Include libs" aria-label="Toggle libraries dropdown" aria-pressed="false" aria-haspopup="true")
-        span.fas.fa-book
-        span.hideable &nbsp;Libraries
-    .top-bar.btn-toolbar.bg-light.panel-compilation.d-none(role="toolbar")
+    .top-bar.btn-toolbar.bg-light.panel-compilation(role="toolbar")
       .btn-group.btn-group-sm(role="group" aria-label="Compiler picker")
         select.compiler-picker(placeholder="Select a compiler...")
         .input-group.mb-auto

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -173,6 +173,23 @@
 
   #executor
     .top-bar.btn-toolbar.bg-light(role="toolbar")
+      button.btn.btn-light.btn-sm.toggle-compilation
+        span.fas.fa-cogs
+        span.hideable &nbsp;Compilation
+      button.btn.btn-light.btn-sm.toggle-args
+        span.fas.fa-terminal
+        span.hideable &nbsp;Arguments
+      button.btn.btn-light.btn-sm.toggle-stdin
+        span.fas.fa-sign-in-alt
+        span.hideable &nbsp;Stdin
+      button.btn.btn-light.btn-sm.toggle-stdout.active
+        span.fas.fa-sign-out-alt
+        span.hideable &nbsp;Stdout
+      include font-size
+      button.btn.btn-light.btn-sm.show-libs.dropdown-toggle(title="Include libs" aria-label="Toggle libraries dropdown" aria-pressed="false" aria-haspopup="true")
+        span.fas.fa-book
+        span.hideable &nbsp;Libraries
+    .top-bar.btn-toolbar.bg-light.panel-compilation.d-none(role="toolbar")
       .btn-group.btn-group-sm(role="group" aria-label="Compiler picker")
         select.compiler-picker(placeholder="Select a compiler...")
         .input-group.mb-auto
@@ -180,15 +197,10 @@
             button.input-group-text.prepend-options(data-trigger="click" style="cursor: pointer;" role="button" title="All compilation options")
               span.btn.btn-light.btn-sm.status-icon
           input.compilation-options.form-control(type="text" placeholder="Compiler options..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
-          input.execution-arguments.form-control(type="text" placeholder="Execution arguments..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
-      include font-size
-      .btn-group.btn-group-sm(role="group" aria-label="Compiler additions")
-        button.btn.btn-light.btn-sm.show-libs.dropdown-toggle(title="Include libs" aria-label="Toggle libraries dropdown" aria-pressed="false" aria-haspopup="true")
-          span.fas.fa-book
-          span.hideable &nbsp;Libraries
-      .btn-group.btn-group-sm(role="group" aria-label="Execution stdin")
-        .input-group.mb-auto
-          textarea.execution-stdin.form-control(placeholder="Execution stdin..." cols="1024" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-multiline="false" style="resize: none")
+    .top-bar.btn-toolbar.bg-light.panel-args.d-none(role="toolbar")
+      input.execution-arguments.form-control(type="text" placeholder="Execution arguments..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
+    .top-bar.btn-toolbar.bg-light.panel-stdin.d-none(role="toolbar")
+      textarea.execution-stdin.form-control(placeholder="Execution stdin..." cols="1024" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-multiline="false" style="resize: none")
     pre.content
     .bottom-bar.bg-light
       span.short-compiler-name


### PR DESCRIPTION
Divides up the different parts of execution, and adds toggle buttons to turn those parts on and off.

**Just Stdout active**
![image](https://user-images.githubusercontent.com/442630/59980795-e356f400-95fa-11e9-9591-a3e33c25ca0e.png)

**Arguments and Stdin**
![image](https://user-images.githubusercontent.com/442630/59980825-3761d880-95fb-11e9-90ce-6c81f77b0ea0.png)

**Everything on**
![image](https://user-images.githubusercontent.com/442630/59980785-c8847f80-95fa-11e9-8963-97be1c949652.png)

**Hidden labels**
![image](https://user-images.githubusercontent.com/442630/59980848-89a2f980-95fb-11e9-9715-2ad516e2e78e.png)

