### PR TITLE
Add remote storage backend

### DIFF
--- a/etc/config/compiler-explorer.defaults.properties
+++ b/etc/config/compiler-explorer.defaults.properties
@@ -33,3 +33,4 @@ privacyPolicyEnabled=false
 supportsLibraryCodeFilter=false
 ldPath=${exePath}/../lib|${exePath}/../lib32|${exePath}/../lib64
 ceToolsPath=../compiler-explorer-tools
+remoteStorageServer=https://godbolt.org

--- a/lib/storage/storage-remote.js
+++ b/lib/storage/storage-remote.js
@@ -1,0 +1,64 @@
+const logger = require('../logger').logger,
+    request = require('request'),
+    StorageBase = require('./storage').StorageBase,
+    util = require('util');
+
+class StorageRemote extends StorageBase {
+    constructor(httpRootDir, compilerProps) {
+        super(httpRootDir, compilerProps);
+
+        this.baseUrl = compilerProps.ceProps('remoteStorageServer');
+
+        const req = request.defaults({
+            baseUrl: this.baseUrl
+        });
+
+        this.get = util.promisify(req.get);
+        this.post = util.promisify(req.post);
+    }
+
+    async handler(req, res) {
+        let resp;
+        try {
+            resp = await this.post('/shortener', {
+                json: true,
+                body: req.body
+            });
+        } catch (err) {
+            logger.error(err);
+            res.status(500);
+            res.end(err.message);
+            return;
+        }
+
+        const url = resp.body.url;
+        if (!url) {
+            res.status(resp.statusCode);
+            res.end(resp.body);
+            return;
+        }
+
+        const relativeUrl = url.substring(url.lastIndexOf('/z/') + 1);
+        const shortlink = `${req.protocol}://${req.get('host')}${this.httpRootDir}${relativeUrl}`;
+
+        res.set('Content-Type', 'application/json');
+        res.send(JSON.stringify({url: shortlink}));
+    }
+
+    async expandId(id) {
+        const resp = await this.get(`/api/shortlinkinfo/${id}`);
+
+        if (resp.statusCode !== 200) throw new Error(`ID ${id} not present in remote storage`);
+
+        return {
+            config: resp.body,
+            specialMetadata: null
+        };
+    }
+
+    incrementViewCount() {
+        return Promise.resolve();
+    }
+}
+
+module.exports = StorageRemote;


### PR DESCRIPTION
Allows a CE instance to utilize another remote CE instance for shortlink storage

Just add `storageSolution=remote` to `compiler-explorer.local.properties` and you can now locally open any shortlink that exists on `remoteStorageServer` (which defaults to `https://godbolt.org`).

Clicking "Share" also forwards the shortlink creation to `remoteStorageServer`.

Of course for any of this to work correctly both the local and remote CE instances have to be configured relatively similarly (same compilers, tools, etc).

The intention is not for people running their own local CE instances to start using this (although I can imagine it being useful in certain cases if you are sufficiently careful).

I primarily find this useful for developing and debugging - if someone shares a shortlink in a bug report you can now simply open that link on your own local instance.
