### PR TITLE
Tool improvements

### DIFF
--- a/docs/AddingATool.md
+++ b/docs/AddingATool.md
@@ -13,6 +13,7 @@ tools.rewritecpp.type=independent
 tools.rewritecpp.exclude=
 tools.rewritecpp.class=base-tool
 tools.rewritecpp.stdinHint=disabled
+tools.rewritecpp.languageId=cppp
 ```
 
 The `name` and `exe` are what they say they are, this is the display name for within CE and the tool executable that will be used.
@@ -30,6 +31,8 @@ Should you want to deviate from the standard behaviour of `base-tool`, which run
 you should add a new class that extends from `base-tool`.
 
 The `stdinHint` is there to show the user a hint as to what the stdin field is used for in the tool. To disable stdin you can use _disabled_ here.
+
+The `languageId` can be used to highlight the output of the tool according to a language known within CE. For example `cppp` will highlight c++ output. Leaving `languageId` empty will use the terminal-like output.
 
 # compilationInfo
 

--- a/docs/AddingATool.md
+++ b/docs/AddingATool.md
@@ -1,0 +1,75 @@
+# Adding a new tool
+
+Tools are a way to execute something on your code or the output of a compilation.
+
+Adding tools requires adding configuration to a properties file for a specific language:
+
+```
+tools=rewritecpp
+
+tools.rewritecpp.name=rewritecpp
+tools.rewritecpp.exe=/opt/compiler-explorer/rewritertool/bin/rewritecpp
+tools.rewritecpp.type=independent
+tools.rewritecpp.exclude=
+tools.rewritecpp.class=base-tool
+tools.rewritecpp.stdinHint=disabled
+```
+
+The **name** and **exe** are what they say they are, this is the display name for within CE and the tool executable that will be used.
+
+The **type** of the tool represents the stage in which the tool will run:
+* independent - when running a tool on sourcecode
+* postcompilation - when running a tool on the assembly or a binary
+
+The **exclude** property is to indicate which compilers are proven to be incompatible with the tool.
+You can supply the full id of the compiler or a partial id (for example 'arm' to exclude all arm compilers).
+
+The **class** of the tool says which javascript class is needed to run the tool and process its output.
+
+Should you want to deviate from the standard behaviour of base-tool, which runs the tool on the sourcecode filename,
+you should add a new class that extends from base-tool.
+
+The **stdinHint** is there to show the user a hint as to what the stdin field is used for in the tool. To disable stdin you can use _disabled_ here.
+
+## compilationInfo
+
+When writing a special class for a tool, you will probably need the `compilationInfo` parameter to pass the correct parameters to the tool.
+
+The contents of `compilationInfo` varies slightly between the different **type**s of tools.
+
+### compilationInfo for independent tools
+
+```json
+{
+    "backendOptions": {"produceGccDump": {}, "produceCfg": false},
+    "compiler": {"id": "clang_trunk", "exe": "clang++", ...},
+    "filters": {"binary": false, "commentOnly": true, "demangle": true, ... },
+    "inputFilename": "/tmp/ce-tmp/example.cpp",
+    "dirPath": "/tmp/ce-tmp",
+    "libraries": [{"id": "ctre", "version": "v2"}],
+    "options": ["-O3"],
+    "source": "int main() {\nreturn 1;\n}\n"
+}
+```
+
+### compilationInfo for postcompilation tools
+
+```json
+{
+    ... everything from the compilationInfo for independent tools
+    "asm": [
+        {"text": "main:", "source": null},
+        {"text": "  mov eax, 1", "source": {"file": null, "line": 2}}
+        {"text": "  ret", "source": {"file": null, "line": 3}}
+    ],
+    "asmSize": 123,
+    "compilationOptions": ["-O3", "-S", "/tmp/ce-tmp/example.cpp", ...],
+    "code": 0,
+    "stderr": [
+        {"text": "warning: 'x' is used uninitialized in this function [-Wuninitialized]", "tag": {"line": 4, "column": 16}}
+    ],
+    "stdout": [],
+    "outputFilename": "/tmp/ce-tmp/example.o",
+    "executableFilename": "/tmp/ce-tmp/a.out"
+}
+```

--- a/docs/AddingATool.md
+++ b/docs/AddingATool.md
@@ -4,7 +4,7 @@ Tools are a way to execute something on your code or the output of a compilation
 
 Adding tools requires adding configuration to a properties file for a specific language:
 
-```
+```yaml
 tools=rewritecpp
 
 tools.rewritecpp.name=rewritecpp
@@ -15,29 +15,29 @@ tools.rewritecpp.class=base-tool
 tools.rewritecpp.stdinHint=disabled
 ```
 
-The **name** and **exe** are what they say they are, this is the display name for within CE and the tool executable that will be used.
+The `name` and `exe` are what they say they are, this is the display name for within CE and the tool executable that will be used.
 
-The **type** of the tool represents the stage in which the tool will run:
+The `type` of the tool represents the stage in which the tool will run:
 * independent - when running a tool on sourcecode
 * postcompilation - when running a tool on the assembly or a binary
 
-The **exclude** property is to indicate which compilers are proven to be incompatible with the tool.
+The `exclude` property is to indicate which compilers are proven to be incompatible with the tool.
 You can supply the full id of the compiler or a partial id (for example 'arm' to exclude all arm compilers).
 
-The **class** of the tool says which javascript class is needed to run the tool and process its output.
+The `class` of the tool says which javascript class is needed to run the tool and process its output. The folder _lib/tooling_ is used for these classes.
 
-Should you want to deviate from the standard behaviour of base-tool, which runs the tool on the sourcecode filename,
-you should add a new class that extends from base-tool.
+Should you want to deviate from the standard behaviour of `base-tool`, which runs the tool on the sourcecode filename,
+you should add a new class that extends from `base-tool`.
 
-The **stdinHint** is there to show the user a hint as to what the stdin field is used for in the tool. To disable stdin you can use _disabled_ here.
+The `stdinHint` is there to show the user a hint as to what the stdin field is used for in the tool. To disable stdin you can use _disabled_ here.
 
-## compilationInfo
+# compilationInfo
 
 When writing a special class for a tool, you will probably need the `compilationInfo` parameter to pass the correct parameters to the tool.
 
-The contents of `compilationInfo` varies slightly between the different **type**s of tools.
+The contents of `compilationInfo` varies slightly between the different `type`s of tools.
 
-### compilationInfo for independent tools
+## compilationInfo for independent tools
 
 ```json
 {
@@ -52,19 +52,28 @@ The contents of `compilationInfo` varies slightly between the different **type**
 }
 ```
 
