### PR TITLE
Fix a small error in llvm-ir-parser-tests.js

### DIFF
--- a/test/llvm-ir-parser-tests.js
+++ b/test/llvm-ir-parser-tests.js
@@ -36,7 +36,7 @@ const languages = {
 };
 
 let compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
-compilerProps = compilerProps.get.bind(compilerProps);
+compilerProps = compilerProps.get.bind(compilerProps, 'c++');
 
 describe('llvm-ir parseMetaNode', function () {
     const llvmIrParser = new LlvmIrParser(compilerProps);


### PR DESCRIPTION
This removes the 'error: Tried to pass maxLinesOfAsm as a language ID'.
Those are printed when the test creates a LlvmIrParser.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
