### PR TITLE
Fix support for IE11. Closes #1258

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2516,6 +2516,11 @@
         "es6-promise": "^4.0.3"
       }
     },
+    "es6-shim": {
+      "version": "0.35.5",
+      "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.5.tgz",
+      "integrity": "sha512-E9kK/bjtCQRpN1K28Xh4BlmP8egvZBGJJ+9GtnzOwt7mdqtrjHFuVGr7QJfdjBIKqrlU5duPf3pCBoDrkjVYFg=="
+    },
     "es6-templates": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cross-env": "^5.1.3",
     "denodeify": "^1.2.1",
     "es6-promise": "4.2.6",
+    "es6-shim": "^0.35.5",
     "express": "4.16.x",
     "file-saver": "^1.3.3",
     "fs-extra": "7.0.1",

--- a/static/main.js
+++ b/static/main.js
@@ -23,7 +23,6 @@
 // POSSIBILITY OF SUCH DAMAGE
 "use strict";
 
-require('es6-shim');
 require("monaco-loader")().then(function () {
     require('popper.js');
     require('bootstrap');

--- a/static/main.js
+++ b/static/main.js
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE
 "use strict";
 
+require('es6-shim');
 require("monaco-loader")().then(function () {
     require('popper.js');
     require('bootstrap');

--- a/static/themes/dark-theme.css
+++ b/static/themes/dark-theme.css
@@ -5,19 +5,19 @@
  * not all icons in golden-layout are used, so we don't replace all of them
  */
 .lm_header .lm_tab .lm_close_tab {
-    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23fff" d="M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z"/%3E%3C/svg%3E') !important;
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 9'%3E%3Cpath fill='%23fff' d='M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z'/%3E%3C/svg%3E") !important;
     background-size: 9px !important;
 }
 .lm_controls .lm_maximise {
-    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23fff" d="M0 4.5V0h9v9H0zM8 5V2H1v6h7z"/%3E%3C/svg%3E') !important;
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 9'%3E%3Cpath fill='%23fff' d='M0 4.5V0h9v9H0zM8 5V2H1v6h7z'/%3E%3C/svg%3E") !important;
     background-size: 9px !important;
 }
 .lm_controls .lm_close {
-    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23fff" d="M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z"/%3E%3C/svg%3E') !important;
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 9'%3E%3Cpath fill='%23fff' d='M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z'/%3E%3C/svg%3E") !important;
     background-size: 9px !important;
 }
 .lm_maximised .lm_controls .lm_maximise {
-    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23fff" d="M1.0096 8.0019v-.99809h6.9807v1.9962H1.0096z"/%3E%3C/svg%3E') !important;
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 9'%3E%3Cpath fill='%23fff' d='M1.0096 8.0019v-.99809h6.9807v1.9962H1.0096z'/%3E%3C/svg%3E") !important;
     background-size: 9px !important;
 }
 

--- a/static/themes/default-theme.css
+++ b/static/themes/default-theme.css
@@ -5,19 +5,19 @@
  * not all icons in golden-layout are used, so we don't replace all of them
  */
 .lm_header .lm_tab .lm_close_tab {
-    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23000" d="M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z"/%3E%3C/svg%3E') !important;
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 9'%3E%3Cpath fill='%23000' d='M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z'/%3E%3C/svg%3E") !important;
     background-size: 9px !important;
 }
 .lm_controls .lm_maximise {
-    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23000" d="M0 4.5V0h9v9H0zM8 5V2H1v6h7z"/%3E%3C/svg%3E') !important;
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 9'%3E%3Cpath fill='%23000' d='M0 4.5V0h9v9H0zM8 5V2H1v6h7z'/%3E%3C/svg%3E") !important;
     background-size: 9px !important;
 }
 .lm_controls .lm_close {
-    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23000" d="M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z"/%3E%3C/svg%3E') !important;
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 9'%3E%3Cpath fill='%23000' d='M.45713 8.5429l-.44426-.44438 3.5955-3.5956L.00697.90152l.8944-.89463 3.6016 3.6015 3.6014-3.6015.88867.88867-3.6014 3.6015 3.6014 3.6015-.89449.89449-3.6015-3.6014-3.5957 3.5956z'/%3E%3C/svg%3E") !important;
     background-size: 9px !important;
 }
 .lm_maximised .lm_controls .lm_maximise {
-    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 9"%3E%3Cpath fill="%23000" d="M1.0096 8.0019v-.99809h6.9807v1.9962H1.0096z"/%3E%3C/svg%3E') !important;
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 9 9'%3E%3Cpath fill='%23000' d='M1.0096 8.0019v-.99809h6.9807v1.9962H1.0096z'/%3E%3C/svg%3E") !important;
     background-size: 9px !important;
 }
 

--- a/views/monaco.pug
+++ b/views/monaco.pug
@@ -1,1 +1,9 @@
+// this must come before the monaco loader because otherwise the es6-shim script
+// detects the monaco loader's AMD module stuff and doesn't actually execute
+script
+  | if (window.navigator.userAgent.indexOf("Trident/") > 0) {
+  |   var s = document.createElement("script");
+  |   s.src = "#{httpRootDir}dist/es6-shim.min.js";
+  |   document.head.appendChild(s);
+  | }
 script(src=httpRootDir + "vs/loader.js")

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,10 @@ let plugins = [
         from: path.join(staticPath, "favicon.ico"),
         to: distPath,
     },
+    {
+        from: 'node_modules/es6-shim/es6-shim.min.js',
+        to: distPath,
+    },
     ]),
     new webpack.ProvidePlugin({
         $: 'jquery',


### PR DESCRIPTION
I bisected this back to 322086b923bcb40b1f336cc4ee49c9e97c71acc4, which introduces a client-side dependency on [String.prototype.endsWith](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith), which is part of ES6 (and missing in IE11).

There is still at least one major UI issue with the site on IE11, but its "workaroundable" (and maybe not hard to fix, but I haven't looked yet).
You must resize the IE11 window in both width and height multiple times before the goldenlayout windows populate.
When the page first loads they will look like this:
![image](https://user-images.githubusercontent.com/63636/61197116-13952e00-a6a1-11e9-9f0e-fcca49b7e8e6.png)

I haven't done an exhaustive test of the site in IE11, but it at least loads and basic functionality works now.

Worth mentioning that es6-shim is almost 60k of javascript to pull in. It may be worth handling specially and conditionally loading only for IE somehow.
~Perhaps:~ *EDIT:* this doesn't work for IE11, but there may be additional methods
```html
<!--[if IE]><script src="shim.js"></script><![endif]-->
```