### PR TITLE
Fix sever comparison for single digit

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -77,4 +77,5 @@ From oldest to newest contributor, we would like to thank:
 - [Austin Morton](https://github.com/apmorton)
 - [Matt Hammerly](https://github.com/mhammerly)
 - [Christian Vonrüti](https://github.com/alshain)
+- [Alessandro Vergani](https://github.com/Loghorn)
 

--- a/lib/options-handler.js
+++ b/lib/options-handler.js
@@ -205,7 +205,10 @@ class ClientOptionsHandler {
     }
 
     _asSafeVer(semver) {
-        return semverParser.valid(semver, true) || semverParser.valid(semver + '.0', true) || "9999999.99999.999";
+        return semverParser.valid(semver, true) ||
+            semverParser.valid(semver + '.0', true) ||
+            semverParser.valid(semver + '.0.0', true) ||
+            "9999999.99999.999";
     }
 
     setCompilers(compilers) {

--- a/test/options-handler.js
+++ b/test/options-handler.js
@@ -58,7 +58,7 @@ const libProps = {
 if (process.platform === "win32") {
     libProps['libs.fakelib.versions.twoPaths.path'] =
         libProps['libs.fakelib.versions.twoPaths.path'].replace(':', ';');
-    libProps['libs.fakelib.versions.twoPaths.libpath'] = 
+    libProps['libs.fakelib.versions.twoPaths.libpath'] =
         libProps['libs.fakelib.versions.twoPaths.libpath'].replace(':', ';');
 }
 
@@ -121,7 +121,11 @@ describe('Options handler', () => {
             makeFakeCompilerInfo('d3', languages.fake.id, 'd', '0.0.5', true),
 
             makeFakeCompilerInfo('e1', languages.fake.id, 'e', '0..0', false),
-            makeFakeCompilerInfo('e2', languages.fake.id, 'e', undefined, false)
+            makeFakeCompilerInfo('e2', languages.fake.id, 'e', undefined, false),
+
+            makeFakeCompilerInfo('f1', languages.fake.id, 'f', '5', true),
+            makeFakeCompilerInfo('f2', languages.fake.id, 'f', '5.1', true),
+            makeFakeCompilerInfo('f3', languages.fake.id, 'f', '5.2', true)
         ];
         const expectedOrder = {
             a: {
@@ -140,18 +144,23 @@ describe('Options handler', () => {
                 c3: -2
             },
             d: {
-                d1: -2,
-                d2: -1,
+                d1: -1,
+                d2: -2,
                 d3: -0
             },
             e: {
                 e1: undefined,
                 e2: undefined
+            },
+            f: {
+                f1: -0,
+                f2: -1,
+                f3: -2
             }
         };
         optionsHandler.setCompilers(compilers);
         _.each(optionsHandler.get().compilers, compiler => {
-            should.equal(compiler['$order'], expectedOrder[compiler.group][compiler.id]);
+            should.equal(compiler['$order'], expectedOrder[compiler.group][compiler.id], `group: ${compiler.group} id: ${compiler.id}`);
         });
         optionsHandler.setCompilers([]);
     });


### PR DESCRIPTION
This fixes #1598 by making a comparison between 'x' and 'x.1', behave like 'x' is 'x.0' thus sorting it after 'x.1'
