### PR TITLE
Fix external compilers when httpRoot is set

### DIFF
--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -26,6 +26,7 @@ const logger = require('./logger').logger,
     _ = require('underscore'),
     fs = require('fs-extra'),
     path = require('path'),
+    urljoin = require('url-join'),
     http = require('http'),
     https = require('https'),
     aws = require('./aws');
@@ -56,14 +57,11 @@ class CompilerFinder {
         return this.awsPoller.getInstances();
     }
 
-    fetchRemote(host, port, props, langId) {
+    fetchRemote(host, port, uriBase, props, langId) {
         const requestLib = port === 443 ? https : http;
         const uriSchema = port === 443 ? "https" : "http";
-        const uri = `${uriSchema}://${host}:${port}`;
-        let apiPath = '/api/compilers';
-        if (langId !== null) {
-            apiPath += `/${langId}`;
-        }
+        const uri = urljoin(`${uriSchema}://${host}:${port}`, uriBase);
+        let apiPath = urljoin('/', uriBase || '', 'api/compilers', langId || '');
         logger.info(`Fetching compilers from remote source ${uri}`);
         return this.retryPromise(
             () => {
@@ -102,7 +100,10 @@ class CompilerFinder {
                             try {
                                 const compilers = JSON.parse(str).map(compiler => {
                                     compiler.exe = null;
-                                    compiler.remote = `${uriSchema}://${host}:${port}`;
+                                    compiler.remote = {
+                                        target: `${uriSchema}://${host}:${port}`,
+                                        path: urljoin('/', uriBase, 'api/compiler', compiler.id, 'compile')
+                                    };
                                     return compiler;
                                 });
                                 resolve(compilers);
@@ -135,7 +136,7 @@ class CompilerFinder {
                 if (this.awsProps("externalTestMode", false)) {
                     address = instance.PublicDnsName;
                 }
-                return this.fetchRemote(address, this.args.port, this.awsProps, null);
+                return this.fetchRemote(address, this.args.port, '', this.awsProps, null);
             }));
         });
     }
@@ -221,8 +222,10 @@ class CompilerFinder {
         if (this.args.fetchCompilersFromRemote && compilerName.indexOf("@") !== -1) {
             const bits = compilerName.split("@");
             const host = bits[0];
-            const port = parseInt(bits[1]);
-            return this.fetchRemote(host, port, this.ceProps, langId);
+            const pathParts = bits[1].split('/');
+            const port = parseInt(pathParts.shift());
+            const path = pathParts.join('/');
+            return this.fetchRemote(host, port, path, this.ceProps, langId);
         }
         if (compilerName.indexOf("&") === 0) {
             const groupName = compilerName.substr(1);

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -263,9 +263,8 @@ class CompileHandler {
             bypassCache, tools, executionParameters, libraries} = this.parseRequest(req, compiler);
         const remote = compiler.getRemote();
         if (remote) {
-            // Undo any routing that was done to get here (i.e. /api/* path has been removed)
-            req.url = req.originalUrl;
-            this.proxy.web(req, res, {target: remote, changeOrigin: true}, e => {
+            req.url = remote.path;
+            this.proxy.web(req, res, {target: remote.target, changeOrigin: true}, e => {
                 logger.error("Proxy error: ", e);
                 next(e);
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9310,6 +9310,11 @@
         "querystring": "0.2.0"
       }
     },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
     "url-loader": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "tree-kill": "^1.2.0",
     "uglifyjs-webpack-plugin": "^2.1.3",
     "underscore": "1.9.1",
+    "url-join": "^4.0.1",
     "vis": "4.20.1",
     "winston": "^3.2.1",
     "winston-papertrail": "^1.0.5",


### PR DESCRIPTION
It is now also possible to use remotes that themselves have a `httpRoot` set.

`compilers=godbolt.org@443/staging`