### PR TITLE
Compile API supplying libraries

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -36,7 +36,9 @@ Returns a list of compilers for the provided language id. In text form,
 Returns a list of libraries and library versions available for the provided language id.
  This request only returns data in JSON.
 
-You can use the given include paths to supply in the userArguments for compilation.
+You can use the given include paths to supply in the userArguments for compilation. *(deprecated)*
+
+You will need the library id's and the version id's to supply to **compile** if you want to include libraries during compilation.
 
 ###  `GET /api/shortlinkinfo/<linkid>` - return information about a given link
 
@@ -56,7 +58,8 @@ To specify a compilation request as a JSON document, post it as the appropriate
         "filters": {
             "filter": true
         },
-        "tools": []
+        "tools": [],
+        "libraries": []
     }
 }
 ``` 
@@ -82,6 +85,9 @@ With the tools array you can ask CE to execute certain tools available for
  the current compiler, and also supply arguments for this tool.
  For example: ```"tools": [{"id":"clangtidytrunk","args":"-checks=*"}]```
  to execute clang-tidy with all checks enabled.
+
+Libraries can be included by supplying the library id and versions in an array, for example:
+ ```[{"id": "range-v3", "version": "trunk"}, {"id": "fmt", "version": "400"}]```
 
 The text request is designed for simplicity for command-line clients like `curl`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -56,13 +56,26 @@ To specify a compilation request as a JSON document, post it as the appropriate
         "userArguments": "Compiler flags",
         "compilerOptions": {},
         "filters": {
-            "filter": true
+             "binary": false,
+             "commentOnly": true,
+             "demangle": true,
+             "directives": true,
+             "execute": false,
+             "intel": true,
+             "labels": true,
+             "libraryCode": false,
+             "trim": false
         },
-        "tools": [],
-        "libraries": []
+        "tools": [
+             {"id":"clangtidytrunk", "args":"-checks=*"}
+        ],
+        "libraries": [
+             {"id": "range-v3", "version": "trunk"},
+             {"id": "fmt", "version": "400"}
+        ]
     }
 }
-``` 
+```
 
 The filters are a JSON object with `true`/`false` values. If not supplied,
  defaults are used. If supplied, the filters are used as-is.
@@ -71,23 +84,29 @@ The filters are a JSON object with `true`/`false` values. If not supplied,
 
 To force a cache bypass, set `bypassCache` in the root of the request to `true`.
 
+Filters include `binary`, `labels`, `intel`, `directives` and
+ `demangle`, which correspond to the UI buttons on the HTML version.
+
+With the tools array you can ask CE to execute certain tools available for
+ the current compiler, and also supply arguments for this tool.
+
+Libraries can be marked to have their directories available when including
+ their header files. The can be listed by supplying the library ids and versions in an array.
+ The id's to supply can be found with the `/api/libraries/<language-id>`
+
+
+# Non-REST API's
+
+### `POST /api/compiler/<compiler-id>/compile` - perform a compilation
+
+This is same endpoint as for compilation using JSON.
+
 A text compilation request has the source as the body of the post, and uses
  query parameters to pass the options and filters. Filters are supplied as a
  comma-separated string. Use the query parameter `filters=XX` to set the
  filters directly, else `addFilters=XX` to add a filter to defaults,
  or `removeFilters` to remove from defaults.
  Compiler parameters should be passed as `options=-O2` and default to empty.
-
-Filters include `binary`, `labels`, `intel`, `comments`, `directives` and
- `demangle`, which correspond to the UI buttons on the HTML version.
-
-With the tools array you can ask CE to execute certain tools available for
- the current compiler, and also supply arguments for this tool.
- For example: ```"tools": [{"id":"clangtidytrunk","args":"-checks=*"}]```
- to execute clang-tidy with all checks enabled.
-
-Libraries can be included by supplying the library id and versions in an array, for example:
- ```[{"id": "range-v3", "version": "trunk"}, {"id": "fmt", "version": "400"}]```
 
 The text request is designed for simplicity for command-line clients like `curl`
 
@@ -144,8 +163,6 @@ If JSON is present in the request's `Accept` header, the compilation results
      }
 }
 ```
