### PR TITLE
[WIP] add support for tools that use a compiler command line

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1015,7 +1015,7 @@ libs.benri.versions.211.path=/opt/compiler-explorer/libs/benri/v2.1.1/include
 #################################
 # Installed tools
 
-tools=clangtidytrunk:llvm-mcatrunk:pahole:clangquerytrunk:readelf:x86to6502:ldd
+tools=clangtidytrunk:llvm-mcatrunk:pahole:clangquerytrunk:readelf:x86to6502:ldd:iwyu
 
 tools.clangtidytrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang-tidy
 tools.clangtidytrunk.name=clang-tidy (trunk)
@@ -1067,3 +1067,11 @@ tools.x86to6502.class=x86to6502-tool
 tools.x86to6502.exclude=avr:rv32:arm:aarch:mips:msp:ppc:cl19:cl_new:djggp:riscv:wasm:frc2019:raspbian:arduino
 tools.x86to6502.stdinHint=disabled
 tools.x86to6502.languageId=asm6502
+
+tools.iwyu.exe=/opt/compiler-explorer/iwyu/bin/include-what-you-use
+tools.iwyu.name=include-what-you-use
+tools.iwyu.type=independent
+tools.iwyu.class=compiler-dropin-tool
+# e.g.
+# tools.iwyu.options=-Xiwyu --mapping_file=/opt/compiler-explorer/iwyu/share/include-what-you-use/gcc-8.intrinsics.imp
+tools.iwyu.stdinHint=disabled

--- a/lib/tooling/base-tool.js
+++ b/lib/tooling/base-tool.js
@@ -26,6 +26,7 @@
 const
     exec = require('../exec'),
     utils = require('../utils'),
+    _ = require('underscore'),
     logger = require('../logger').logger,
     path = require('path');
 
@@ -68,6 +69,27 @@ class BaseTool {
             languageId: "stderr",
             stdout: utils.parseOutput(message)
         };
