### PR TITLE
Add direct rust demangler

### DIFF
--- a/etc/config/rust.defaults.properties
+++ b/etc/config/rust.defaults.properties
@@ -2,6 +2,7 @@ compilers=/usr/local/bin/rustc
 supportsBinary=false
 compilerType=rust
 demangler=${ceToolsPath}/rust/bin/rustfilt
+demanglerClassFile=./demangler-rust-direct
 objdumper=objdump
 stubRe=\bmain\b
 stubText=pub fn main() {/*stub provided by Compiler Explorer*/}

--- a/lib/demangler-rust-direct.js
+++ b/lib/demangler-rust-direct.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const
+    Demangler = require("./demangler").Demangler,
+    utils = require('./utils');
+
+class DemanglerRustDirect extends Demangler {
+    getInput() {
+        this.input = this.result.asm.map(line => line.text);
+        return this.input.join("\n");
+    }
+
+    processOutput(output) {
+        const lines = utils.splitLines(output.stdout);
+        for (let i = 0; i < this.result.asm.length; ++i) {
+            this.result.asm[i].text = lines[i];
+        }
+
+        return this.result;
+    }
+}
+
+exports.Demangler = DemanglerRustDirect;


### PR DESCRIPTION
`rustfilt` is able to demangle the asm file on its own, implement a direct `rust` demangler that demangles lines one-by-one directly instead of using all the logic of `demangler.js`. This fixes some cases where symbols would not get demangled properly, for example `std::io::stdio::__print@GOTPCREL`
![Screenshot 2019-06-28 at 19 46 46](https://user-images.githubusercontent.com/40798022/60367620-8b4b3380-99e6-11e9-91eb-a2f326beb0d5.png)
![Screenshot 2019-06-28 at 19 46 57](https://user-images.githubusercontent.com/40798022/60367622-8be3ca00-99e6-11e9-9375-f28447a0745d.png)

