### PR TITLE
Updates to Privacy Policy

### DIFF
--- a/static/compiler-service.js
+++ b/static/compiler-service.js
@@ -174,8 +174,8 @@ function handleRequestError(request, reject, xhr, textStatus, errorThrown) {
 }
 
 CompilerService.prototype.submit = function (request) {
-    var jsonRequest = JSON.stringify(request);
     request.allowStoreCodeDebug = this.allowStoreCodeDebug;
+    var jsonRequest = JSON.stringify(request);
     if (options.doCache) {
         var cachedResult = this.cache.get(jsonRequest);
         if (cachedResult) {

--- a/static/compiler-service.js
+++ b/static/compiler-service.js
@@ -30,8 +30,9 @@ var LruCache = require('lru-cache');
 var options = require('./options');
 var Promise = require('es6-promise').Promise;
 
-function CompilerService() {
+function CompilerService(eventHub) {
     this.base = window.httpRoot;
+    this.allowStoreCodeDebug = true;
     if (!this.base.endsWith('/')) {
         this.base += '/';
     }
@@ -48,6 +49,10 @@ function CompilerService() {
         if (compiler.alias) {
             this.compilersByLang[compiler.lang][compiler.alias] = compiler;
         }
+    }, this);
+    // settingsChange is triggered on page load
+    eventHub.on('settingsChange', function (newSettings) {
+        this.allowStoreCodeDebug = newSettings.allowStoreCodeDebug;
     }, this);
 }
 
@@ -170,6 +175,7 @@ function handleRequestError(request, reject, xhr, textStatus, errorThrown) {
 
 CompilerService.prototype.submit = function (request) {
     var jsonRequest = JSON.stringify(request);
+    request.allowStoreCodeDebug = this.allowStoreCodeDebug;
     if (options.doCache) {
         var cachedResult = this.cache.get(jsonRequest);
         if (cachedResult) {

--- a/static/hub.js
+++ b/static/hub.js
@@ -67,7 +67,7 @@ function Hub(layout, subLangId) {
     this.layout = layout;
     this.editorIds = new Ids();
     this.compilerIds = new Ids();
-    this.compilerService = new CompilerService();
+    this.compilerService = new CompilerService(layout.eventHub);
     this.deferred = true;
     this.deferredEmissions = [];
     this.lastOpenedLangId = null;

--- a/static/policies/privacy.html
+++ b/static/policies/privacy.html
@@ -39,7 +39,11 @@ No need to update this! It's done by the CLI build process
     window along with your chosen compiler and options to the Compiler Explorer servers. There, the source code is
     written to disk and your chosen compiler is invoked on it. If your request was to have your code executed, the
     resulting executable is run. The outputs from compilation and execution are processed and sent back to your web
-    browser, where they're shown. Once this process completed, your source code is deleted from disk.
+    browser, where they're shown. Shortly after this process completes, your source code is deleted from disk. If, in
+    processing your query, an issue with Compiler Explorer is found, your code may be kept a little longer in order to
+    help debug and diagnose the problem. Only the Compiler Explorer team will have access to your code, and only for the
+    purposes of debugging the site: we will never share your code with anyone. We will never keep your code longer than
+    a week.
 </p>
 
 <p>
@@ -59,7 +63,8 @@ No need to update this! It's done by the CLI build process
 
 <p>
     In short: your source code is stored in plaintext for the minimum time feasible to be able to process your request.
-    After that, it is discarded and is inaccessible.
+    After that, it is discarded and is inaccessible. In very rare cases your code may be kept for a little longer (at
+    most a week) to help debug issues in Compiler Explorer.
 </p>
 
 <h4>Short links</h4>

--- a/static/policies/privacy.html
+++ b/static/policies/privacy.html
@@ -40,10 +40,9 @@ No need to update this! It's done by the CLI build process
     written to disk and your chosen compiler is invoked on it. If your request was to have your code executed, the
     resulting executable is run. The outputs from compilation and execution are processed and sent back to your web
     browser, where they're shown. Shortly after this process completes, your source code is deleted from disk. If, in
-    processing your query, an issue with Compiler Explorer is found, your code may be kept a little longer in order to
+    processing your query, an issue with Compiler Explorer is found, your code may be kept for up to a week in order to
     help debug and diagnose the problem. Only the Compiler Explorer team will have access to your code, and only for the
-    purposes of debugging the site: we will never share your code with anyone. We will never keep your code longer than
-    a week.
+    purposes of debugging the site: we will never share your code with anyone.
 </p>
 
 <p>

--- a/static/settings.js
+++ b/static/settings.js
@@ -225,6 +225,7 @@ function setupSettings(root, settings, onChange, langId) {
     );
     add(root.find('.enableCtrlS'), 'enableCtrlS', true, Checkbox);
     add(root.find('.editorsFFont'), 'editorsFFont', 'Consolas, "Liberation Mono", Courier, monospace', Textbox);
+    add(root.find('.allowStoreCodeDebug'), 'allowStoreCodeDebug', true, Checkbox);
 
     setSettings(settings);
     handleThemes();

--- a/views/popups.pug
+++ b/views/popups.pug
@@ -86,7 +86,7 @@
               .checkbox
                 label
                   input.allowStoreCodeDebug(type="checkbox")
-                  | Allow my request to be stored (for up to a week) for diagnostic purposes in the event of an error
+                  | Allow my source code to be temporarily stored for diagnostic purposes in the event of an error
               div
                 label
                   | Theme&nbsp;

--- a/views/popups.pug
+++ b/views/popups.pug
@@ -83,6 +83,10 @@
                 small
                   span.fas.fa-info-circle(title="New editors only (Reset UI to clear yours)" aria-label="New editors only (Reset UI to clear yours)")
                 select.defaultLanguage
+              .checkbox
+                label
+                  input.allowStoreCodeDebug(type="checkbox")
+                  | Allow my request to be stored (for up to a week) for diagnostic purposes in the event of an error
               div
                 label
                   | Theme&nbsp;


### PR DESCRIPTION
Make explicit the fact we may wish to use people's code for debugging
and diagnosing CE issues. Puts a hard limit on a week for storing
people's code, and only in the case it caused an issue.

Comments welcomed on the wording, and the "one week" maximum. Is this long enough? Could we shorten it? Can we mechanically enforce (e.g. the "long query" bucket has a one-week autodelete or similar?)