-### compilationInfo for postcompilation tools
+The `filters` can be used to assert boundary conditions or adjust the tooling process based on the filters the user checked on or off.
+
+The `inputFilename` contains the path to the sourcecode stored on disk. The `source` contains the sourcecode as text.
+
+The `dirPath` can be used to write extra files to disk which the tool might need.
+
+The `options` are the arguments the user gave for the compilation.
+
+
+## compilationInfo for postcompilation tools
 
 ```json
 {
     ... everything from the compilationInfo for independent tools
+    "compilationOptions": ["-O3", "-S", "/tmp/ce-tmp/example.cpp", ...],
+    "code": 0,
     "asm": [
         {"text": "main:", "source": null},
         {"text": "  mov eax, 1", "source": {"file": null, "line": 2}}
         {"text": "  ret", "source": {"file": null, "line": 3}}
     ],
     "asmSize": 123,
-    "compilationOptions": ["-O3", "-S", "/tmp/ce-tmp/example.cpp", ...],
-    "code": 0,
     "stderr": [
         {"text": "warning: 'x' is used uninitialized in this function [-Wuninitialized]", "tag": {"line": 4, "column": 16}}
     ],
@@ -73,3 +82,13 @@ The contents of `compilationInfo` varies slightly between the different **type**
     "executableFilename": "/tmp/ce-tmp/a.out"
 }
 ```
+
+`code` indicates the exitcode of the compilation. Usually, 0 means everything's ok.
+
+`asm` contains the returned assembly. This is the same assembly that is shown within compiler-explorer, including extra information like for which sourcecode line the assembly was generated.
+
+`stderr` and `stdout` contain the different outputs from the compilation process.
+
+The `outputFilename` is always filled, but not guaranteed to exist, for example when the compilation has failed.
+
+The `executableFilename` is always filled, but does not guarantee the existance of an executable.

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -942,7 +942,7 @@ libs.pegtl.versions.280.path=/opt/compiler-explorer/libs/PEGTL/2.8.0/include
 #################################
 # Installed tools
 
-tools=clangtidytrunk:llvm-mcatrunk:pahole:clangquerytrunk:readelf
+tools=clangtidytrunk:llvm-mcatrunk:pahole:clangquerytrunk:readelf:x86to6502
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
 tools.clangtidytrunk.name=clang-tidy
@@ -979,3 +979,11 @@ tools.clangquerytrunk.name=clang-query
 tools.clangquerytrunk.type=independent
 tools.clangquerytrunk.class=clang-query-tool
 tools.clangquerytrunk.stdinHint=Query commands
+
+tools.x86to6502.exe=/opt/compiler-explorer/x86-to-6502/lefticus/x86-to-6502
+tools.x86to6502.name=x86-to-6502
+tools.x86to6502.type=postcompilation
+tools.x86to6502.class=x86to6502-tool
+tools.x86to6502.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new:djggp:riscv:wasm:frc2019:raspbian:arduino
+tools.x86to6502.stdinHint=disabled
+tools.x86to6502.languageId=asm

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -942,7 +942,7 @@ libs.pegtl.versions.280.path=/opt/compiler-explorer/libs/PEGTL/2.8.0/include
 #################################
 # Installed tools
 
-tools=clangtidytrunk:llvm-mcatrunk:pahole:clangquerytrunk
+tools=clangtidytrunk:llvm-mcatrunk:pahole:clangquerytrunk:readelf
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
 tools.clangtidytrunk.name=clang-tidy
@@ -966,6 +966,13 @@ tools.pahole.class=pahole-tool
 tools.pahole.exclude=djggp
 tools.pahole.stdinHint=disabled
 tools.pahole.languageId=cppp
+
+tools.readelf.name=readelf
+tools.readelf.exe=/opt/compiler-explorer/gcc-snapshot/bin/readelf
+tools.readelf.type=postcompilation
+tools.readelf.class=readelf-tool
+tools.readelf.exclude=djggp
+tools.readelf.stdinHint=disabled
 
 tools.clangquerytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-query
 tools.clangquerytrunk.name=clang-query

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -950,15 +950,19 @@ tools.clangtidytrunk.type=independent
 tools.clangtidytrunk.class=clang-tidy-tool
 tools.clangtidytrunk.exclude=cl19:cl_new
 tools.clangtidytrunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.2.0
+tools.clangtidytrunk.stdinHint=disabled
 
 tools.llvm-mcatrunk.name=llvm-mca
 tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
 tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new:djggp
+tools.llvm-mcatrunk.stdinHint=disabled
 
 tools.pahole.name=pahole
 tools.pahole.exe=/opt/compiler-explorer/pahole/bin/pahole
 tools.pahole.type=postcompilation
 tools.pahole.class=pahole-tool
 tools.pahole.exclude=djggp
+tools.pahole.stdinHint=disabled
+tools.pahole.languageId=cppp

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -971,4 +971,4 @@ tools.clangquerytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-query
 tools.clangquerytrunk.name=clang-query
 tools.clangquerytrunk.type=independent
 tools.clangquerytrunk.class=clang-query-tool
-tools.pahole.stdinHint=Query commands
+tools.clangquerytrunk.stdinHint=Query commands

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -971,3 +971,4 @@ tools.clangquerytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-query
 tools.clangquerytrunk.name=clang-query
 tools.clangquerytrunk.type=independent
 tools.clangquerytrunk.class=clang-query-tool
+tools.pahole.stdinHint=Query commands

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -942,7 +942,7 @@ libs.pegtl.versions.280.path=/opt/compiler-explorer/libs/PEGTL/2.8.0/include
 #################################
 # Installed tools
 
-tools=clangtidytrunk:llvm-mcatrunk:pahole
+tools=clangtidytrunk:llvm-mcatrunk:pahole:clangquerytrunk
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
 tools.clangtidytrunk.name=clang-tidy
@@ -966,3 +966,8 @@ tools.pahole.class=pahole-tool
 tools.pahole.exclude=djggp
 tools.pahole.stdinHint=disabled
 tools.pahole.languageId=cppp
+
+tools.clangquerytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-query
+tools.clangquerytrunk.name=clang-query
+tools.clangquerytrunk.type=independent
+tools.clangquerytrunk.class=clang-query-tool

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -417,10 +417,18 @@ compiler.cc65_217.semver=2.17
 #################################
 # Installed tools
 
-tools=llvm-mcatrunk
+tools=llvm-mcatrunk:pahole
 
 tools.llvm-mcatrunk.name=llvm-mca
 tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
 tools.llvm-mcatrunk.type=postcompilation
 tools.llvm-mcatrunk.class=llvm-mca-tool
 tools.llvm-mcatrunk.exclude=cavr:carm:caarch:cmips:cmsp:cppc:ppci
