### PR TITLE
Override monaco line number cursor to work around comically large cursors on high DPI systems

### DIFF
--- a/static/explorer.css
+++ b/static/explorer.css
@@ -6,6 +6,11 @@
     margin-left: 0;
 }
 
+/* workaround high DPI issues in monaco. SEE: https://github.com/mattgodbolt/compiler-explorer/issues/1488 */
+.monaco-editor .margin-view-overlays .line-numbers {
+    cursor: default !important;
+}
+
 /*
  * https://github.com/Microsoft/monaco-editor/issues/417
  * Safari 10.1, fails inherit correct visibility from parent when we change the visibility of parent element from hidden to inherit, in this particular case.


### PR DESCRIPTION
Closes #1488 