### PR TITLE
Fix some dark theme backgrounds

### DIFF
--- a/static/themes/dark-theme.css
+++ b/static/themes/dark-theme.css
@@ -187,9 +187,12 @@ a.navbar-brand img.logo.normal {
     color: #fff;
 }
 
-pre.content {
+pre {
     color: #f2f2f2 !important;
-    background-color: #333 !important;
+}
+
+pre.content {
+    background-color: #1e1e1e !important;
 }
 
 .bottom-bar {


### PR DESCRIPTION
The compiler output window used a lighter background color than all the other code windows, which decreased the text contrast. Also, the embedded compiler output boxes didn't have a color override, so they displayed as black on dark grey.

### Before
<img width="1278" alt="Screen Shot 2019-10-11 at 02 55 53" src="https://user-images.githubusercontent.com/1690225/66630779-e9390b00-ebd2-11e9-909b-4bf72e0c8e51.png">

### After
<img width="1280" alt="Screen Shot 2019-10-11 at 02 56 06" src="https://user-images.githubusercontent.com/1690225/66630777-e9390b00-ebd2-11e9-959b-f2437e5daa6c.png">

Should see if this helps with #1583. 