### PR TITLE
Add basic support for CUDA native SASS assembly

### DIFF
--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -1,10 +1,8 @@
 compilers=&nvcc:&cuclang
 defaultCompiler=nvcc92
-supportsBinary=true
+supportsBinary=false
 supportsExecute=false
-rpathFlag=-L # WAR, really need `-Xcompiler "-Wl,-rpath=<path>"`, but not required because supportsExecute=false
 demangler=/opt/compiler-explorer/gcc-9.1.0/bin/c++filt
-objdumper=/opt/compiler-explorer/cuda/10.1.168/bin/nvdisasm
 
 group.nvcc.compilers=nvcc101u1:nvcc101:nvcc100:nvcc92:nvcc91
 group.nvcc.versionRe=^Cuda.*
@@ -12,6 +10,9 @@ group.nvcc.compilerType=nvcc
 group.nvcc.isSemVer=true
 group.nvcc.baseName=NVCC
 group.nvcc.includeFlag=-I
+group.nvcc.supportsBinary=true
+group.nvcc.objdumper=/opt/compiler-explorer/cuda/10.1.168/bin/nvdisasm
+group.nvcc.rpathFlag=-L # WAR, really need `-Xcompiler "-Wl,-rpath=<path>"`, but not required because supportsExecute=false
 compiler.nvcc91.semver=9.1
 compiler.nvcc91.exe=/opt/compiler-explorer/cuda/9.1.85/bin/nvcc
 compiler.nvcc91.options=--compiler-bindir /opt/compiler-explorer/gcc-6.4.0/bin -I/opt/compiler-explorer/cuda/9.1.85/include -I/opt/compiler-explorer/cuda/9.1.85/include/crt

--- a/etc/config/cuda.amazon.properties
+++ b/etc/config/cuda.amazon.properties
@@ -1,7 +1,10 @@
 compilers=&nvcc:&cuclang
 defaultCompiler=nvcc92
-supportsBinary=false
+supportsBinary=true
+supportsExecute=false
+rpathFlag=-L # WAR, really need `-Xcompiler "-Wl,-rpath=<path>"`, but not required because supportsExecute=false
 demangler=/opt/compiler-explorer/gcc-9.1.0/bin/c++filt
+objdumper=/opt/compiler-explorer/cuda/10.1.168/bin/nvdisasm
 
 group.nvcc.compilers=nvcc101u1:nvcc101:nvcc100:nvcc92:nvcc91
 group.nvcc.versionRe=^Cuda.*

--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -451,6 +451,7 @@ class AsmParser extends AsmRegex {
 
             match = line.match(this.asmOpcodeRe);
             if (match) {
+                if (typeof match[5] !== 'undefined') match[2] = match[5].replace(/([0-9a-f]{2})/g, '$1 ').split(" ").reverse().join(" "); // For nvdisasm
                 const address = parseInt(match[1], 16);
                 const opcodes = match[2].split(" ").filter(x => !!x);
                 const disassembly = " " + AsmRegex.filterAsmLine(match[4], filters);

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -153,7 +153,6 @@ class BaseCompiler {
         let args = ["-d", outputFilename, "-l", "--insn-width=16"];
         if (demangle) args = args.concat("-C");
         if (intelAsm) args = args.concat(["-M", "intel"]);
-        if (this.lang.name === 'CUDA') args = [outputFilename, "-c", "-g", "-hex"]; // For nvdisasm
         const execOptions = {maxOutput: maxSize, customCwd: path.dirname(outputFilename)};
 
         return this.exec(this.compiler.objdumper, args, execOptions)

--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -153,6 +153,7 @@ class BaseCompiler {
         let args = ["-d", outputFilename, "-l", "--insn-width=16"];
         if (demangle) args = args.concat("-C");
         if (intelAsm) args = args.concat(["-M", "intel"]);
+        if (this.lang.name === 'CUDA') args = [outputFilename, "-c", "-g", "-hex"]; // For nvdisasm
         const execOptions = {maxOutput: maxSize, customCwd: path.dirname(outputFilename)};
 
         return this.exec(this.compiler.objdumper, args, execOptions)

--- a/lib/compilers/nvcc.js
+++ b/lib/compilers/nvcc.js
@@ -23,6 +23,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 const BaseCompiler = require('../base-compiler'),
+    path = require('path'),
     argumentParsers = require("./argument-parsers");
 
 class NvccCompiler extends BaseCompiler {
@@ -46,6 +47,21 @@ class NvccCompiler extends BaseCompiler {
 
     getArgumentParser() {
         return argumentParsers.Clang;
+    }
+
+    objdump(outputFilename, result, maxSize, intelAsm, demangle) {
+        // For nvdisasm.
+        let args = [outputFilename, "-c", "-g", "-hex"];
+        const execOptions = {maxOutput: maxSize, customCwd: path.dirname(outputFilename)};
+
+        return this.exec(this.compiler.objdumper, args, execOptions)
+            .then(objResult => {
+                result.asm = objResult.stdout;
+                if (objResult.code !== 0) {
+                    result.asm = `<No output: nvdisasm returned ${objResult.code}>`;
+                }
+                return result;
+            });
     }
 }
 

--- a/lib/compilers/nvcc.js
+++ b/lib/compilers/nvcc.js
@@ -49,7 +49,7 @@ class NvccCompiler extends BaseCompiler {
         return argumentParsers.Clang;
     }
 
-    objdump(outputFilename, result, maxSize, intelAsm, demangle) {
+    objdump(outputFilename, result, maxSize) {
         // For nvdisasm.
         let args = [outputFilename, "-c", "-g", "-hex"];
         const execOptions = {maxOutput: maxSize, customCwd: path.dirname(outputFilename)};

--- a/lib/compilers/nvcc.js
+++ b/lib/compilers/nvcc.js
@@ -28,6 +28,10 @@ const BaseCompiler = require('../base-compiler'),
 class NvccCompiler extends BaseCompiler {
     constructor(info, env) {
         super(info, env);
+        // These are for parsing the output of nvdisasm.
+        this.asm.asmOpcodeRe = /^\s*\/\*([^*]+)\*\/()()\s*{?\s*([^};]+)(?:}|;\s*\/\* 0x([0-9a-f]+) \*\/)$/;
+        this.asm.lineRe = /^\s*\/\/## File "([^"]+)", line (\d+)$/;
+        this.asm.labelRe = /^(?!\.text\.)()(\S[^:]+):$/;
     }
 
     // TODO: (for all of CUDA)
@@ -37,7 +41,7 @@ class NvccCompiler extends BaseCompiler {
     // * would be nice to try and filter unused `.func`s from e.g. clang output
 
     optionsForFilter(filters, outputFilename) {
-        return ['-o', this.filename(outputFilename), '--ptx', '--generate-line-info'];
+        return ['-o', this.filename(outputFilename), '-lineinfo', filters.binary ? '-cubin' : '-ptx'];
     }
 
     getArgumentParser() {


### PR DESCRIPTION
- Enables "Compile to binary and disassemble the output" for CUDA source.
- Parses labels, line numbers, opcodes and disassembly.
- Fixes #946 