### PR TITLE
Move bulk of client side options to non-inlined script

### DIFF
--- a/app.js
+++ b/app.js
@@ -379,8 +379,9 @@ aws.initConfig(awsProps)
                 if (gitReleaseName) logger.info(`  git release ${gitReleaseName}`);
 
                 function renderConfig(extra) {
+                    const extraJson = JSON.stringify(extra);
                     const options = _.extend(extra, clientOptionsHandler.get());
-                    options.compilerExplorerOptions = JSON.stringify(options);
+                    options.compilerExplorerOptions = extraJson;
                     options.extraBodyClass = extraBodyClass;
                     options.httpRoot = httpRoot;
                     options.httpRootDir = httpRootDir;
@@ -617,6 +618,12 @@ aws.initConfig(awsProps)
                         res.render('sitemap');
                     })
                     .use(sFavicon(path.join(defArgs.staticDir, webpackConfig.output.publicPath, 'favicon.ico')))
+                    .get('/client-options.js', (req, res) => {
+                        staticHeaders(res);
+                        res.set('Content-Type', 'application/javascript');
+                        const options = JSON.stringify(clientOptionsHandler.get());
+                        res.end(`window.compilerExplorerOptions = ${options};`);
+                    })
                     .use(bodyParser.json({limit: ceProps('bodyParserLimit', maxUploadSize)}))
                     .use(bodyParser.text({limit: ceProps('bodyParserLimit', maxUploadSize), type: () => true}))
                     .use('/source', sourceHandler.handle.bind(sourceHandler))

--- a/app.js
+++ b/app.js
@@ -381,12 +381,12 @@ aws.initConfig(awsProps)
                 function renderConfig(extra) {
                     const extraJson = JSON.stringify(extra);
                     const options = _.extend(extra, clientOptionsHandler.get());
+                    options.optionsHash = clientOptionsHandler.getHash();
                     options.compilerExplorerOptions = extraJson;
                     options.extraBodyClass = extraBodyClass;
                     options.httpRoot = httpRoot;
                     options.httpRootDir = httpRootDir;
                     options.storageSolution = storageSolution;
-                    options.gitRelease = gitReleaseName;
                     options.require = function (path) {
                         if (isDevMode()) {
                             if (fs.existsSync('static/assets/' + path)) {

--- a/app.js
+++ b/app.js
@@ -386,6 +386,7 @@ aws.initConfig(awsProps)
                     options.httpRoot = httpRoot;
                     options.httpRootDir = httpRootDir;
                     options.storageSolution = storageSolution;
+                    options.gitRelease = gitReleaseName;
                     options.require = function (path) {
                         if (isDevMode()) {
                             if (fs.existsSync('static/assets/' + path)) {

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -117,6 +117,7 @@ class ClientOptionsHandler {
             },
             motdUrl: ceProps('motdUrl', '')
         };
+        this._updateOptionsHash();
     }
 
     parseTools(baseTools) {
@@ -215,10 +216,20 @@ class ClientOptionsHandler {
         });
 
         this.options.compilers = copiedCompilers;
+        this._updateOptionsHash();
+    }
+
+    _updateOptionsHash() {
+        this.optionsHash = getHash(this.options, "Options Hash V1");
+        logger.info(`OPTIONS HASH: ${this.optionsHash}`);
     }
 
     get() {
         return this.options;
+    }
+
+    getHash() {
+        return this.optionsHash;
     }
 
     static getFileHash(path) {

--- a/views/head.pug
+++ b/views/head.pug
@@ -32,7 +32,7 @@ style#theme
 // The atob/base64 stuff below is to prevent any XSS attacks: now we have user content in the options (from
 // short links), it's possible to do XSS attacks, by leaving <script> tags in the source etc, which can be
 // interpreted by the browser.
-script(src=httpRootDir + "client-options.js")
+script(src=httpRootDir + `client-options.js?hash=${gitRelease}`)
 script
   | var extraOptions = JSON.parse(decodeURIComponent("!{encodeURIComponent(compilerExplorerOptions)}"));
   | for (k in extraOptions) { window.compilerExplorerOptions[k] = extraOptions[k]; }

--- a/views/head.pug
+++ b/views/head.pug
@@ -32,6 +32,9 @@ style#theme
 // The atob/base64 stuff below is to prevent any XSS attacks: now we have user content in the options (from
 // short links), it's possible to do XSS attacks, by leaving <script> tags in the source etc, which can be
 // interpreted by the browser.
-script window.compilerExplorerOptions = JSON.parse(decodeURIComponent("!{encodeURIComponent(compilerExplorerOptions)}"))
+script(src=httpRootDir + "client-options.js")
+script
+  | var extraOptions = JSON.parse(decodeURIComponent("!{encodeURIComponent(compilerExplorerOptions)}"));
+  | for (k in extraOptions) { window.compilerExplorerOptions[k] = extraOptions[k]; }
 script window.httpRoot = '#{httpRoot}'; window.httpRootDir = '#{httpRootDir}';
 script(src=require("main.js"))

--- a/views/head.pug
+++ b/views/head.pug
@@ -32,7 +32,7 @@ style#theme
 // The atob/base64 stuff below is to prevent any XSS attacks: now we have user content in the options (from
 // short links), it's possible to do XSS attacks, by leaving <script> tags in the source etc, which can be
 // interpreted by the browser.
-script(src=httpRootDir + `client-options.js?hash=${gitRelease}`)
+script(src=`${httpRootDir}client-options.js?hash=${optionsHash}`)
 script
   | var extraOptions = JSON.parse(decodeURIComponent("!{encodeURIComponent(compilerExplorerOptions)}"));
   | for (k in extraOptions) { window.compilerExplorerOptions[k] = extraOptions[k]; }


### PR DESCRIPTION
This allows the client options to be cached between requests that currently would not be.

For example, someone visits `https://godbolt.org` (so their cache is populated locally), and then clicks a shared link: `https://godbolt.org/z/xxxx`.  Before this change the shared link response also must include the entire contents of the client side options.

After this change only the "extra" client side options are included in the html content.
The otherwise largely invariant bulk being in `/client-options.js`, which can be cached client side.

Locally I measured approximately a 300ms decrease in response time for `/` when applying this change. (using `make run`, refreshing the page several times before measuring to ensure the app is hot).

Additionally, because we include no user-controlled options in `/client-options.js` we do not have to apply the xss mitigations, which cuts the size in half and saves approximately 20ms in script execution time (measured with chrome performance profiler).