### PR TITLE
Enable escape and insert to work properly in VIM mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5691,9 +5691,9 @@
       }
     },
     "monaco-vim": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/monaco-vim/-/monaco-vim-0.0.14.tgz",
-      "integrity": "sha512-9y1oqMG2YTfnr7GdaZc60tpXaMURl0qDHpP0eXmi2nJc5nY39V8XQjzHxpbNi5bAhMF+VHaop7wFEY8fES8HKg=="
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/monaco-vim/-/monaco-vim-0.1.3.tgz",
+      "integrity": "sha512-1Rvgbren/4HbL1S/LhW2IVHyayFBxNUxHrh0Do+afh/MTYbteyKwC4ANjVRlqeSX2Ib8qovDUajLG30yF6aeQA=="
     },
     "morgan": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lz-string": "^1.4.4",
     "mkdirp": "^0.5.1",
     "monaco-editor": "^0.15.6",
-    "monaco-vim": "0.0.14",
+    "monaco-vim": "0.1.3",
     "morgan": "^1.9.1",
     "node-graceful": "^2.0.0",
     "node-targz": "^0.2.0",

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -258,11 +258,43 @@ Editor.prototype.initCallbacks = function () {
     }, this));
 
     this.eventHub.on('initialised', this.maybeEmitChange, this);
+
+    $(document).on('keyup.editable', _.bind(function (e) {
+        if (event.target === this.domRoot.find(".monaco-placeholder .inputarea")[0]) {
+            if (e.which === 27) {
+                this.onEscapeKey(e);
+            } else if (e.which === 45) {
+                this.onInsertKey(e);
+            }
+        }
+    }, this));
 };
 
 Editor.prototype.onMouseMove = function (e) {
     if (e !== null && e.target !== null && this.settings.hoverShowSource && e.target.position !== null) {
         this.tryPanesLinkLine(e.target.position.lineNumber, false);
+    }
+};
+
+Editor.prototype.onEscapeKey = function (event) {
+    if (this.editor.vimInUse) {
+        monacoVim.VimMode.Vim.exitInsertMode(this.vimMode);
+    }
+};
+
+Editor.prototype.onInsertKey = function (event) {
+    if (this.editor.vimInUse) {
+        var currentState = monacoVim.VimMode.Vim.maybeInitVimState_(this.vimMode);
+        if (!currentState.insertMode) {
+            var insertEvent = {};
+            insertEvent.preventDefault = event.preventDefault;
+            insertEvent.stopPropagation = event.stopPropagation;
+            insertEvent.browserEvent = {};
+            insertEvent.browserEvent.key = 'i';
+            insertEvent.browserEvent.defaultPrevented = false;
+            insertEvent.keyCode = 39;
+            this.vimMode.handleKeyDown(insertEvent);
+        }
     }
 };
 

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -260,7 +260,7 @@ Editor.prototype.initCallbacks = function () {
     this.eventHub.on('initialised', this.maybeEmitChange, this);
 
     $(document).on('keyup.editable', _.bind(function (e) {
-        if (event.target === this.domRoot.find(".monaco-placeholder .inputarea")[0]) {
+        if (e.target === this.domRoot.find(".monaco-placeholder .inputarea")[0]) {
             if (e.which === 27) {
                 this.onEscapeKey(e);
             } else if (e.which === 45) {

--- a/static/panes/editor.js
+++ b/static/panes/editor.js
@@ -276,7 +276,7 @@ Editor.prototype.onMouseMove = function (e) {
     }
 };
 
-Editor.prototype.onEscapeKey = function (event) {
+Editor.prototype.onEscapeKey = function () {
     if (this.editor.vimInUse) {
         monacoVim.VimMode.Vim.exitInsertMode(this.vimMode);
     }


### PR DESCRIPTION
Escape has a nice solution, but Insert required some faking the keypress magic, unfortunately.

Toggle problem will be fixed with https://github.com/brijeshb42/monaco-vim/pull/37
