### PR TITLE
[BUG] /healthcheck doesn't detect NFS mount failure

### DIFF
--- a/app.js
+++ b/app.js
@@ -351,12 +351,14 @@ aws.initConfig(awsProps)
                     router = express.Router(),
                     healthCheck = require('./lib/handlers/health-check');
 
+                const healthCheckFilePath = ceProps("healthCheckFilePath", false);
+
                 webServer
                     .set('trust proxy', true)
                     .set('view engine', 'pug')
                     .on('error', err => logger.error('Caught error in web handler; continuing:', err))
                     // Handle healthchecks at the root, as they're not expected from the outside world
-                    .use('/healthcheck', new healthCheck.HealthCheckHandler().handle)
+                    .use('/healthcheck', new healthCheck.HealthCheckHandler(healthCheckFilePath).handle)
                     .use(httpRootDir, router)
                     .use((req, res, next) => {
                         next({status: 404, message: `page "${req.path}" could not be found`});

--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -20,3 +20,4 @@ formatter.clangformat.exe=/opt/compiler-explorer/clang-trunk/bin/clang-format
 formatter.clangformat.styles=Google:LLVM:Mozilla:Chromium:WebKit
 motdUrl=/motd/motd-prod.json
 storageSolution=s3
+healthCheckFilePath=/opt/.health

--- a/lib/handlers/health-check.js
+++ b/lib/handlers/health-check.js
@@ -22,9 +22,34 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+const
+    denodeify = require('denodeify'),
+    fs = require('fs'),
+    logger = require('../logger').logger,
+    Sentry = require('@sentry/node');
+
 class HealthCheckHandler {
-    handle(req, res) {
-        res.end("Everything is awesome");
+    constructor(filePath) {
+        this.filePath = filePath;
+        this.readFile = denodeify(fs.readFile);
+
+        this.handle = this._handle.bind(this);
+    }
+
+    async _handle(req, res) {
+        if (!this.filePath) {
+            res.end('Everything is awesome');
+            return;
+        }
+
+        try {
+            const content = await this.readFile(this.filePath);
+            res.end(content);
+        } catch (e) {
+            logger.error(`*** HEALTH CHECK FAILURE: while reading file '${this.filePath}' got ${e}`);
+            Sentry.captureException(e);
+            res.status(500).end();
+        }
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5612,6 +5612,12 @@
         }
       }
     },
+    "mock-fs": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.1.tgz",
+      "integrity": "sha512-w22rOL5ZYu6HbUehB5deurghGM0hS/xBVyHMGKOuQctkk93J9z9VEOhDsiWrXOprVNQpP9uzGKdl8v9mFspKuw==",
+      "dev": true
+    },
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "file-loader": "^1.1.5",
     "mini-css-extract-plugin": "^0.7.0",
     "mocha": "^5.2.0",
+    "mock-fs": "^4.10.1",
     "nock": "^9.1.4",
     "nyc": "^14.1.1",
     "requirejs": "2.3.6",


### PR DESCRIPTION
Just happened in beta.

In nginx logs:
```
[04/Jul/2019:18:06:28 +0000] "GET /healthcheck HTTP/1.1" 200 32 "-" "ELB-HealthChecker/2.0"
[04/Jul/2019:18:06:32 +0000] "GET /beta HTTP/1.1" 499 0 "-" "Amazon CloudFront"
```

the node app continued to respond successfully to `/healthcheck` when all other requests would hang indefinitely (eventually resulting in 499 when the client hangs up).

Root cause was NFS mount being hung for some reason.

The following resolved the issue:
```
umount -l -f /opt
mount /opt
mount /opt/wine-stable
systemctl restart compiler-explorer
```

Perhaps `/healthcheck` should do one of the following:
- run a binary configurable via properties and expect exit code 0
- serve a static file configurable via properties

In either case we could put the corresponding file on the nfs mount in order to have the healthcheck fail when the nfs mount dies so that the instance will get automatically recycled.