### PR TITLE
Replace golden-layout icons with SVG versions to improve high DPI displays

### DIFF
--- a/static/themes/dark-theme.css
+++ b/static/themes/dark-theme.css
@@ -1,5 +1,26 @@
 @import url("~golden-layout/src/css/goldenlayout-dark-theme.css");
 
+/*
+ * replace low res golden-layout icons with svg recreations to improve high DPI displays
+ * not all icons in golden-layout are used, so we don't replace all of them
+ */
+.lm_header .lm_tab .lm_close_tab {
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23fff" d="M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z"/%3E%3C/svg%3E') !important;
+    background-size: 9px !important;
+}
+.lm_controls .lm_maximise {
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23fff" d="M0 4.5V0h9v9H0zM8 5V2H1v6h7z"/%3E%3C/svg%3E') !important;
+    background-size: 9px !important;
+}
+.lm_controls .lm_close {
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23fff" d="M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z"/%3E%3C/svg%3E') !important;
+    background-size: 9px !important;
+}
+.lm_maximised .lm_controls .lm_maximise {
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23fff" d="M1.0096 8.0019v-.99809h6.9807v1.9962H1.0096z"/%3E%3C/svg%3E') !important;
+    background-size: 9px !important;
+}
+
 body {
     background-color: #333 !important;
 }

--- a/static/themes/default-theme.css
+++ b/static/themes/default-theme.css
@@ -1,5 +1,26 @@
 @import url("~golden-layout/src/css/goldenlayout-light-theme.css");
 
+/*
+ * replace low res golden-layout icons with svg recreations to improve high DPI displays
+ * not all icons in golden-layout are used, so we don't replace all of them
+ */
+.lm_header .lm_tab .lm_close_tab {
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23000" d="M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z"/%3E%3C/svg%3E') !important;
+    background-size: 9px !important;
+}
+.lm_controls .lm_maximise {
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23000" d="M0 4.5V0h9v9H0zM8 5V2H1v6h7z"/%3E%3C/svg%3E') !important;
+    background-size: 9px !important;
+}
+.lm_controls .lm_close {
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23000" d="M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z"/%3E%3C/svg%3E') !important;
+    background-size: 9px !important;
+}
+.lm_maximised .lm_controls .lm_maximise {
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23000" d="M1.0096 8.0019v-.99809h6.9807v1.9962H1.0096z"/%3E%3C/svg%3E') !important;
+    background-size: 9px !important;
+}
+
 body {
     background-color: #FFFFFF;
 }


### PR DESCRIPTION
This should eventually be a patch for golden-layout.  I recreated the entire icon set for golden-layout and then went to submit a PR upstream only to find golden-layout is currently a bit of a mess.

Full icon set here for reference: https://gist.github.com/apmorton/56a1c54c20ada10e670066d2594d8bbb

Before/After at 400% zoom:
![image](https://user-images.githubusercontent.com/63636/61161870-e5aebe80-a4d3-11e9-9864-41339d7395e7.png)
![image](https://user-images.githubusercontent.com/63636/61161877-f52e0780-a4d3-11e9-9ada-76c4a157b0be.png)