+
+tools.pahole.name=pahole
+tools.pahole.exe=/opt/compiler-explorer/pahole/bin/pahole
+tools.pahole.type=postcompilation
+tools.pahole.class=pahole-tool
+tools.pahole.exclude=
+tools.pahole.stdinHint=disabled
+tools.pahole.languageId=cppp

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -600,11 +600,12 @@ class BaseCompiler {
                             })
                             .then(result => {
                                 const outputFilename = this.getOutputFilename(result.dirPath, this.outputFilebase);
-                                const executableFilename = this.getExecutableFilename(result.dirPath, outputFilebase);
+                                const executableFilename = this.getExecutableFilename(result.dirPath,
+                                    this.outputFilebase);
 
                                 const postToolsPromise = this.runToolsOfType(
                                     result.inputFilename, tools, "postcompilation",
-                                    this.compiler.exe, outputFilename, options, filters, result.asm);
+                                    this.compiler.exe, outputFilename, options, filters, result.asm,
                                     executableFilename);
 
                                 return Promise.all([Promise.all(postToolsPromise)]).then(([postToolsResult]) => {

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -437,7 +437,7 @@ class BaseCompiler {
     }
 
     getCompilationInfo(key, result) {
-        let compilationinfo = Object.assign({}, key, result);
+        const compilationinfo = Object.assign({}, key, result);
         compilationinfo.outputFilename = this.getOutputFilename(result.dirPath, this.outputFilebase);
         compilationinfo.executableFilename = this.getExecutableFilename(result.dirPath, this.outputFilebase);
 

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -325,7 +325,7 @@ class BaseCompiler {
             .then(() => this.postProcess(asmResult, outputFilename, filters));
     }
 
-    runToolsOfType(sourcefile, tools, type, compilerExe, outputFilename, options, filters, asm, executableFilename) {
+    runToolsOfType(tools, type, compilationInfo) {
         let tooling = [];
         if (tools) {
             tools.forEach((tool) => {
@@ -335,8 +335,8 @@ class BaseCompiler {
                 });
 
                 if (matches[0]) {
-                    const toolPromise = matches[0].runTool(sourcefile, tool.args,
-                        compilerExe, outputFilename, options, filters, asm, executableFilename);
+                    const toolPromise = matches[0].runTool(compilationInfo,
+                        compilationInfo.inputFilename, tool.args, tool.stdin);
                     tooling.push(toolPromise);
                 }
             });
@@ -436,6 +436,14 @@ class BaseCompiler {
         return {compiler: this.compiler, source, options, backendOptions, filters, tools, libraries};
     }
 
+    getCompilationInfo(key, result) {
+        let compilationinfo = Object.assign({}, key, result);
+        compilationinfo.outputFilename = this.getOutputFilename(result.dirPath, this.outputFilebase);
+        compilationinfo.executableFilename = this.getExecutableFilename(result.dirPath, this.outputFilebase);
+
+        return compilationinfo;
+    }
+
     compile(source, options, backendOptions, filters, bypassCache, tools, executionParameters, libraries) {
         const optionsError = this.checkOptions(options);
         if (optionsError) return Promise.reject(optionsError);
@@ -497,9 +505,8 @@ class BaseCompiler {
                                     inputFilename, outputFilename, libraries)
                             );
 
-                            const toolsPromise = this.runToolsOfType(
-                                inputFilename, tools, "independent",
-                                this.compiler.exe, outputFilename, options, filters);
+                            const toolsPromise = this.runToolsOfType(tools, "independent",
+                                this.getCompilationInfo(key, {inputFilename, dirPath, outputFilename}));
 
                             const execOptions = this.getDefaultExecOptions();
 
@@ -599,14 +606,8 @@ class BaseCompiler {
                                 return result;
                             })
                             .then(result => {
-                                const outputFilename = this.getOutputFilename(result.dirPath, this.outputFilebase);
-                                const executableFilename = this.getExecutableFilename(result.dirPath,
-                                    this.outputFilebase);
-
-                                const postToolsPromise = this.runToolsOfType(
-                                    result.inputFilename, tools, "postcompilation",
-                                    this.compiler.exe, outputFilename, options, filters, result.asm,
-                                    executableFilename);
+                                const postToolsPromise = this.runToolsOfType(tools, "postcompilation",
+                                    this.getCompilationInfo(key, result));
 
                                 return Promise.all([Promise.all(postToolsPromise)]).then(([postToolsResult]) => {
                                     result.tools = _.union(result.tools, postToolsResult);

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -134,8 +134,10 @@ function executeDirect(command, args, options, filenameTransform) {
             logger.debug("Execution", {type: "executed", command: command, args: args, result: result});
             resolve(result);
         });
-        if (options.input) child.stdin.write(options.input);
-        child.stdin.end();
+        if (child.stdin) {
+            if (options.input) child.stdin.write(options.input);
+            child.stdin.end();
+        }
     });
 }
 

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -135,7 +135,8 @@ class ClientOptionsHandler {
                         exe: this.compilerProps(lang, toolBaseName + '.exe'),
                         exclude: this.compilerProps(lang, toolBaseName + '.exclude'),
                         options: this.compilerProps(lang, toolBaseName + '.options'),
-                        languageId: this.compilerProps(lang, toolBaseName + '.languageId')
+                        languageId: this.compilerProps(lang, toolBaseName + '.languageId'),
+                        stdinHint: this.compilerProps(lang, toolBaseName + '.stdinHint')
                     },
                     {
                         ceProps: this.ceProps,

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -134,7 +134,8 @@ class ClientOptionsHandler {
                         type: this.compilerProps(lang, toolBaseName + '.type'),
                         exe: this.compilerProps(lang, toolBaseName + '.exe'),
                         exclude: this.compilerProps(lang, toolBaseName + '.exclude'),
-                        options: this.compilerProps(lang, toolBaseName + '.options')
+                        options: this.compilerProps(lang, toolBaseName + '.options'),
+                        languageId: this.compilerProps(lang, toolBaseName + '.languageId')
                     },
                     {
                         ceProps: this.ceProps,

--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -64,6 +64,7 @@ class BaseTool {
             id: this.tool.id,
             name: this.tool.name,
             code: -1,
+            languageId: "stderr",
             stdout: utils.parseOutput(message)
         };
     }
@@ -84,6 +85,7 @@ class BaseTool {
                 id: this.tool.id,
                 name: this.tool.name,
                 code: result.code,
+                languageId: this.tool.languageId,
                 stderr: utils.parseOutput(result.stderr, inputFilepath, exeDir),
                 stdout: utils.parseOutput(result.stdout, inputFilepath, exeDir)
             };

--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -26,6 +26,7 @@
 const
     exec = require('../exec'),
     utils = require('../utils'),
+    logger = require('../logger').logger,
     path = require('path');
 
 class BaseTool {
@@ -89,7 +90,8 @@ class BaseTool {
                 stderr: utils.parseOutput(result.stderr, inputFilepath, exeDir),
                 stdout: utils.parseOutput(result.stdout, inputFilepath, exeDir)
             };
-        }).catch(() => {
+        }).catch((e) => {
+            logger.error("Error while running tool: ", e);
             return this.createErrorResponse("Error while running tool");
         });
     }

--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -68,13 +68,14 @@ class BaseTool {
         };
     }
 
-    runTool(sourcefile, args) {
+    runTool(compilationInfo, inputFilepath, args, stdin) {
         let execOptions = this.getDefaultExecOptions();
-        execOptions.customCwd = path.dirname(sourcefile);
+        execOptions.customCwd = path.dirname(inputFilepath);
+        execOptions.input = stdin;
 
         args = args ? args : [];
         args = args.filter((arg) => !arg.includes('/'));
-        args.push(sourcefile);
+        if (inputFilepath) args.push(inputFilepath);
 
         const exeDir = path.dirname(this.tool.exe);
 
@@ -83,8 +84,8 @@ class BaseTool {
                 id: this.tool.id,
                 name: this.tool.name,
                 code: result.code,
-                stderr: utils.parseOutput(result.stderr, sourcefile, exeDir),
-                stdout: utils.parseOutput(result.stdout, sourcefile, exeDir)
+                stderr: utils.parseOutput(result.stderr, inputFilepath, exeDir),
+                stdout: utils.parseOutput(result.stdout, inputFilepath, exeDir)
             };
         }).catch(() => {
             return this.createErrorResponse("Error while running tool");

--- a/lib/tooling/clang-query-tool.js
+++ b/lib/tooling/clang-query-tool.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2018, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+const
+    fs = require('fs-extra'),
+    path = require('path'),
+    BaseTool = require('./base-tool');
+
+class ClangQueryTool extends BaseTool {
+    constructor(toolInfo, env) {
+        super(toolInfo, env);
+    }
+
+    async runTool(compilationInfo, inputFilepath, args, stdin) {
+        const sourcefile = inputFilepath;
+        const compilerExe = compilationInfo.compiler.exe;
+        const options = compilationInfo.options;
+        const dir = path.dirname(sourcefile);
+
+        const compileFlags = options.filter(option => (option !== sourcefile));
+        if (!compilerExe.includes("clang++")) {
+            compileFlags.push(this.tool.options);
+        }
+
+        //args.push("-color=false");
+
+        await fs.writeFile(path.join(dir, "commands.txt"), stdin);
+        await fs.writeFile(path.join(dir, "compile_flags.txt"), compileFlags.join('\n'));
+        return super.runTool(compilationInfo, sourcefile, args, stdin);
+    }
+}
+
+module.exports = ClangQueryTool;

--- a/lib/tooling/clang-query-tool.js
+++ b/lib/tooling/clang-query-tool.js
@@ -48,7 +48,7 @@ class ClangQueryTool extends BaseTool {
 
         await fs.writeFile(path.join(dir, "commands.txt"), stdin);
         await fs.writeFile(path.join(dir, "compile_flags.txt"), compileFlags.join('\n'));
-        return super.runTool(compilationInfo, sourcefile, args, stdin);
+        return super.runTool(compilationInfo, sourcefile, args, false);
     }
 }
 

--- a/lib/tooling/clang-query-tool.js
+++ b/lib/tooling/clang-query-tool.js
@@ -44,8 +44,6 @@ class ClangQueryTool extends BaseTool {
             compileFlags.push(this.tool.options);
         }
 
-        //args.push("-color=false");
-
         await fs.writeFile(path.join(dir, "commands.txt"), stdin);
         await fs.writeFile(path.join(dir, "compile_flags.txt"), compileFlags.join('\n'));
         return super.runTool(compilationInfo, sourcefile, args, false);

--- a/lib/tooling/clang-query-tool.js
+++ b/lib/tooling/clang-query-tool.js
@@ -44,9 +44,8 @@ class ClangQueryTool extends BaseTool {
             compileFlags.push(this.tool.options);
         }
 
-        await fs.writeFile(path.join(dir, "commands.txt"), stdin);
         await fs.writeFile(path.join(dir, "compile_flags.txt"), compileFlags.join('\n'));
-        return super.runTool(compilationInfo, sourcefile, args, false);
+        return super.runTool(compilationInfo, sourcefile, args, stdin);
     }
 }
 

--- a/lib/tooling/clang-query-tool.js
+++ b/lib/tooling/clang-query-tool.js
@@ -45,7 +45,14 @@ class ClangQueryTool extends BaseTool {
         }
 
         await fs.writeFile(path.join(dir, "compile_flags.txt"), compileFlags.join('\n'));
-        return super.runTool(compilationInfo, sourcefile, args, stdin);
+        const toolResult = await super.runTool(compilationInfo, sourcefile, args, stdin);
+
+        if (toolResult.stdout.length > 0) {
+            const lastLine = toolResult.stdout.length - 1;
+            toolResult.stdout[lastLine].text = toolResult.stdout[lastLine].text.replace(/(clang-query>\s)/gi, "");
+        }
+
+        return toolResult;
     }
 }
 

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -35,7 +35,7 @@ class ClangTidyTool extends BaseTool {
 
     runTool(compilationInfo, inputFilepath, args) {
         const sourcefile = inputFilepath;
-        const compilerExe = "";
+        const compilerExe = compilationInfo.compiler.exe;
         const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
 

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -56,7 +56,7 @@ class ClangTidyTool extends BaseTool {
         return fs.writeFile(
             path.join(dir, "compile_flags.txt"),
             compileFlags.join("\n")
-        ).then(() => super.runTool(sourcefile, args)
+        ).then(() => super.runTool(compilationInfo, sourcefile, args)
         ).then((result) => {
             result.sourcechanged = false;
 

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -33,7 +33,10 @@ class ClangTidyTool extends BaseTool {
         super(toolInfo, env);
     }
 
-    runTool(sourcefile, args, compilerExe, outputFilename, options) {
+    runTool(compilationInfo, inputFilepath, args) {
+        const sourcefile = inputFilepath;
+        const compilerExe = "";
+        const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
 
         let source;

--- a/lib/tooling/llvm-mca-tool.js
+++ b/lib/tooling/llvm-mca-tool.js
@@ -58,7 +58,7 @@ class LLVMMcaTool extends BaseTool {
 
         const rewrittenOutputFilename = compilationInfo.outputFilename + ".mca";
         return this.writeAsmFile(compilationInfo.asm, rewrittenOutputFilename).then(() => {
-            return super.runTool(rewrittenOutputFilename, args);
+            return super.runTool(compilationInfo, rewrittenOutputFilename, args);
         });
     }
 }

--- a/lib/tooling/llvm-mca-tool.js
+++ b/lib/tooling/llvm-mca-tool.js
@@ -43,21 +43,21 @@ class LLVMMcaTool extends BaseTool {
         return fs.writeFile(destination, this.rewriteAsm(data));
     }
 
-    runTool(sourcefile, args, compilerExe, outputFilename, options, filters, asm) {
+    runTool(compilationInfo, inputFilepath, args) {
         let extraargs = [];
-        if (filters.intel) {
+        if (compilationInfo.filters.intel) {
             extraargs.push("--x86-asm-syntax=intel");
             extraargs.push("-output-asm-variant=1");
         }
 
-        if (filters.binary) {
+        if (compilationInfo.filters.binary) {
             return new Promise((resolve) => {
                 resolve(this.createErrorResponse("<cannot run analysis on binary>"));
             });
         }
 
-        const rewrittenOutputFilename = outputFilename + ".mca";
-        return this.writeAsmFile(asm, rewrittenOutputFilename).then(() => {
+        const rewrittenOutputFilename = compilationInfo.outputFilename + ".mca";
+        return this.writeAsmFile(compilationInfo.asm, rewrittenOutputFilename).then(() => {
             return super.runTool(rewrittenOutputFilename, args);
         });
     }

--- a/lib/tooling/pahole-tool.js
+++ b/lib/tooling/pahole-tool.js
@@ -36,8 +36,8 @@ class PaholeTool extends BaseTool {
         this.stat = denodeify(fs.stat);
     }
 
-    runTool(sourcefile, args, compilerExe, outputFilename, options, filters, asm, executableFilename) {
-        if(!filters.binary)
+    runTool(compilationInfo, inputFilepath, args) {
+        if(!compilationInfo.filters.binary)
         {
             return {
                 id: this.tool.id,
@@ -47,10 +47,10 @@ class PaholeTool extends BaseTool {
             };
         }
 
-        return this.stat(executableFilename).then(() => {
-            return super.runTool(executableFilename, args);
+        return this.stat(compilationInfo.executableFilename).then(() => {
+            return super.runTool(compilationInfo.executableFilename, args);
         }).catch(() => {
-            return super.runTool(outputFilename, args);
+            return super.runTool(compilationInfo.outputFilename, args);
         });
     }
 }

--- a/lib/tooling/pahole-tool.js
+++ b/lib/tooling/pahole-tool.js
@@ -24,7 +24,6 @@
 "use strict";
 
 const
-    utils = require('../utils'),
     fs = require('fs-extra'),
     BaseTool = require('./base-tool');
 
@@ -36,12 +35,7 @@ class PaholeTool extends BaseTool {
     runTool(compilationInfo, inputFilepath, args) {
         if(!compilationInfo.filters.binary)
         {
-            return {
-                id: this.tool.id,
-                name: this.tool.name,
-                code: 0,
-                stdout: utils.parseOutput("Pahole requires a binary output")
-            };
+            return this.createErrorResponse("Pahole requires a binary output");
         }
 
         return fs.stat(compilationInfo.executableFilename).then(() => {

--- a/lib/tooling/pahole-tool.js
+++ b/lib/tooling/pahole-tool.js
@@ -45,9 +45,9 @@ class PaholeTool extends BaseTool {
         }
 
         return fs.stat(compilationInfo.executableFilename).then(() => {
-            return super.runTool(compilationInfo.executableFilename, args);
+            return super.runTool(compilationInfo, compilationInfo.executableFilename, args);
         }).catch(() => {
-            return super.runTool(compilationInfo.outputFilename, args);
+            return super.runTool(compilationInfo, compilationInfo.outputFilename, args);
         });
     }
 }

--- a/lib/tooling/pahole-tool.js
+++ b/lib/tooling/pahole-tool.js
@@ -26,14 +26,11 @@
 const
     utils = require('../utils'),
     fs = require('fs-extra'),
-    denodeify = require('denodeify'),
     BaseTool = require('./base-tool');
 
 class PaholeTool extends BaseTool {
     constructor(toolInfo, env) {
         super(toolInfo, env);
-
-        this.stat = denodeify(fs.stat);
     }
 
     runTool(compilationInfo, inputFilepath, args) {
@@ -47,7 +44,7 @@ class PaholeTool extends BaseTool {
             };
         }
 
-        return this.stat(compilationInfo.executableFilename).then(() => {
+        return fs.stat(compilationInfo.executableFilename).then(() => {
             return super.runTool(compilationInfo.executableFilename, args);
         }).catch(() => {
             return super.runTool(compilationInfo.outputFilename, args);

--- a/lib/tooling/readelf-tool.js
+++ b/lib/tooling/readelf-tool.js
@@ -1,0 +1,43 @@
+// Copyright (c) 2019, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+"use strict";
+
+const
+    BaseTool = require('./base-tool');
+
+class ReadElfTool extends BaseTool {
+    constructor(toolInfo, env) {
+        super(toolInfo, env);
+    }
+
+    runTool(compilationInfo, inputFilename, args) {
+        if(!compilationInfo.filters.binary)
+        {
+            return this.createErrorResponse("readelf requires an executable");
+        }
+        return super.runTool(compilationInfo, compilationInfo.executableFilename, args);
+    }
+}
+
+module.exports = ReadElfTool;

--- a/static/explorer.css
+++ b/static/explorer.css
@@ -468,11 +468,3 @@ kbd {
 .linked-compiler-output-line {
     cursor: pointer;
 }
-
-textarea.tool-stdin {
-    resize: vertical !important;
-}
-
-textarea.execution-stdin {
-    resize: vertical !important;
-}

--- a/static/explorer.css
+++ b/static/explorer.css
@@ -468,3 +468,11 @@ kbd {
 .linked-compiler-output-line {
     cursor: pointer;
 }
+
+textarea.tool-stdin {
+    resize: vertical !important;
+}
+
+textarea.execution-stdin {
+    resize: vertical !important;
+}

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1001,7 +1001,7 @@ Compiler.prototype.initToolButton = function (togglePannerAdder, button, toolId)
 
 Compiler.prototype.initToolButtons = function (togglePannerAdder) {
     this.toolsMenu = this.domRoot.find('.toolsmenu');
-    this.toolsMenu.html("");
+    this.toolsMenu.empty();
 
     if (!this.compiler) return;
 

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1012,12 +1012,18 @@ Compiler.prototype.initToolButtons = function (togglePannerAdder) {
         btn.append("<span class='dropdown-icon fas fa-cog' />" + title);
         this.toolsMenu.append(btn);
 
-        this.initToolButton(togglePannerAdder, btn, toolName);
+        if (toolName !== "none") {
+            this.initToolButton(togglePannerAdder, btn, toolName);
+        }
     }, this);
 
-    _.each(this.compiler.tools, function (tool) {
-        addTool(tool.tool.id, tool.tool.name);
-    });
+    if (_.isEmpty(this.compiler.tools)) {
+        addTool("none", "No tools available");
+    } else {
+        _.each(this.compiler.tools, function (tool) {
+            addTool(tool.tool.id, tool.tool.name);
+        });
+    }
 };
 
 Compiler.prototype.enableToolButtons = function () {
@@ -1261,7 +1267,11 @@ Compiler.prototype.updateCompilerInfo = function () {
 };
 
 Compiler.prototype.updateCompilerUI = function () {
-    this.initToolButtons();
+    var panerDropdown = this.domRoot.find('.pane-dropdown');
+    var togglePannerAdder = function () {
+        panerDropdown.dropdown('toggle');
+    };
+    this.initToolButtons(togglePannerAdder);
     this.updateButtons();
     this.updateCompilerInfo();
     // Resize in case the new compiler name is too big

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -1001,6 +1001,9 @@ Compiler.prototype.initToolButton = function (togglePannerAdder, button, toolId)
 
 Compiler.prototype.initToolButtons = function (togglePannerAdder) {
     this.toolsMenu = this.domRoot.find('.toolsmenu');
+    this.toolsMenu.html("");
+
+    if (!this.compiler) return;
 
     var addTool = _.bind(function (toolName, title) {
         var btn = $("<button class='dropdown-item btn btn-light btn-sm'>");
@@ -1258,6 +1261,7 @@ Compiler.prototype.updateCompilerInfo = function () {
 };
 
 Compiler.prototype.updateCompilerUI = function () {
+    this.initToolButtons();
     this.updateButtons();
     this.updateCompilerInfo();
     // Resize in case the new compiler name is too big

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -99,6 +99,7 @@ function Compiler(hub, container, state) {
     this.alertSystem.prefixMessage = "Compiler #" + this.id + ": ";
 
     this.linkedFadeTimeoutId = -1;
+    this.toolsMenu = null;
 
     this.initButtons(state);
 
@@ -425,7 +426,8 @@ Compiler.prototype.findTools = function (content, tools) {
             (content.componentState.compiler === this.id)) {
             tools.push({
                 id: content.componentState.toolId,
-                args: content.componentState.args
+                args: content.componentState.args,
+                stdin: content.componentState.stdin
             });
         }
     } else if (content.content) {
@@ -444,7 +446,8 @@ Compiler.prototype.getActiveTools = function (newToolSettings) {
     if (newToolSettings) {
         tools.push({
             id: newToolSettings.toolId,
-            args: newToolSettings.args
+            args: newToolSettings.args,
+            stdin: newToolSettings.stdin
         });
     }
 
@@ -723,13 +726,15 @@ Compiler.prototype.onEditorChange = function (editor, source, langId, compilerId
 Compiler.prototype.onToolOpened = function (compilerId, toolSettings) {
     if (this.id === compilerId) {
         var toolId = toolSettings.toolId;
-        if (toolId === "clangtidytrunk") {
-            this.clangtidyToolButton.prop('disabled', true);
-        } else if (toolId === "llvm-mcatrunk") {
-            this.llvmmcaToolButton.prop('disabled', true);
-        } else if (toolId === "pahole") {
-            this.paholeToolButton.prop('disabled', true);
-        }
+
+        var buttons = this.toolsMenu.find('button');
+        $(buttons).each(_.bind(function (idx, button) {
+            var toolButton = $(button);
+            var toolName = toolButton.data('toolname');
+            if (toolId === toolName) {
+                toolButton.prop('disabled', true);
+            }
+        }, this));
 
         this.compile(false, toolSettings);
     }
@@ -738,13 +743,15 @@ Compiler.prototype.onToolOpened = function (compilerId, toolSettings) {
 Compiler.prototype.onToolClosed = function (compilerId, toolSettings) {
     if (this.id === compilerId) {
         var toolId = toolSettings.toolId;
-        if (toolId === "clangtidytrunk") {
-            this.clangtidyToolButton.prop('disabled', !this.supportsTool(toolId));
-        } else if (toolId === "llvm-mcatrunk") {
-            this.llvmmcaToolButton.prop('disabled', !this.supportsTool(toolId));
-        } else if (toolId === "pahole") {
-            this.paholeToolButton.prop('disabled', !this.supportsTool(toolId));
-        }
+
+        var buttons = this.toolsMenu.find('button');
+        $(buttons).each(_.bind(function (idx, button) {
+            var toolButton = $(button);
+            var toolName = toolButton.data('toolname');
+            if (toolId === toolName) {
+                toolButton.prop('disabled', !this.supportsTool(toolId));
+            }
+        }, this));
     }
 };
 
@@ -993,13 +1000,34 @@ Compiler.prototype.initToolButton = function (togglePannerAdder, button, toolId)
 };
 
 Compiler.prototype.initToolButtons = function (togglePannerAdder) {
-    this.clangtidyToolButton = this.domRoot.find('.view-clangtidytool');
-    this.llvmmcaToolButton = this.domRoot.find('.view-llvmmcatool');
-    this.paholeToolButton = this.domRoot.find('.view-pahole');
+    this.toolsMenu = this.domRoot.find('.toolsmenu');
 
-    this.initToolButton(togglePannerAdder, this.clangtidyToolButton, "clangtidytrunk");
-    this.initToolButton(togglePannerAdder, this.llvmmcaToolButton, "llvm-mcatrunk");
-    this.initToolButton(togglePannerAdder, this.paholeToolButton, "pahole");
+    var addTool = _.bind(function (toolName, title) {
+        var btn = $("<button class='dropdown-item btn btn-light btn-sm'>");
+        btn.addClass('.view-' + toolName);
+        btn.data('toolname', toolName);
+        btn.append("<span class='dropdown-icon fas fa-cog' />" + title);
+        this.toolsMenu.append(btn);
+
+        this.initToolButton(togglePannerAdder, btn, toolName);
+    }, this);
+
+    _.each(this.compiler.tools, function (tool) {
+        addTool(tool.tool.id, tool.tool.name);
+    });
+};
+
+Compiler.prototype.enableToolButtons = function () {
+    var activeTools = this.getActiveTools();
+
+    var buttons = this.toolsMenu.find('button');
+    $(buttons).each(_.bind(function (idx, button) {
+        var toolButton = $(button);
+        var toolName = toolButton.data('toolname');
+        toolButton.prop('disabled',
+            !(this.supportsTool(toolName)
+            && !this.isToolActive(activeTools, toolName)));
+    }, this));
 };
 
 Compiler.prototype.updateButtons = function () {
@@ -1044,13 +1072,7 @@ Compiler.prototype.updateButtons = function () {
     this.cfgButton.prop('disabled', !this.compiler.supportsCfg);
     this.gccDumpButton.prop('disabled', !this.compiler.supportsGccDump);
 
-    var activeTools = this.getActiveTools();
-    this.clangtidyToolButton.prop('disabled',
-        !(this.supportsTool("clangtidytrunk") && !this.isToolActive(activeTools, "clangtidytrunk")));
-    this.llvmmcaToolButton.prop('disabled',
-        !(this.supportsTool("llvm-mcatrunk") && !this.isToolActive(activeTools, "llvm-mcatrunk")));
-    this.paholeToolButton.prop('disabled',
-        !(this.supportsTool("pahole") && !this.isToolActive(activeTools, "pahole")));
+    this.enableToolButtons();
 };
 
 Compiler.prototype.handlePopularArgumentsResult = function (result) {

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -618,6 +618,12 @@ Executor.prototype.initCallbacks = function () {
     }, this));
 
     this.eventHub.on('initialised', this.undefer, this);
+
+    if (MutationObserver !== undefined) {
+        new MutationObserver(_.bind(this.resize, this)).observe(this.execStdinField[0], {
+            attributes: true, attributeFilter: ["style"]
+        });
+    }
 };
 
 Executor.prototype.onOptionsChange = function (options) {

--- a/static/panes/tool.js
+++ b/static/panes/tool.js
@@ -85,13 +85,7 @@ function Tool(hub, container, state) {
     this.options.on('change', _.bind(this.onOptionsChange, this));
 
     this.initArgs(state);
-
-    this.container.on('resize', this.resize, this);
-    this.container.on('shown', this.resize, this);
-    this.container.on('destroy', this.close, this);
-
-    this.eventHub.on('compileResult', this.onCompileResult, this);
-    this.eventHub.on('compilerClose', this.onCompilerClose, this);
+    this.initCallbacks();
 
     this.onOptionsChange();
     this.updateCompilerName();
@@ -103,11 +97,16 @@ function Tool(hub, container, state) {
     });
 
     this.eventHub.emit('toolOpened', this.compilerId, this.currentState());
-
-    this.initCallbacks();
 }
 
 Tool.prototype.initCallbacks = function () {
+    this.container.on('resize', this.resize, this);
+    this.container.on('shown', this.resize, this);
+    this.container.on('destroy', this.close, this);
+
+    this.eventHub.on('compileResult', this.onCompileResult, this);
+    this.eventHub.on('compilerClose', this.onCompilerClose, this);
+
     this.toggleArgs.on('click', _.bind(function () {
         this.togglePanel(this.toggleArgs, this.panelArgs);
     }, this));
@@ -242,7 +241,9 @@ Tool.prototype.currentState = function () {
         wrap: options.wrap,
         toolId: this.toolId,
         args: this.getInputArgs(),
-        stdin: this.getInputStdin()
+        stdin: this.getInputStdin(),
+        stdinPanelShown: !this.panelStdin.hasClass('d-none'),
+        argsPanelShow: !this.panelArgs.hasClass('d-none')
     };
     this.fontScale.addState(state);
     return state;
@@ -310,7 +311,11 @@ Tool.prototype.onCompileResult = function (id, compiler, result) {
                 this.setEditorContent(_.pluck(toolResult.stdout, 'text').join('\n'));
             } else {
                 _.each((toolResult.stdout || []).concat(toolResult.stderr || []), function (obj) {
-                    this.add(this.normalAnsiToHtml.toHtml(obj.text), obj.tag ? obj.tag.line : obj.line);
+                    if (obj.text === "") {
+                        this.add('<br/>');
+                    } else {
+                        this.add(this.normalAnsiToHtml.toHtml(obj.text), obj.tag ? obj.tag.line : obj.line);
+                    }
                 }, this);
             }
 

--- a/static/panes/tool.js
+++ b/static/panes/tool.js
@@ -279,6 +279,21 @@ Tool.prototype.onCompileResult = function (id, compiler, result) {
             }, this);
         }
 
+        var toolInfo = null;
+        if (compiler && compiler.tools) {
+            toolInfo = _.find(compiler.tools, function (tool) {
+                return (tool.tool.id === this.toolId);
+            }, this);
+        }
+
+        if (toolInfo) {
+            if (toolInfo.tool.stdinHint) {
+                this.stdinField.prop("placeholder", toolInfo.tool.stdinHint);
+            } else {
+                this.stdinField.prop("placeholder", "Tool stdin...");
+            }
+        }
+
         if (toolResult) {
             if (toolResult.languageId && (toolResult.languageId === "stderr")) {
                 toolResult.languageId = false;

--- a/static/panes/tool.js
+++ b/static/panes/tool.js
@@ -287,8 +287,13 @@ Tool.prototype.onCompileResult = function (id, compiler, result) {
         }
 
         if (toolInfo) {
+            this.toggleStdin.prop("disabled", false);
+
             if (toolInfo.tool.stdinHint) {
                 this.stdinField.prop("placeholder", toolInfo.tool.stdinHint);
+                if (toolInfo.tool.stdinHint === "disabled") {
+                    this.toggleStdin.prop("disabled", true);
+                }
             } else {
                 this.stdinField.prop("placeholder", "Tool stdin...");
             }

--- a/static/panes/tool.js
+++ b/static/panes/tool.js
@@ -306,7 +306,8 @@ Tool.prototype.onCompileResult = function (id, compiler, result) {
             this.setEditorContent("No tool result");
         }
     } catch(e) {
-        console.error(e);
+        this.setLanguage(false);
+        this.add("javascript error: " + e.message);
     }
 };
 
@@ -331,7 +332,7 @@ Tool.prototype.add = function (msg, lineNum) {
     }
 };
 
-Tool.prototype.setEditorContent = function(content) {
+Tool.prototype.setEditorContent = function (content) {
     if (!this.outputEditor || !this.outputEditor.getModel()) return;
     var editorModel = this.outputEditor.getModel();
     var visibleRanges = this.outputEditor.getVisibleRanges();
@@ -341,7 +342,7 @@ Tool.prototype.setEditorContent = function(content) {
     this.setNormalContent();
 };
 
-Tool.prototype.setNormalContent = function() {
+Tool.prototype.setNormalContent = function () {
     this.outputEditor.updateOptions({
         lineNumbers: true,
         codeLens: false

--- a/static/panes/tool.js
+++ b/static/panes/tool.js
@@ -307,12 +307,10 @@ Tool.prototype.onCompileResult = function (id, compiler, result) {
                 _.each((toolResult.stdout || []).concat(toolResult.stderr || []), function (obj) {
                     this.add(this.normalAnsiToHtml.toHtml(obj.text), obj.tag ? obj.tag.line : obj.line);
                 }, this);
-
-                this.toolName = toolResult.name;
-                //this.add(this.toolName + " returned: " + toolResult.code);
-
-                this.updateCompilerName();
             }
+
+            this.toolName = toolResult.name;
+            this.updateCompilerName();
 
             if (toolResult.sourcechanged) {
                 this.eventHub.emit('newSource', this.editorId, toolResult.newsource);

--- a/static/panes/tool.js
+++ b/static/panes/tool.js
@@ -61,7 +61,7 @@ function Tool(hub, container, state) {
     this.errorAnsiToHtml = makeAnsiToHtml('red');
 
     this.optionsField = this.domRoot.find('input.options');
-    this.stdinField = this.domRoot.find('textarea.stdin');
+    this.stdinField = this.domRoot.find('textarea.tool-stdin');
 
     this.initButtons(state);
     this.options = new Toggles(this.domRoot.find('.options'), state);

--- a/static/panes/tool.js
+++ b/static/panes/tool.js
@@ -114,6 +114,12 @@ Tool.prototype.initCallbacks = function () {
     this.toggleStdin.on('click', _.bind(function () {
         this.togglePanel(this.toggleStdin, this.panelStdin);
     }, this));
+
+    if (MutationObserver !== undefined) {
+        new MutationObserver(_.bind(this.resize, this)).observe(this.stdinField[0], {
+            attributes: true, attributeFilter: ["style"]
+        });
+    }
 };
 
 Tool.prototype.initArgs = function (state) {

--- a/static/themes/dark-theme.css
+++ b/static/themes/dark-theme.css
@@ -415,3 +415,11 @@ div.argmenuitem span.argdescription {
 .logo-sec {
     fill: #999999 !important;
 }
+
+textarea.tool-stdin {
+    resize: vertical !important;
+}
+
+textarea.execution-stdin {
+    resize: vertical !important;
+}

--- a/static/themes/dark-theme.css
+++ b/static/themes/dark-theme.css
@@ -415,11 +415,3 @@ div.argmenuitem span.argdescription {
 .logo-sec {
     fill: #999999 !important;
 }
-
-textarea.tool-stdin {
-    resize: vertical !important;
-}
-
-textarea.execution-stdin {
-    resize: vertical !important;
-}

--- a/static/themes/default-theme.css
+++ b/static/themes/default-theme.css
@@ -281,3 +281,11 @@ div.argmenuitem span.argdescription {
 .logo-sec {
     fill: #3c3c3f;
 }
+
+textarea.tool-stdin {
+    resize: vertical !important;
+}
+
+textarea.execution-stdin {
+    resize: vertical !important;
+}

--- a/static/themes/default-theme.css
+++ b/static/themes/default-theme.css
@@ -281,11 +281,3 @@ div.argmenuitem span.argdescription {
 .logo-sec {
     fill: #3c3c3f;
 }
-
-textarea.tool-stdin {
-    resize: vertical !important;
-}
-
-textarea.execution-stdin {
-    resize: vertical !important;
-}

--- a/static/toggles.js
+++ b/static/toggles.js
@@ -32,6 +32,7 @@ function Togglesv2(root, state) {
     EventEmitter.call(this);
     var buttons = root.find('.button-checkbox');
     var self = this;
+    this.buttons = buttons;
     this.state = _.extend({}, state);
     // Based on https://bootsnipp.com/snippets/featured/jquery-checkbox-buttons
     buttons.each(function () {
@@ -103,6 +104,17 @@ Togglesv2.prototype.set = function (key, value) {
     this._change(function () {
         this.state[key] = value;
     }.bind(this));
+};
+
+Togglesv2.prototype.enableToggle = function (key, enable) {
+    this.buttons.each(function () {
+        var widget = $(this);
+        var button = $(widget.find('button'));
+        var bind = button.data('bind');
+        if (bind === key) {
+            button.prop("disabled", !enable);
+        }
+    });
 };
 
 Togglesv2.prototype._change = function (update) {

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -232,6 +232,7 @@
     .top-bar.btn-toolbar.bg-light.panel-stdin.d-none(role="toolbar")
       textarea.tool-stdin.form-control(placeholder="Tool stdin..." cols="1024" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-multiline="false" style="resize: none")
     pre.content
+    .monaco-placeholder
 
   #diff
     .top-bar.btn-toolbar.bg-light(role="toolbar")

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -230,7 +230,7 @@
     .top-bar.btn-toolbar.bg-light.panel-args.d-none(role="toolbar")
       input.options.form-control(type="text" placeholder="Tool arguments..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
     .top-bar.btn-toolbar.bg-light.panel-stdin.d-none(role="toolbar")
-      textarea.stdin.form-control(placeholder="Tool stdin..." cols="1024" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-multiline="false" style="resize: none")
+      textarea.tool-stdin.form-control(placeholder="Tool stdin..." cols="1024" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-multiline="false" style="resize: none")
     pre.content
 
   #diff

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -192,7 +192,7 @@
     .top-bar.btn-toolbar.bg-light.panel-args.d-none(role="toolbar")
       input.execution-arguments.form-control(type="text" placeholder="Execution arguments..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
     .top-bar.btn-toolbar.bg-light.panel-stdin.d-none(role="toolbar")
-      textarea.execution-stdin.form-control(placeholder="Execution stdin..." cols="1024" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-multiline="false" style="resize: none")
+      textarea.execution-stdin.form-control(placeholder="Execution stdin..." cols="1024" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-multiline="false" style="resize: vertical")
     pre.content
       .execution-status
       .compiler-output
@@ -230,7 +230,7 @@
     .top-bar.btn-toolbar.bg-light.panel-args.d-none(role="toolbar")
       input.options.form-control(type="text" placeholder="Tool arguments..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
     .top-bar.btn-toolbar.bg-light.panel-stdin.d-none(role="toolbar")
-      textarea.tool-stdin.form-control(placeholder="Tool stdin..." cols="1024" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-multiline="false" style="resize: none")
+      textarea.tool-stdin.form-control(placeholder="Tool stdin..." cols="1024" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-multiline="false" style="resize: vertical")
     pre.content
     .monaco-placeholder
 

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -139,16 +139,7 @@
         button.btn.btn-light.btn-sm.dropdown-toggle.add-tool(type="button" title="Add tool" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Add tooling to this editor and compiler")
           span.fas.fa-cogs
           span.hideable &nbsp;Add tool...
-        .dropdown-menu.dropdown-menu-right
-          button.dropdown-item.btn.btn-light.btn-sm.view-clangtidytool(title="Clang-tidy")
-            span.dropdown-icon.fas.fa-cog
-            | Clang-tidy
-          button.dropdown-item.btn.btn-light.btn-sm.view-llvmmcatool(title="LLVM MCA")
-            span.dropdown-icon.fas.fa-cog
-            | LLVM MCA
-          button.dropdown-item.btn.btn-light.btn-sm.view-pahole(title="Pahole")
-            span.dropdown-icon.fas.fa-cog
-            | Pahole
+        .dropdown-menu.dropdown-menu-right.toolsmenu
     .monaco-placeholder
     .bottom-bar.bg-light
       if !embedded
@@ -230,7 +221,16 @@
             button.btn.btn-light.btn-sm.wrap-lines(type="button" title="Wrap lines" data-bind="wrap" aria-pressed="false" aria-label="Wrap lines")
               span Wrap lines
             input.d-none(type="checkbox" checked=false)
-          input.options.form-control(type="text" placeholder="Tool options..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
+        button.btn.btn-light.btn-sm.toggle-args
+          span.fas.fa-terminal
+          span.hideable &nbsp;Arguments
+        button.btn.btn-light.btn-sm.toggle-stdin
+          span.fas.fa-sign-in-alt
+          span.hideable &nbsp;Stdin
+    .top-bar.btn-toolbar.bg-light.panel-args.d-none(role="toolbar")
+      input.options.form-control(type="text" placeholder="Tool arguments..." size="256" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
+    .top-bar.btn-toolbar.bg-light.panel-stdin.d-none(role="toolbar")
+      textarea.stdin.form-control(placeholder="Tool stdin..." cols="1024" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-multiline="false" style="resize: none")
     pre.content
 
   #diff


### PR DESCRIPTION
Current features:
* No more needing to add tool manually to the UI
* Extra textarea input that's stdin by default
* Internal rewrite of arguments passed to runTool changed to object with all the information any tool should need
* Vertical resizing for textarea stdin (also for execution)
* Pahole for Pascal FPC

Todo:
- [x] Fix tool refresh issue when changing language
- [x] Actually test all the tools again
- [x] Add Pahole to C
- [x] Test if clang-query can be done with these changes (fix #1166)
- [x] Be able to customize hint for stdin to explain what it is
~~Support syntax highlighting for stdin~~ - this would make vertical resizing more problematic
- [x] Support syntax highlighting for stdout
- [x] Add more tools, because why not
- [x] Write doc for adding more tools
