### PR TITLE
Refresh libraries per compiler

### DIFF
--- a/static/libs-widget.js
+++ b/static/libs-widget.js
@@ -71,9 +71,11 @@ LibsWidget.prototype.updateAvailableLibs = function (possibleLibs) {
 
     if (!this.availableLibs[this.currentLangId][this.currentCompilerId]) {
         if (this.currentCompilerId === '_default_') {
-            this.availableLibs[this.currentLangId][this.currentCompilerId] = $.extend(true, {}, options.libs[this.currentLangId]);
+            this.availableLibs[this.currentLangId][this.currentCompilerId] =
+                $.extend(true, {}, options.libs[this.currentLangId]);
         } else {
-            this.availableLibs[this.currentLangId][this.currentCompilerId] = $.extend(true, {}, possibleLibs);
+            this.availableLibs[this.currentLangId][this.currentCompilerId] =
+                $.extend(true, {}, possibleLibs);
         }
     }
 

--- a/static/panes/compiler.js
+++ b/static/panes/compiler.js
@@ -169,6 +169,7 @@ Compiler.prototype.initLangAndCompiler = function (state) {
     var result = this.compilerService.processFromLangAndCompiler(langId, compilerId);
     this.compiler = result.compiler;
     this.currentLangId = result.langId;
+    this.updateLibraries();
 };
 
 Compiler.prototype.close = function () {
@@ -935,8 +936,12 @@ Compiler.prototype.onLibsChanged = function () {
 };
 
 Compiler.prototype.initLibraries = function (state) {
-    this.libsWidget = new Libraries.Widget(this.currentLangId, this.libsButton,
+    this.libsWidget = new Libraries.Widget(this.currentLangId, this.compiler.id, this.compiler.libs, this.libsButton,
         state, _.bind(this.onLibsChanged, this));
+};
+
+Compiler.prototype.updateLibraries = function () {
+    if (this.libsWidget) this.libsWidget.setNewLangId(this.currentLangId, this.compiler.id, this.compiler.libs);
 };
 
 Compiler.prototype.supportsTool = function (toolId) {
@@ -1246,6 +1251,7 @@ Compiler.prototype.updateCompilerUI = function () {
 Compiler.prototype.onCompilerChange = function (value) {
     this.compiler = this.compilerService.findCompiler(this.currentLangId, value);
     this.saveState();
+    this.updateLibraries();
     this.compile();
     this.updateCompilerUI();
     this.sendCompiler();
@@ -1682,7 +1688,6 @@ Compiler.prototype.onLanguageChange = function (editorId, newLangId) {
             compiler: this.compiler && this.compiler.id ? this.compiler.id : options.defaultCompiler[oldLangId],
             options: this.options
         };
-        this.libsWidget.setNewLangId(newLangId);
         var info = this.infoByLang[this.currentLangId] || {};
         this.initLangAndCompiler({lang: newLangId, compiler: info.compiler});
         this.updateCompilersSelector(info);

--- a/static/panes/conformance-view.js
+++ b/static/panes/conformance-view.js
@@ -228,6 +228,7 @@ Conformance.prototype.setCompilationOptionsPopover = function (element, content)
 
 Conformance.prototype.removeCompilerSelector = function (element) {
     if (element) element.remove();
+    this.updateLibraries();
     this.handleToolbarUI();
     this.saveState();
 };
@@ -415,26 +416,24 @@ Conformance.prototype.updateHideables = function () {
 };
 
 Conformance.prototype.updateLibraries = function () {
-    var compilers = _.map(this.selectorList.children(), _.bind(function (child) {
-        var compilerId = $(child).find('.compiler-picker').val();
-        if (compilerId) {
-            return this.compilerService.findCompiler(this.langId, compilerId);
-        } else {
-            return false;
-        }
+    var compilerIds = _.uniq(
+        _.filter(
+            _.map(this.selectorList.children(), function (child) {
+                return $(child).find('.compiler-picker').val();
+            })
+        , function (compilerId) {
+            return compilerId !== "";
+        })
+    );
+
+    var compilers = _.map(compilerIds, _.bind(function (compilerId) {
+        return this.compilerService.findCompiler(this.langId, compilerId);
     }, this));
 
-    var compilerIds = false;
     var libraries = {};
     var first = true;
     _.forEach(compilers, function (compiler) {
         if (compiler) {
-            if (compilerIds) {
-                compilerIds = compilerIds + "|" + compiler.id;
-            } else {
-                compilerIds = compiler.id;
-            }
-
             if (first) {
                 libraries = _.extend({}, compiler.libs);
                 first = false;
@@ -446,7 +445,7 @@ Conformance.prototype.updateLibraries = function () {
         }
     });
 
-    this.libsWidget.setNewLangId(this.langId, compilerIds, libraries);
+    this.libsWidget.setNewLangId(this.langId, compilerIds.join("|"), libraries);
 };
 
 Conformance.prototype.onLanguageChange = function (editorId, newLangId) {

--- a/static/panes/conformance-view.js
+++ b/static/panes/conformance-view.js
@@ -89,7 +89,8 @@ Conformance.prototype.onLibsChanged = function () {
 };
 
 Conformance.prototype.initLibraries = function (state) {
-    this.libsWidget = new Libraries.Widget(this.langId, false, false, this.libsButton, state, _.bind(this.onLibsChanged, this));
+    this.libsWidget = new Libraries.Widget(this.langId, false, false,
+        this.libsButton, state, _.bind(this.onLibsChanged, this));
 };
 
 Conformance.prototype.initButtons = function () {
@@ -413,7 +414,7 @@ Conformance.prototype.updateHideables = function () {
 };
 
 Conformance.prototype.updateLibraries = function () {
-    this.libsWidget.setNewLangId(newLangId);
+    this.libsWidget.setNewLangId(this.langId);
 };
 
 Conformance.prototype.onLanguageChange = function (editorId, newLangId) {

--- a/static/panes/conformance-view.js
+++ b/static/panes/conformance-view.js
@@ -171,6 +171,7 @@ Conformance.prototype.addCompilerSelector = function (config) {
         this.handleStatusIcon(status, {code: 0});
         var compiler = this.compilerService.findCompiler(this.langId, compilerId);
         if (compiler) this.setCompilationOptionsPopover(prependOptions, compiler.options);
+        this.updateLibraries();
     }, this);
 
     var compilerPicker = newEntry.find('.compiler-picker').selectize({
@@ -414,7 +415,38 @@ Conformance.prototype.updateHideables = function () {
 };
 
 Conformance.prototype.updateLibraries = function () {
-    this.libsWidget.setNewLangId(this.langId);
+    var compilers = _.map(this.selectorList.children(), _.bind(function (child) {
+        var compilerId = $(child).find('.compiler-picker').val();
+        if (compilerId) {
+            return this.compilerService.findCompiler(this.langId, compilerId);
+        } else {
+            return false;
+        }
+    }, this));
+
+    var compilerIds = false;
+    var libraries = {};
+    var first = true;
+    _.forEach(compilers, function (compiler) {
+        if (compiler) {
+            if (compilerIds) {
+                compilerIds = compilerIds + "|" + compiler.id;
+            } else {
+                compilerIds = compiler.id;
+            }
+
+            if (first) {
+                libraries = _.extend({}, compiler.libs);
+                first = false;
+            } else {
+                libraries = _.omit(libraries, function (value, key) {
+                    return !_.keys(compiler.libs).includes(key);
+                });
+            }
+        }
+    });
+
+    this.libsWidget.setNewLangId(this.langId, compilerIds, libraries);
 };
 
 Conformance.prototype.onLanguageChange = function (editorId, newLangId) {

--- a/static/panes/conformance-view.js
+++ b/static/panes/conformance-view.js
@@ -89,7 +89,7 @@ Conformance.prototype.onLibsChanged = function () {
 };
 
 Conformance.prototype.initLibraries = function (state) {
-    this.libsWidget = new Libraries.Widget(this.langId, this.libsButton, state, _.bind(this.onLibsChanged, this));
+    this.libsWidget = new Libraries.Widget(this.langId, false, false, this.libsButton, state, _.bind(this.onLibsChanged, this));
 };
 
 Conformance.prototype.initButtons = function () {
@@ -412,6 +412,10 @@ Conformance.prototype.updateHideables = function () {
     this.hideable.toggle(this.domRoot.width() > this.addCompilerButton.width());
 };
 
+Conformance.prototype.updateLibraries = function () {
+    this.libsWidget.setNewLangId(newLangId);
+};
+
 Conformance.prototype.onLanguageChange = function (editorId, newLangId) {
     if (editorId === this.editorId && this.langId !== newLangId) {
         var oldLangId = this.langId;
@@ -421,7 +425,7 @@ Conformance.prototype.onLanguageChange = function (editorId, newLangId) {
         this.selectorList.children().remove();
         var langState = this.stateByLang[newLangId];
         this.initFromState(langState);
-        this.libsWidget.setNewLangId(newLangId);
+        this.updateLibraries();
         this.handleToolbarUI();
         this.saveState();
     }

--- a/static/panes/conformance-view.js
+++ b/static/panes/conformance-view.js
@@ -421,9 +421,9 @@ Conformance.prototype.updateLibraries = function () {
             _.map(this.selectorList.children(), function (child) {
                 return $(child).find('.compiler-picker').val();
             })
-        , function (compilerId) {
-            return compilerId !== "";
-        })
+            , function (compilerId) {
+                return compilerId !== "";
+            })
     );
 
     var compilers = _.map(compilerIds, _.bind(function (compilerId) {

--- a/static/panes/executor.js
+++ b/static/panes/executor.js
@@ -127,6 +127,7 @@ Executor.prototype.initLangAndCompiler = function (state) {
     var result = this.compilerService.processFromLangAndCompiler(langId, compilerId);
     this.compiler = result.compiler;
     this.currentLangId = result.langId;
+    this.updateLibraries();
 };
 
 Executor.prototype.close = function () {
@@ -752,6 +753,10 @@ Executor.prototype.handleCompilationStatus = function (status) {
         .toggleClass('fa-check-circle', status.code !== 4 && status.didExecute);
 };
 
+Executor.prototype.updateLibraries = function () {
+    if (this.libsWidget) this.libsWidget.setNewLangId(this.currentLangId, this.compiler.id, this.compiler.libs);
+};
+
 Executor.prototype.onLanguageChange = function (editorId, newLangId) {
     if (this.sourceEditorId === editorId) {
         var oldLangId = this.currentLangId;
@@ -763,7 +768,6 @@ Executor.prototype.onLanguageChange = function (editorId, newLangId) {
             execArgs: this.executionArguments,
             execStdin: this.executionStdin
         };
-        this.libsWidget.setNewLangId(newLangId);
         var info = this.infoByLang[this.currentLangId] || {};
         this.initLangAndCompiler({lang: newLangId, compiler: info.compiler});
         this.updateCompilersSelector(info);


### PR DESCRIPTION
Makes use of the library listing on a specific compiler to change the list of libraries.
Adds update of libraries when changing compiler.

Only client-side changes, because we already had libraries per compiler.

Fixes https://github.com/mattgodbolt/compiler-explorer/issues/1572

Needs a bit more testing.

For conformance view only the libraries available in all selected compilers are listed.