-
-# Not-so-RESTful API's
 
 ### `POST /shortener` - saves given state *forever* to a shortlink and returns the unique id for the link
 

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -203,7 +203,27 @@ class BaseCompiler {
         return options;
     }
 
-    prepareArguments(userOptions, filters, backendOptions, inputFilename, outputFilename) {
+    getIncludeArguments(libraries) {
+        const includeFlag = this.compiler.includeFlag || "-I";
+
+        return _.map(libraries, (selectedLib) => {
+            const foundLib = _.find(this.compiler.libs, (o, libId) => {
+                return (libId === selectedLib.id);
+            });
+
+            if (!foundLib) return false;
+
+            const foundVersion = _.find(foundLib.versions, (o, versionId) => {
+                return (versionId === selectedLib.version);
+            });
+
+            if (!foundVersion) return false;
+
+            return includeFlag + foundVersion.path;
+        });
+    }
+
+    prepareArguments(userOptions, filters, backendOptions, inputFilename, outputFilename, libraries) {
         let options = this.optionsForFilter(filters, outputFilename, userOptions);
         backendOptions = backendOptions || {};
 
@@ -215,8 +235,9 @@ class BaseCompiler {
             options = options.concat(this.compiler.optArg);
         }
 
+        const libIncludes = this.getIncludeArguments(libraries);
         userOptions = this.filterUserOptions(userOptions);
-        return options.concat(userOptions || []).concat([this.filename(inputFilename)]);
+        return libIncludes.concat(options).concat(userOptions || []).concat([this.filename(inputFilename)]);
     }
 
 
@@ -339,7 +360,8 @@ class BaseCompiler {
         buildFilters.execute = true;
 
         const compilerArguments = _.compact(
-            this.prepareArguments(key.options, buildFilters, key.backendOptions, inputFilename, outputFilename)
+            this.prepareArguments(key.options, buildFilters, key.backendOptions,
+                inputFilename, outputFilename, key.libraries)
         );
 
         const result = await this.buildExecutable(key.compiler.exe, compilerArguments, inputFilename,
@@ -409,11 +431,11 @@ class BaseCompiler {
         return result;
     }
 
-    getCacheKey(source, options, backendOptions, filters, tools) {
-        return {compiler: this.compiler, source, options, backendOptions, filters, tools};
+    getCacheKey(source, options, backendOptions, filters, tools, libraries) {
+        return {compiler: this.compiler, source, options, backendOptions, filters, tools, libraries};
     }
 
-    compile(source, options, backendOptions, filters, bypassCache, tools, executionParameters) {
+    compile(source, options, backendOptions, filters, bypassCache, tools, executionParameters, libraries) {
         const optionsError = this.checkOptions(options);
         if (optionsError) return Promise.reject(optionsError);
         const sourceError = this.checkSource(source);
@@ -428,7 +450,7 @@ class BaseCompiler {
             stdin: executionParameters.stdin || ""
         };
         delete options.executeParameters;
-        const key = this.getCacheKey(source, options, backendOptions, filters, tools);
+        const key = this.getCacheKey(source, options, backendOptions, filters, tools, libraries);
 
         const doExecute = filters.execute;
         filters = Object.assign({}, filters);
@@ -470,7 +492,8 @@ class BaseCompiler {
                             const outputFilename = this.getOutputFilename(dirPath, this.outputFilebase);
 
                             options = _.compact(
-                                this.prepareArguments(options, filters, backendOptions, inputFilename, outputFilename)
+                                this.prepareArguments(options, filters, backendOptions,
+                                    inputFilename, outputFilename, libraries)
                             );
 
                             const toolsPromise = this.runToolsOfType(

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -236,11 +236,12 @@ class BaseCompiler {
         }
 
         const libIncludes = this.getIncludeArguments(libraries);
-        userOptions = this.filterUserOptions(userOptions);
-        return libIncludes.concat(options).concat(userOptions || []).concat([this.filename(inputFilename)]);
+
+        userOptions = this.filterUserOptions(userOptions) || [];
+        return options.concat(libIncludes, userOptions, [this.filename(inputFilename)]);
     }
 
-
+    
     filterUserOptions(userOptions) {
         return userOptions;
     }

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -206,7 +206,7 @@ class BaseCompiler {
     getIncludeArguments(libraries) {
         const includeFlag = this.compiler.includeFlag || "-I";
 
-        return _.map(libraries, (selectedLib) => {
+        return _.flatten(_.map(libraries, (selectedLib) => {
             const foundLib = _.find(this.compiler.libs, (o, libId) => {
                 return (libId === selectedLib.id);
             });
@@ -219,8 +219,8 @@ class BaseCompiler {
 
             if (!foundVersion) return false;
 
-            return includeFlag + foundVersion.path;
-        });
+            return _.map(foundVersion.path, (path) => includeFlag + path);
+        }));
     }
 
     prepareArguments(userOptions, filters, backendOptions, inputFilename, outputFilename, libraries) {

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -181,6 +181,7 @@ class CompileHandler {
 
     parseRequest(req, compiler) {
         let source, options, backendOptions, filters, bypassCache = false, tools, executionParameters = {};
+        let libraries = [];
         // IF YOU MODIFY ANYTHING HERE PLEASE UPDATE THE DOCUMENTATION!
         if (req.is('json')) {
             // JSON-style request
@@ -195,6 +196,7 @@ class CompileHandler {
             backendOptions = requestOptions.compilerOptions;
             filters = requestOptions.filters || compiler.getDefaultFilters();
             tools = requestOptions.tools;
+            libraries = requestOptions.libraries || [];
         } else {
             // API-style
             source = req.body;
@@ -221,7 +223,7 @@ class CompileHandler {
         tools.forEach((tool) => {
             tool.args = this.splitArguments(tool.args);
         });
-        return {source, options, backendOptions, filters, bypassCache, tools, executionParameters};
+        return {source, options, backendOptions, filters, bypassCache, tools, executionParameters, libraries};
     }
 
     splitArguments(options) {
@@ -258,7 +260,7 @@ class CompileHandler {
             return next();
         }
         const {source, options, backendOptions, filters,
-            bypassCache, tools, executionParameters} = this.parseRequest(req, compiler);
+            bypassCache, tools, executionParameters, libraries} = this.parseRequest(req, compiler);
         const remote = compiler.getRemote();
         if (remote) {
             // Undo any routing that was done to get here (i.e. /api/* path has been removed)
@@ -279,7 +281,7 @@ class CompileHandler {
             return _.pluck(array || [], 'text').join("\n");
         }
 
-        compiler.compile(source, options, backendOptions, filters, bypassCache, tools, executionParameters)
+        compiler.compile(source, options, backendOptions, filters, bypassCache, tools, executionParameters, libraries)
             .then(result => {
                 if (req.accepts(['text', 'json']) === 'json') {
                     res.set('Content-Type', 'application/json');

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -168,7 +168,9 @@ class ClientOptionsHandler {
                                 this.compilerProps(lang, libVersionName + '.version');
                             const includes = this.compilerProps(lang, libVersionName + '.path');
                             libraries[lang][lib].versions[version].path = [];
-                            if (includes) {
+                            if (includes && (process.platform === "win32")) {
+                                libraries[lang][lib].versions[version].path = includes.split(';');
+                            } else if (includes) {
                                 libraries[lang][lib].versions[version].path = includes.split(':');
                             } else {
                                 logger.warn(`Library ${lib} ${version} (${lang}) has no include paths`);

--- a/static/libs-widget.js
+++ b/static/libs-widget.js
@@ -186,11 +186,11 @@ LibsWidget.prototype.listUsedLibs = function () {
 
 LibsWidget.prototype.getLibsInUse = function () {
     var libs = [];
-    _.each(this.availableLibs[this.currentLangId], function (library) {
+    _.each(this.availableLibs[this.currentLangId], function (library, libId) {
         _.each(library.versions, function (version, ver) {
             if (library.versions[ver].used) {
-                // We trust the invariant of only 1 used version at any given time per lib
-                libs.push(library.versions[ver]);
+                var libVer = Object.assign({libId: libId, versionId: ver}, library.versions[ver]);
+                libs.push(libVer);
             }
         });
     });

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -484,14 +484,17 @@ Compiler.prototype.compile = function (bypassCache, newTools) {
             produceIr: this.irViewOpen
         },
         filters: this.getEffectiveFilters(),
-        tools: this.getActiveTools(newTools)
+        tools: this.getActiveTools(newTools),
+        libraries: []
     };
-    var includeFlag = this.compiler ? this.compiler.includeFlag : '-I';
+
     _.each(this.libsWidget.getLibsInUse(), function (item) {
-        _.each(item.path, function (path) {
-            options.userArguments += ' ' + includeFlag + path;
+        options.libraries.push({
+            id: item.libId,
+            version: item.versionId
         });
     });
+
     this.compilerService.expand(this.source).then(_.bind(function (expanded) {
         var request = {
             source: expanded || '',

--- a/static/panes/conformance-view.js
+++ b/static/panes/conformance-view.js
@@ -306,16 +306,18 @@ Conformance.prototype.compileChild = function (child) {
             options: {
                 userArguments: child.find(".options").val() || "",
                 filters: {},
-                compilerOptions: {produceAst: false, produceOptInfo: false}
+                compilerOptions: {produceAst: false, produceOptInfo: false},
+                libraries: []
             }
         };
-        var compiler = this.compilerService.findCompiler(this.langId, picker.val());
-        var includeFlag = compiler ? compiler.includeFlag : '-I';
+
         _.each(this.libsWidget.getLibsInUse(), function (item) {
-            _.each(item.path, function (path) {
-                request.options.userArguments += ' ' + includeFlag + path;
+            request.options.libraries.push({
+                id: item.libId,
+                version: item.versionId
             });
         });
+    
         // This error function ensures that the user will know we had a problem (As we don't save asm)
         this.compilerService.submit(request)
             .then(_.bind(function (x) {

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -231,14 +231,17 @@ Executor.prototype.compile = function (bypassCache) {
             executorRequest: true
         },
         filters: {execute: true},
-        tools: []
+        tools: [],
+        libraries: []
     };
-    var includeFlag = this.compiler ? this.compiler.includeFlag : '-I';
+
     _.each(this.libsWidget.getLibsInUse(), function (item) {
-        _.each(item.path, function (path) {
-            options.userArguments += ' ' + includeFlag + path;
+        options.libraries.push({
+            id: item.libId,
+            version: item.versionId
         });
     });
+
     this.compilerService.expand(this.source).then(_.bind(function (expanded) {
         var request = {
             source: expanded || '',

--- a/test/options-handler.js
+++ b/test/options-handler.js
@@ -51,6 +51,10 @@ const libProps = {
     'libs.fakelib.versions.noPaths.path': ''
 };
 
+if (process.platform === "win32") {
+    libProps['libs.fakelib.versions.twoPaths.path'] = '/dev/null;/dev/urandom';
+}
+
 const compilerProps = new properties.CompilerProps(languages, properties.fakeProps(libProps));
 
 const optionsHandler = new OptionsHandler([], compilerProps, {});


### PR DESCRIPTION
Change in the Compile API to add libraries instead of having to manually supply include paths.

Added a small change to properties path splitting on win32 (didn't want to break current unix implementation)

With these changes, the compilation and executable caching key will change, but link sharing should remain intact.

Fixes https://github.com/mattgodbolt/compiler-explorer/issues/1478