### PR TITLE
Allow forward slash in all command line arguments

### DIFF
--- a/lib/compilers/ppci.js
+++ b/lib/compilers/ppci.js
@@ -26,14 +26,18 @@ const BaseCompiler = require('../base-compiler'),
     exec = require('../exec'),
     logger = require('../logger').logger;
 
+const blacklist = [
+    '--report',
+    '--text-report',
+    '--html-report'
+];
+
 class PPCICompiler extends BaseCompiler {
     filterUserOptions(args) {
         return args.filter((item) => {
             if (typeof item !== "string") return true;
 
-            return ((item.endsWith("output.s") || item.endsWith(this.compileFilename) || !item.includes("/")) &&
-                (item.toLowerCase() !== "--report") &&
-                (item.toLowerCase() !== "--text-report"));
+            return !blacklist.includes(item.toLowerCase());
         });
     }
 

--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -76,7 +76,6 @@ class BaseTool {
         execOptions.input = stdin;
 
         args = args ? args : [];
-        args = args.filter((arg) => !arg.includes('/'));
         if (inputFilepath) args.push(inputFilepath);
 
         const exeDir = path.dirname(this.tool.exe);

--- a/test/ppci-tests.js
+++ b/test/ppci-tests.js
@@ -50,13 +50,13 @@ describe('PPCI', function () {
         compiler.filterUserOptions(["hello", "-help", "--something"]).should.deep.equal(["hello", "-help", "--something"]);
     });
 
-    it('Should be Not ok with path argument', () => {
+    it('Should be ok with path argument', () => {
         const compiler = new PPCICompiler(info, ce);
-        compiler.filterUserOptions(["hello", "--stuff", "/proc/cpuinfo"]).should.deep.equal(["hello", "--stuff"]);
+        compiler.filterUserOptions(["hello", "--stuff", "/proc/cpuinfo"]).should.deep.equal(["hello", "--stuff", "/proc/cpuinfo"]);
     });
 
     it('Should be Not ok with report arguments', () => {
         const compiler = new PPCICompiler(info, ce);
-        compiler.filterUserOptions(["hello", "--report", "--text-report"]).should.deep.equal(["hello"]);
+        compiler.filterUserOptions(["hello", "--report", "--text-report", "--html-report"]).should.deep.equal(["hello"]);
     });
 });


### PR DESCRIPTION
They are already allowed in nearly all places,
the only exceptions being PPCI and tools.

Additionally update PPCI argument blacklist
to include --html-report option.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
