### PR TITLE
Add support for NanoRange

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -572,7 +572,7 @@ compiler.djggp494.semver=4.9.4
 #################################
 #################################
 # Installed libs
-libs=boost:brigand:kvasir:cmcstl2:mp-units:ctbignum:gsl:expected_lite:nlohmann_json:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl
+libs=boost:brigand:kvasir:cmcstl2:mp-units:ctbignum:gsl:expected_lite:nlohmann_json:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl:nanorange
 libs.boost.name=Boost
 libs.boost.versions=164:165:166:167:168:169:170:171
 libs.boost.url=https://www.boost.org
@@ -982,6 +982,11 @@ libs.openssl.versions.111c.version=1.1.1c
 libs.openssl.versions.111c.path=/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86_64/opt/include
 libs.openssl.versions.111c.libpath=/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86_64/opt/lib:/opt/compiler-explorer/libs/openssl/openssl_1_1_1c/x86/opt/lib
 libs.openssl.versions.111c.liblink=ssl:crypto
+libs.nanorange.name=NanoRange
+libs.nanorange.versions=trunk
+libs.nanorange.url=https://github.com/tcbrindle/NanoRange
+libs.nanorange.versions.trunk.version=trunk
+libs.nanorange.versions.trunk.path=/opt/compiler-explorer/libs/nanorange/include
 
 
 #################################


### PR DESCRIPTION
This PR (hopefully?) adds support for the [NanoRange](https://github.com/tcbrindle/NanoRange.git) library, an independent implementation of the C++20 ranges proposals.

Image PR: https://github.com/mattgodbolt/compiler-explorer-image/pull/261

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
