### PR TITLE
Remove protocol from short URL

### DIFF
--- a/lib/storage/storage-remote.js
+++ b/lib/storage/storage-remote.js
@@ -39,7 +39,7 @@ class StorageRemote extends StorageBase {
         }
 
         const relativeUrl = url.substring(url.lastIndexOf('/z/') + 1);
-        const shortlink = `${req.protocol}://${req.get('host')}${this.httpRootDir}${relativeUrl}`;
+        const shortlink = `//${req.get('host')}${this.httpRootDir}${relativeUrl}`;
 
         res.set('Content-Type', 'application/json');
         res.send(JSON.stringify({url: shortlink}));

--- a/lib/storage/storage.js
+++ b/lib/storage/storage.js
@@ -112,7 +112,7 @@ class StorageBase {
             })
             .then(result => {
                 res.set('Content-Type', 'application/json');
-                const shortlink = `${req.protocol}://${req.get('host')}${this.httpRootDir}z/${result.uniqueSubHash}`;
+                const shortlink = `//${req.get('host')}${this.httpRootDir}z/${result.uniqueSubHash}`;
                 res.send(JSON.stringify({url: shortlink}));
             })
             .catch(err => {


### PR DESCRIPTION
This can cause problem with reverse-proxy that expose https and forward to http.
It's also easier as the browser should correctly choose which protocol to use.
See: https://stackoverflow.com/questions/4831741/can-i-change-all-my-http-links-to-just

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
