### PR TITLE
Set overflow:visible in lm_content

### DIFF
--- a/static/explorer.css
+++ b/static/explorer.css
@@ -476,3 +476,7 @@ kbd {
 .linked-compiler-output-line {
     cursor: pointer;
 }
+
+.lm_content {
+    overflow: visible;
+}


### PR DESCRIPTION
Fixes dropdown menus not being displayed if they don't fit on the gl pane

I've tested this and I could not find any issues with it, but I'll let another pair of eyes check it out before merging because if there's any issue, it might be too subtle for me to notice.

Fixes #1441 & related issues reported on Slack