+    }
+
+    // mostly copy&paste from base-compiler.js
+    findLibVersion(selectedLib, compiler) {
+        const foundLib = _.find(compiler.libs, (o, libId) => libId === selectedLib.id);
+        if (!foundLib) return false;
+
+        const foundVersion = _.find(foundLib.versions, (o, versionId) => versionId === selectedLib.version);
+        return foundVersion;
+    }
+
+    // mostly copy&paste from base-compiler.js
+    getIncludeArguments(libraries, compiler) {
+        const includeFlag = "-I";
+
+        return _.flatten(_.map(libraries, (selectedLib) => {
+            const foundVersion = this.findLibVersion(selectedLib, compiler);
+            if (!foundVersion) return false;
+
+            return _.map(foundVersion.path, (path) => includeFlag + path);
+        }));
     }
 
     runTool(compilationInfo, inputFilepath, args, stdin) {

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -57,7 +57,6 @@ class ClangTidyTool extends BaseTool {
 
     runTool(compilationInfo, inputFilepath, args) {
         const sourcefile = inputFilepath;
-        const compilerExe = compilationInfo.compiler.exe;
         const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
         const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -26,6 +26,8 @@
 const
     fs = require('fs-extra'),
     path = require('path'),
+    _ = require('underscore'),
+    logger = require('../logger').logger,
     BaseTool = require('./base-tool');
 
 class ClangTidyTool extends BaseTool {
@@ -33,11 +35,34 @@ class ClangTidyTool extends BaseTool {
         super(toolInfo, env);
     }
 
+    // mostly copy&paste from bse-compiler.js
+    findLibVersion(selectedLib, compiler) {
+        const foundLib = _.find(compiler.libs, (o, libId) => libId === selectedLib.id);
+        if (!foundLib) return false;
+
+        const foundVersion = _.find(foundLib.versions, (o, versionId) => versionId === selectedLib.version);
+        return foundVersion;
+    }
+
+    // mostly copy&paste from bse-compiler.js
+    getIncludeArguments(libraries, compiler) {
+        const includeFlag = "-I";
+
+        return _.flatten(_.map(libraries, (selectedLib) => {
+            const foundVersion = this.findLibVersion(selectedLib, compiler);
+            if (!foundVersion) return false;
+
+            return _.map(foundVersion.path, (path) => includeFlag + path);
+        }));
+    }
+
     runTool(compilationInfo, inputFilepath, args) {
         const sourcefile = inputFilepath;
         const compilerExe = compilationInfo.compiler.exe;
         const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
+
+        const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
 
         let source;
         const wantsFix = args.find(option => option.includes("-fix"));
@@ -52,7 +77,10 @@ class ClangTidyTool extends BaseTool {
         if (!compilerExe.includes("clang++")) {
             compileFlags.push(this.tool.options);
         }
+        // FIXME: map is surely the wrong tool here, but pseyfert is very unfamiliar with js so copy&pasted it together like that
+        _.map(includeflags, (flag) => compileFlags.push(flag));
 
+        // TODO: do we want compile_flags.txt rather than prefixing everything with -extra-arg=
         return fs.writeFile(
             path.join(dir, "compile_flags.txt"),
             compileFlags.join("\n")

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -26,7 +26,6 @@
 const
     fs = require('fs-extra'),
     path = require('path'),
-    _ = require('underscore'),
     BaseTool = require('./base-tool');
 
 class ClangTidyTool extends BaseTool {
@@ -34,32 +33,11 @@ class ClangTidyTool extends BaseTool {
         super(toolInfo, env);
     }
 
-    // mostly copy&paste from bse-compiler.js
-    findLibVersion(selectedLib, compiler) {
-        const foundLib = _.find(compiler.libs, (o, libId) => libId === selectedLib.id);
-        if (!foundLib) return false;
-
-        const foundVersion = _.find(foundLib.versions, (o, versionId) => versionId === selectedLib.version);
-        return foundVersion;
-    }
-
-    // mostly copy&paste from bse-compiler.js
-    getIncludeArguments(libraries, compiler) {
-        const includeFlag = "-I";
-
-        return _.flatten(_.map(libraries, (selectedLib) => {
-            const foundVersion = this.findLibVersion(selectedLib, compiler);
-            if (!foundVersion) return false;
-
-            return _.map(foundVersion.path, (path) => includeFlag + path);
-        }));
-    }
-
     runTool(compilationInfo, inputFilepath, args) {
         const sourcefile = inputFilepath;
         const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
-        const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
+        const includeflags = super.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
 
         let source;
         const wantsFix = args.find(option => option.includes("-fix"));

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -63,6 +63,7 @@ class ClangTidyTool extends BaseTool {
         const dir = path.dirname(sourcefile);
 
         const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
+        // logger.warn(`compiler options ${compilationInfo.compiler.options}`)
 
         let source;
         const wantsFix = args.find(option => option.includes("-fix"));
@@ -73,14 +74,34 @@ class ClangTidyTool extends BaseTool {
             source = data.toString();
         }
 
-        const compileFlags = options.filter(option => (option !== sourcefile));
-        if (!compilerExe.includes("clang++")) {
-            compileFlags.push(this.tool.options);
-        }
-        // FIXME: map is surely the wrong tool here, but pseyfert is very unfamiliar with js so copy&pasted it together like that
-        _.map(includeflags, (flag) => compileFlags.push(flag));
+        // order should be:
+        //  1) options from the compiler config (compilationInfo.compiler.options)
+        //  2) includes from the libraries (includeflags)
+        //  ?) options from the tool config (this.tool.options)
+        //  3) options manually specified in the compiler tab (options)
+        //  *) indepenent are `args` from the clang-tidy tab
+        // let compileFlags = [compilationInfo.compiler.options];
+        let compileFlags = compilationInfo.compiler.options.split(" ");
+        compileFlags = compileFlags.concat(includeflags);
+
+        const manualCompileFlags = options.filter(option => (option !== sourcefile));
+        compileFlags = compileFlags.concat(manualCompileFlags);
+        compileFlags = compileFlags.concat(this.tool.options);
+
+
+        // var toType = function(obj) {
+        //     return ({}).toString.call(obj).match(/\s([a-zA-Z]+)/)[1].toLowerCase()
+        // }
+        //
+        // logger.warn(`compileFlags[0] is a ${toType(compileFlags[0])} while manualCompileFlags[0] is a ${toType(manualCompileFlags[0])}`)
+
+        // FIXME: this does not do the job in my setup
+        // if (!compilerExe.includes("clang++")) {
+        //     compileFlags.push(this.tool.options);
+        // }
 
         // TODO: do we want compile_flags.txt rather than prefixing everything with -extra-arg=
+        // logger.warn(`compile_flags.txt contains ${compileFlags.join("\n")}`);
         return fs.writeFile(
             path.join(dir, "compile_flags.txt"),
             compileFlags.join("\n")

--- a/lib/tooling/clang-tidy-tool.js
+++ b/lib/tooling/clang-tidy-tool.js
@@ -27,7 +27,6 @@ const
     fs = require('fs-extra'),
     path = require('path'),
     _ = require('underscore'),
-    logger = require('../logger').logger,
     BaseTool = require('./base-tool');
 
 class ClangTidyTool extends BaseTool {
@@ -61,9 +60,7 @@ class ClangTidyTool extends BaseTool {
         const compilerExe = compilationInfo.compiler.exe;
         const options = compilationInfo.options;
         const dir = path.dirname(sourcefile);
-
         const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
-        // logger.warn(`compiler options ${compilationInfo.compiler.options}`)
 
         let source;
         const wantsFix = args.find(option => option.includes("-fix"));
@@ -78,9 +75,9 @@ class ClangTidyTool extends BaseTool {
         //  1) options from the compiler config (compilationInfo.compiler.options)
         //  2) includes from the libraries (includeflags)
         //  ?) options from the tool config (this.tool.options)
+        //     -> before my patchup this was done only for non-clang compilers
         //  3) options manually specified in the compiler tab (options)
         //  *) indepenent are `args` from the clang-tidy tab
-        // let compileFlags = [compilationInfo.compiler.options];
         let compileFlags = compilationInfo.compiler.options.split(" ");
         compileFlags = compileFlags.concat(includeflags);
 
@@ -88,20 +85,7 @@ class ClangTidyTool extends BaseTool {
         compileFlags = compileFlags.concat(manualCompileFlags);
         compileFlags = compileFlags.concat(this.tool.options);
 
-
-        // var toType = function(obj) {
-        //     return ({}).toString.call(obj).match(/\s([a-zA-Z]+)/)[1].toLowerCase()
-        // }
-        //
-        // logger.warn(`compileFlags[0] is a ${toType(compileFlags[0])} while manualCompileFlags[0] is a ${toType(manualCompileFlags[0])}`)
-
-        // FIXME: this does not do the job in my setup
-        // if (!compilerExe.includes("clang++")) {
-        //     compileFlags.push(this.tool.options);
-        // }
-
         // TODO: do we want compile_flags.txt rather than prefixing everything with -extra-arg=
-        // logger.warn(`compile_flags.txt contains ${compileFlags.join("\n")}`);
         return fs.writeFile(
             path.join(dir, "compile_flags.txt"),
             compileFlags.join("\n")

--- a/lib/tooling/compiler-dropin-tool.js
+++ b/lib/tooling/compiler-dropin-tool.js
@@ -24,9 +24,6 @@
 "use strict";
 
 const
-    fs = require('fs-extra'),
-    path = require('path'),
-    utils = require('../utils'),
     _ = require('underscore'),
     BaseTool = require('./base-tool');
 
@@ -57,11 +54,9 @@ class CompilerDropinTool extends BaseTool {
         }));
     }
 
-    runTool(compilationInfo, inputFilepath, args, stdin) {
+    runTool(compilationInfo, inputFilepath, args) {
         const sourcefile = inputFilepath;
-        const compilerExe = compilationInfo.compiler.exe;
         const options = compilationInfo.options;
-        const dir = path.dirname(sourcefile);
 
         const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
 
@@ -71,12 +66,15 @@ class CompilerDropinTool extends BaseTool {
         //  3) options from the tool config (this.tool.options)
         //  4) options manually specified in the compiler tab (options)
         //  5) flags from the clang-tidy tab
-        let compileFlags = compilationInfo.compiler.options.split(" ");
+        const compilerOptions = compilationInfo.compiler.options ? compilationInfo.compiler.options.split(" ") : [];
+        let compileFlags = compilerOptions;
         compileFlags = compileFlags.concat(includeflags);
 
         const manualCompileFlags = options.filter(option => (option !== sourcefile));
         compileFlags = compileFlags.concat(manualCompileFlags);
-        compileFlags = compileFlags.concat(this.tool.options.split(" "));
+        const toolOptions = this.tool.options ? this.tool.options.split(" ") : [];
+        compileFlags = compileFlags.concat(toolOptions);
+        args ? args : [];
         compileFlags = compileFlags.concat(args);
 
         return super.runTool(compilationInfo, sourcefile, compileFlags);

--- a/lib/tooling/compiler-dropin-tool.js
+++ b/lib/tooling/compiler-dropin-tool.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Compiler Explorer Authors
+// Copyright (c) 2019, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -24,54 +24,19 @@
 "use strict";
 
 const
-    exec = require('../exec'),
+    fs = require('fs-extra'),
+    path = require('path'),
     utils = require('../utils'),
     _ = require('underscore'),
-    logger = require('../logger').logger,
-    path = require('path');
+    BaseTool = require('./base-tool');
 
-class BaseTool {
+class CompilerDropinTool extends BaseTool {
     constructor(toolInfo, env) {
-        this.tool = toolInfo;
-        this.env = env;
-        this.tool.exclude = this.tool.exclude ? this.tool.exclude.split(':') : [];
-    }
-
-    getId() {
-        return this.tool.id;
-    }
-
-    getType() {
-        return this.tool.type || "independent";
-    }
-
-    isCompilerExcluded(compilerId) {
-        return this.tool.exclude.find((excl) => compilerId.includes(excl));
-    }
-
-    exec(toolExe, args, options) {
-        return exec.execute(toolExe, args, options);
-    }
-
-    getDefaultExecOptions() {
-        return {
-            timeoutMs: this.env.ceProps("compileTimeoutMs", 7500),
-            maxErrorOutput: this.env.ceProps("max-error-output", 5000),
-            wrapper: this.env.compilerProps("compiler-wrapper")
-        };
-    }
-
-    createErrorResponse(message) {
-        return {
-            id: this.tool.id,
-            name: this.tool.name,
-            code: -1,
-            languageId: "stderr",
-            stdout: utils.parseOutput(message)
-        };
+        super(toolInfo, env);
     }
 
     // mostly copy&paste from base-compiler.js
+    // FIXME: remove once #1617 is merged
     findLibVersion(selectedLib, compiler) {
         const foundLib = _.find(compiler.libs, (o, libId) => libId === selectedLib.id);
         if (!foundLib) return false;
@@ -93,30 +58,29 @@ class BaseTool {
     }
 
     runTool(compilationInfo, inputFilepath, args, stdin) {
-        let execOptions = this.getDefaultExecOptions();
-        if (inputFilepath) execOptions.customCwd = path.dirname(inputFilepath);
-        execOptions.input = stdin;
+        const sourcefile = inputFilepath;
+        const compilerExe = compilationInfo.compiler.exe;
+        const options = compilationInfo.options;
+        const dir = path.dirname(sourcefile);
 
-        args = args ? args : [];
-        if (inputFilepath) args.push(inputFilepath);
+        const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
 
-        const exeDir = path.dirname(this.tool.exe);
+        // order should be:
+        //  1) options from the compiler config (compilationInfo.compiler.options)
+        //  2) includes from the libraries (includeflags)
+        //  3) options from the tool config (this.tool.options)
+        //  4) options manually specified in the compiler tab (options)
+        //  5) flags from the clang-tidy tab
+        let compileFlags = compilationInfo.compiler.options.split(" ");
+        compileFlags = compileFlags.concat(includeflags);
 
-        return this.exec(this.tool.exe, args, execOptions).then(result => {
-            const transformedFilepath = result.filenameTransform(inputFilepath);
-            return {
-                id: this.tool.id,
-                name: this.tool.name,
-                code: result.code,
-                languageId: this.tool.languageId,
-                stderr: utils.parseOutput(result.stderr, transformedFilepath, exeDir),
-                stdout: utils.parseOutput(result.stdout, transformedFilepath, exeDir)
-            };
-        }).catch((e) => {
-            logger.error("Error while running tool: ", e);
-            return this.createErrorResponse("Error while running tool");
-        });
+        const manualCompileFlags = options.filter(option => (option !== sourcefile));
+        compileFlags = compileFlags.concat(manualCompileFlags);
+        compileFlags = compileFlags.concat(this.tool.options.split(" "));
+        compileFlags = compileFlags.concat(args);
+
+        return super.runTool(compilationInfo, sourcefile, compileFlags);
     }
 }
 
-module.exports = BaseTool;
+module.exports = CompilerDropinTool;

--- a/lib/tooling/compiler-dropin-tool.js
+++ b/lib/tooling/compiler-dropin-tool.js
@@ -23,42 +23,18 @@
 // POSSIBILITY OF SUCH DAMAGE.
 "use strict";
 
-const
-    _ = require('underscore'),
-    BaseTool = require('./base-tool');
+const BaseTool = require('./base-tool');
 
 class CompilerDropinTool extends BaseTool {
     constructor(toolInfo, env) {
         super(toolInfo, env);
     }
 
-    // mostly copy&paste from base-compiler.js
-    // FIXME: remove once #1617 is merged
-    findLibVersion(selectedLib, compiler) {
-        const foundLib = _.find(compiler.libs, (o, libId) => libId === selectedLib.id);
-        if (!foundLib) return false;
-
-        const foundVersion = _.find(foundLib.versions, (o, versionId) => versionId === selectedLib.version);
-        return foundVersion;
-    }
-
-    // mostly copy&paste from base-compiler.js
-    getIncludeArguments(libraries, compiler) {
-        const includeFlag = "-I";
-
-        return _.flatten(_.map(libraries, (selectedLib) => {
-            const foundVersion = this.findLibVersion(selectedLib, compiler);
-            if (!foundVersion) return false;
-
-            return _.map(foundVersion.path, (path) => includeFlag + path);
-        }));
-    }
-
     runTool(compilationInfo, inputFilepath, args) {
         const sourcefile = inputFilepath;
         const options = compilationInfo.options;
 
-        const includeflags = this.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
+        const includeflags = super.getIncludeArguments(compilationInfo.libraries, compilationInfo.compiler);
 
         // order should be:
         //  1) options from the compiler config (compilationInfo.compiler.options)


### PR DESCRIPTION
I'd like to run tools that are command line compatible with compilers.

More specifically that is [include-what-you-use](https://include-what-you-use.org/) which is clang based and uses the same CLI (with some additional `-Xiwyu --something` flags).

As discussed on slack, for this I need to remove the filter for `/` in the base tool (otherwise include paths don't reach the tool). It could be re-added in `runToolsOfType` in `base-compiler.js`, though as far as I understood the slack discussion there's a preference to be compatible between tools and compilers and allow `/`.

Obviously for this PR to be useful for godbolt.org include-what-you-use needs to be made available on the amazon instance…

For me locally it looks like that: 

![2019-10-09-231405_1360x713_scrot](https://user-images.githubusercontent.com/5124749/66524066-abb08100-eaf1-11e9-9615-a8f2acef2b08.png)
