### PR TITLE
Trims dist output and makes test run only once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ static/vs
 lib/storage/data
 f.out
 /.nyc_output
+/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ node_js:
     - "10"
 
 script:
-    - npm run check
-    - npm run codecov
+    - npm run ci-lint
+    - npm run test
     - make changelog
     - make policies
     - make -j$(nproc) travis-dist
@@ -22,3 +22,5 @@ deploy:
     acl: public_read
     local_dir: out/dist-bin
     upload-dir: dist/travis/${TRAVIS_BRANCH}
+
+after_success: npm run codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 
 script:
     - npm run ci-lint
-    - npm run test
+    - npm run ci-test
     - make changelog
     - make policies
     - make -j$(nproc) travis-dist

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ dist: prereqs  ## Creates a distribution
 	echo ${HASH} > out/dist/git_hash
 
 travis-dist: dist  ## Creates a distribution as if we were running on travis
-	tar --exclude './.travis-compilers' --exclude './.git' --exclude './static' -Jcf /tmp/ce-build.tar.xz .
+	tar --exclude './.travis-compilers' --exclude './.git' --exclude './static' --exclude './.github' --exclude './.idea' --exclude './.nyc_output' --exclude './coverage' --exclude './test' -Jcf /tmp/ce-build.tar.xz .
 	rm -rf out/dist-bin
 	mkdir -p out/dist-bin
 	mv /tmp/ce-build.tar.xz out/dist-bin/${TRAVIS_BUILD_NUMBER}.tar.xz

--- a/package.json
+++ b/package.json
@@ -91,16 +91,15 @@
     "webpack-manifest-plugin": "^1.3.2"
   },
   "scripts": {
+    "ci-lint": "eslint --config static/.eslintrc --ignore-path static/.eslintignore ./static/*.js ./static/panes/*.js ./static/modes/*.js && eslint --config .eslintrc --ignore-path .eslintignore ./app.js ./lib/**",
     "lint-client": "eslint --config static/.eslintrc --ignore-path static/.eslintignore --fix ./static/*.js ./static/panes/*.js ./static/modes/*.js",
     "lint-server": "eslint --config .eslintrc --ignore-path .eslintignore --fix ./app.js ./lib/**",
     "lint": "npm run lint-client && npm run lint-server",
-    "test": "mocha --recursive",
+    "test": "nyc --reporter=lcov mocha --recursive",
     "check": "npm run lint && npm run test",
     "dev": "cross-env NODE_ENV=DEV node app.js",
     "start": "npx webpack && cross-env NODE_ENV=LOCAL node app.js",
-    "codecov": "nyc --report lcovonly mocha -R spec --recursive && codecov",
-    "coverage": "nyc --report lcovonly mocha -R spec --recursive",
-    "localcoverage": "nyc --report html mocha -R spec --recursive"
+    "codecov": "codecov"
   },
   "license": "BSD-2-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -92,10 +92,11 @@
   },
   "scripts": {
     "ci-lint": "eslint --config static/.eslintrc --ignore-path static/.eslintignore ./static/*.js ./static/panes/*.js ./static/modes/*.js && eslint --config .eslintrc --ignore-path .eslintignore ./app.js ./lib/**",
+    "ci-test": "nyc --reporter=lcov mocha --recursive",
     "lint-client": "eslint --config static/.eslintrc --ignore-path static/.eslintignore --fix ./static/*.js ./static/panes/*.js ./static/modes/*.js",
     "lint-server": "eslint --config .eslintrc --ignore-path .eslintignore --fix ./app.js ./lib/**",
     "lint": "npm run lint-client && npm run lint-server",
-    "test": "nyc --reporter=lcov mocha --recursive",
+    "test": "mocha --recursive",
     "check": "npm run lint && npm run test",
     "dev": "cross-env NODE_ENV=DEV node app.js",
     "start": "npx webpack && cross-env NODE_ENV=LOCAL node app.js",

--- a/static/main.js
+++ b/static/main.js
@@ -28,7 +28,6 @@ require("monaco-loader")().then(function () {
     require('bootstrap');
     require('bootstrap-slider');
 
-
     var analytics = require('./analytics');
     var sharing = require('./sharing');
     var _ = require('underscore');

--- a/static/main.js
+++ b/static/main.js
@@ -27,7 +27,8 @@ require("monaco-loader")().then(function () {
     require('popper.js');
     require('bootstrap');
     require('bootstrap-slider');
-    console.log("Forcing tests not to pass on CI with this.");
+
+
     var analytics = require('./analytics');
     var sharing = require('./sharing');
     var _ = require('underscore');

--- a/static/main.js
+++ b/static/main.js
@@ -27,7 +27,7 @@ require("monaco-loader")().then(function () {
     require('popper.js');
     require('bootstrap');
     require('bootstrap-slider');
-
+    console.log("Forcing tests not to pass on CI with this.");
     var analytics = require('./analytics');
     var sharing = require('./sharing');
     var _ = require('underscore');


### PR DESCRIPTION
 - Excludes `.github`, `.idea`, `.nyc_output`, `coverage` and `tests` from the dist output file generated by Travis.
 - Makes the linter not waste time fixing the errors that it finds on the files (With the drawback of having to duplicate some lines. Maybe there's a way to pass arguments to npm scripts? Would be great to hear about those
 - Tests should now run only once. The codecov report is generated directly from the test pass