### PR TITLE
Add basic event loop lag logging capability

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,5 +23,8 @@
   },
   "parserOptions": {
     "ecmaVersion": 2017
+  },
+  "globals": {
+    "BigInt": true
   }
 }

--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -21,3 +21,7 @@ formatter.clangformat.styles=Google:LLVM:Mozilla:Chromium:WebKit
 motdUrl=/motd/motd-prod.json
 storageSolution=s3
 healthCheckFilePath=/opt/.health
+
+eventLoopMeasureIntervalMs=50
+eventLoopLagThresholdWarn=100
+eventLoopLagThresholdErr=1000


### PR DESCRIPTION
This is one of the first steps in identifying long running synchronous code paths that are causing our ELB node failures.

Enabling this in production has very little performance impact, and should let us see how often our nodejs event loop is being blocked and for how long.

[At least one known case](https://godbolt.org/z/Rm0SnL) produces a event loop lag of 9 seconds on my local machine.

This basically works by taking the current time, setting a timeout for some number of milliseconds, and then measuring how long it has actually been once the callback fires. This happens continuously in a `setImmediate` loop, with `eventLoopMeasureIntervalMs` determining the desired measurement frequency.

`eventLoopLagThresholdWarn` and `eventLoopLagThresholdErr` are the lag duration in milliseconds that will trigger the corresponding log entry.

The chosen values of 100ms and 1000ms are completely arbitrary, but should be sane enough defaults to start with.

I chose to enable this only in the amazon environment because the log entries probably won't be meaningful for most other users.