### PR TITLE
[WIP] pass include flags to clang-tidy

### DIFF
--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -26,6 +26,7 @@
 const
     exec = require('../exec'),
     utils = require('../utils'),
+    _ = require('underscore'),
     logger = require('../logger').logger,
     path = require('path');
 
@@ -68,6 +69,27 @@ class BaseTool {
             languageId: "stderr",
             stdout: utils.parseOutput(message)
         };
+    }
+
+    // mostly copy&paste from base-compiler.js
+    findLibVersion(selectedLib, compiler) {
+        const foundLib = _.find(compiler.libs, (o, libId) => libId === selectedLib.id);
+        if (!foundLib) return false;
+
+        const foundVersion = _.find(foundLib.versions, (o, versionId) => versionId === selectedLib.version);
+        return foundVersion;
+    }
+
+    // mostly copy&paste from base-compiler.js
+    getIncludeArguments(libraries, compiler) {
+        const includeFlag = "-I";
+
+        return _.flatten(_.map(libraries, (selectedLib) => {
+            const foundVersion = this.findLibVersion(selectedLib, compiler);
+            if (!foundVersion) return false;
+
+            return _.map(foundVersion.path, (path) => includeFlag + path);
+        }));
     }
 
     runTool(compilationInfo, inputFilepath, args, stdin) {

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -57,7 +57,6 @@ class ClangTidyTool extends BaseTool {
 
     runTool(compilationInfo, inputFilepath, args) {
         const sourcefile = inputFilepath;
-        const compilerExe = compilationInfo.compiler.exe;
         const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
         const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -26,6 +26,8 @@
 const
     fs = require('fs-extra'),
     path = require('path'),
+    _ = require('underscore'),
+    logger = require('../logger').logger,
     BaseTool = require('./base-tool');
 
 class ClangTidyTool extends BaseTool {
@@ -33,11 +35,34 @@ class ClangTidyTool extends BaseTool {
         super(toolInfo, env);
     }
 
+    // mostly copy&paste from bse-compiler.js
+    findLibVersion(selectedLib, compiler) {
+        const foundLib = _.find(compiler.libs, (o, libId) => libId === selectedLib.id);
+        if (!foundLib) return false;
+
+        const foundVersion = _.find(foundLib.versions, (o, versionId) => versionId === selectedLib.version);
+        return foundVersion;
+    }
+
+    // mostly copy&paste from bse-compiler.js
+    getIncludeArguments(libraries, compiler) {
+        const includeFlag = "-I";
+
+        return _.flatten(_.map(libraries, (selectedLib) => {
+            const foundVersion = this.findLibVersion(selectedLib, compiler);
+            if (!foundVersion) return false;
+
+            return _.map(foundVersion.path, (path) => includeFlag + path);
+        }));
+    }
+
     runTool(compilationInfo, inputFilepath, args) {
         const sourcefile = inputFilepath;
         const compilerExe = compilationInfo.compiler.exe;
         const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
+
+        const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
 
         let source;
         const wantsFix = args.find(option => option.includes("-fix"));
@@ -52,7 +77,10 @@ class ClangTidyTool extends BaseTool {
         if (!compilerExe.includes("clang++")) {
             compileFlags.push(this.tool.options);
         }
+        // FIXME: map is surely the wrong tool here, but pseyfert is very unfamiliar with js so copy&pasted it together like that
+        _.map(includeflags, (flag) => compileFlags.push(flag));
 
+        // TODO: do we want compile_flags.txt rather than prefixing everything with -extra-arg=
         return fs.writeFile(
             path.join(dir, "compile_flags.txt"),
             compileFlags.join("\n")

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -26,7 +26,6 @@
 const
     fs = require('fs-extra'),
     path = require('path'),
-    _ = require('underscore'),
     BaseTool = require('./base-tool');
 
 class ClangTidyTool extends BaseTool {
@@ -34,32 +33,11 @@ class ClangTidyTool extends BaseTool {
         super(toolInfo, env);
     }
 
-    // mostly copy&paste from bse-compiler.js
-    findLibVersion(selectedLib, compiler) {
-        const foundLib = _.find(compiler.libs, (o, libId) => libId === selectedLib.id);
-        if (!foundLib) return false;
-
-        const foundVersion = _.find(foundLib.versions, (o, versionId) => versionId === selectedLib.version);
-        return foundVersion;
-    }
-
-    // mostly copy&paste from bse-compiler.js
-    getIncludeArguments(libraries, compiler) {
-        const includeFlag = "-I";
-
-        return _.flatten(_.map(libraries, (selectedLib) => {
-            const foundVersion = this.findLibVersion(selectedLib, compiler);
-            if (!foundVersion) return false;
-
-            return _.map(foundVersion.path, (path) => includeFlag + path);
-        }));
-    }
-
     runTool(compilationInfo, inputFilepath, args) {
         const sourcefile = inputFilepath;
         const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
-        const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
+        const includeflags = super.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
 
         let source;
         const wantsFix = args.find(option => option.includes("-fix"));

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -63,6 +63,7 @@ class ClangTidyTool extends BaseTool {
         const dir = path.dirname(sourcefile);
 
         const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
+        // logger.warn(`compiler options ${compilationInfo.compiler.options}`)
 
         let source;
         const wantsFix = args.find(option => option.includes("-fix"));
@@ -73,14 +74,34 @@ class ClangTidyTool extends BaseTool {
             source = data.toString();
         }
 
-        const compileFlags = options.filter(option => (option !== sourcefile));
-        if (!compilerExe.includes("clang++")) {
-            compileFlags.push(this.tool.options);
-        }
-        // FIXME: map is surely the wrong tool here, but pseyfert is very unfamiliar with js so copy&pasted it together like that
-        _.map(includeflags, (flag) => compileFlags.push(flag));
+        // order should be:
+        //  1) options from the compiler config (compilationInfo.compiler.options)
+        //  2) includes from the libraries (includeflags)
+        //  ?) options from the tool config (this.tool.options)
+        //  3) options manually specified in the compiler tab (options)
+        //  *) indepenent are `args` from the clang-tidy tab
+        // let compileFlags = [compilationInfo.compiler.options];
+        let compileFlags = compilationInfo.compiler.options.split(" ");
+        compileFlags = compileFlags.concat(includeflags);
+
+        const manualCompileFlags = options.filter(option => (option !== sourcefile));
+        compileFlags = compileFlags.concat(manualCompileFlags);
+        compileFlags = compileFlags.concat(this.tool.options);
+
+
+        // var toType = function(obj) {
+        //     return ({}).toString.call(obj).match(/\s([a-zA-Z]+)/)[1].toLowerCase()
+        // }
+        //
+        // logger.warn(`compileFlags[0] is a ${toType(compileFlags[0])} while manualCompileFlags[0] is a ${toType(manualCompileFlags[0])}`)
+
+        // FIXME: this does not do the job in my setup
+        // if (!compilerExe.includes("clang++")) {
+        //     compileFlags.push(this.tool.options);
+        // }
 
         // TODO: do we want compile_flags.txt rather than prefixing everything with -extra-arg=
+        // logger.warn(`compile_flags.txt contains ${compileFlags.join("\n")}`);
         return fs.writeFile(
             path.join(dir, "compile_flags.txt"),
             compileFlags.join("\n")

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -27,7 +27,6 @@ const
     fs = require('fs-extra'),
     path = require('path'),
     _ = require('underscore'),
-    logger = require('../logger').logger,
     BaseTool = require('./base-tool');
 
 class ClangTidyTool extends BaseTool {
@@ -61,9 +60,7 @@ class ClangTidyTool extends BaseTool {
         const compilerExe = compilationInfo.compiler.exe;
         const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
-
         const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
-        // logger.warn(`compiler options ${compilationInfo.compiler.options}`)
 
         let source;
         const wantsFix = args.find(option => option.includes("-fix"));
@@ -78,9 +75,9 @@ class ClangTidyTool extends BaseTool {
         //  1) options from the compiler config (compilationInfo.compiler.options)
         //  2) includes from the libraries (includeflags)
         //  ?) options from the tool config (this.tool.options)
+        //     -> before my patchup this was done only for non-clang compilers
         //  3) options manually specified in the compiler tab (options)
         //  *) indepenent are `args` from the clang-tidy tab
-        // let compileFlags = [compilationInfo.compiler.options];
         let compileFlags = compilationInfo.compiler.options.split(" ");
         compileFlags = compileFlags.concat(includeflags);
 
@@ -88,20 +85,7 @@ class ClangTidyTool extends BaseTool {
         compileFlags = compileFlags.concat(manualCompileFlags);
         compileFlags = compileFlags.concat(this.tool.options);
 
-
-        // var toType = function(obj) {
-        //     return ({}).toString.call(obj).match(/\s([a-zA-Z]+)/)[1].toLowerCase()
-        // }
-        //
-        // logger.warn(`compileFlags[0] is a ${toType(compileFlags[0])} while manualCompileFlags[0] is a ${toType(manualCompileFlags[0])}`)
-
-        // FIXME: this does not do the job in my setup
-        // if (!compilerExe.includes("clang++")) {
-        //     compileFlags.push(this.tool.options);
-        // }
-
         // TODO: do we want compile_flags.txt rather than prefixing everything with -extra-arg=
-        // logger.warn(`compile_flags.txt contains ${compileFlags.join("\n")}`);
         return fs.writeFile(
             path.join(dir, "compile_flags.txt"),
             compileFlags.join("\n")


### PR DESCRIPTION
This is following up on my posting on [compiler-explorer-development](https://groups.google.com/d/msg/compiler-explorer-development/Z9qpfvZQk1k/dw0slkh7AAAJ).

I saw undesired (for me) behaviour of compiler-explorer in when using clang-tidy, as shown in [this](https://godbolt.org/z/y2lJ6y) example.  While compilation with clang worked fine, clang-tidy shows a clang-diagnostic-error from missing headers - one that should be found through the settings of libraries.

## Behaviour that I want to achieve

I claim, when using clang-tidy, one wants to pass the include flags that are given to the compiler also to clang-tidy. Otherwise clang-tidy will fail to work properly (failing to find headers).

Similarly, I assume a user wants settings like (assuming unix/gcc command line interface) `-D... -mavx -std=c++14` when they are specified in the compiler options box in the browser to be applied to clang-tidy consistently (you don't want compilation to be done with the preprocessor for the compilation thinking `SOMESWITCH` was enabled, but clang-tidy to run for the it disabled).  (Writing this, I realise my code will only make sense for compilers that are command line compatible with clang++).

In my instance's settings this applies to user defined compiler options (from the options text box in the browser) as well as to those configured by the admin in `etc/config/c++.local.properties`.

Lastly, at least in my setting I want the clang-tidy settings in `tools.clang-tidy.options=…` to be passed to clang-tidy in any case, for compilation with clang and with gcc. I saw the switch in the existing code that only uses the properties configuration for compilation with not-clang++ compilers but have to admit I didn't understand the reason behind that.

## Implementation

Inexperienced with node.js here …

The code to derive `-I` flags from the user selected libraries is copy and pasted from base-compiler.js (with modifications). That's probably something that deserves cleanup before merging.

No test added or modified.

PS: Not sure which convention for the meaning of WIP you're using here. There's no pending change to the PR from my side. But I expect that you'll want some things to be changed before hitting merge (avoid code duplication, add test, revert change to compiler==clang++ switch …)