### PR TITLE
Zig update

### DIFF
--- a/etc/config/zig.amazon.properties
+++ b/etc/config/zig.amazon.properties
@@ -1,7 +1,7 @@
 compilers=&zig
-defaultCompiler=z040
+defaultCompiler=z050
 
-group.zig.compilers=ztrunk:z020:z030:z040
+group.zig.compilers=ztrunk:z020:z030:z040:z050
 group.zig.objdumper=/opt/compiler-explorer/gcc-9.1.0/bin/objdump
 group.zig.isSemVer=true
 group.zig.baseName=zig
@@ -17,6 +17,8 @@ compiler.z030.exe=/opt/compiler-explorer/zig-0.3.0/zig
 compiler.z030.semver=0.3.0
 compiler.z040.exe=/opt/compiler-explorer/zig-0.4.0/zig
 compiler.z040.semver=0.4.0
+compiler.z050.exe=/opt/compiler-explorer/zig-0.5.0/zig
+compiler.z050.semver=0.5.0
 
 #################################
 #################################

--- a/lib/compilers/zig.js
+++ b/lib/compilers/zig.js
@@ -31,6 +31,8 @@ class ZigCompiler extends BaseCompiler {
     constructor(info, env) {
         super(info, env);
         this.compiler.supportsIntel = true;
+        this.compiler.supportsIrView = true;
+        this.compiler.irArg = ['--emit', 'llvm-ir'];
     }
 
     getSharedLibraryPathsAsArguments() {
@@ -79,6 +81,11 @@ class ZigCompiler extends BaseCompiler {
             if (filters.intel) options = options.concat('-mllvm', '--x86-asm-syntax=intel');
         }
         return options;
+    }
+
+    getIrOutputFilename(inputFilename) {
+        return this.getOutputFilename(path.dirname(inputFilename), this.outputFilebase)
+            .replace('.s', '.ll');
     }
 
     filterUserOptions(userOptions) {

--- a/static/modes/zig-mode.js
+++ b/static/modes/zig-mode.js
@@ -31,17 +31,18 @@ function definition() {
 
         keywords: [
             'const', 'var', 'extern', 'packed', 'export', 'pub', 'noalias', 'inline',
-            'comptime', 'nakedcc', 'stdcallcc', 'volatile', 'align', 'section',
+            'comptime', 'nakedcc', 'stdcallcc', 'volatile', 'align', 'section', 'linksection',
             'struct', 'enum', 'union',
             'break', 'return', 'continue', 'asm', 'defer', 'errdefer', 'unreachable',
             'try', 'catch', 'async', 'await', 'suspend', 'resume', 'cancel',
             'if', 'else', 'switch', 'and', 'or', 'orelse',
             'while', 'for',
-            'null', 'undefined', 'this',
-            'fn', 'use', 'test'
+            'null', 'undefined',
+            'fn', 'usingnamespace', 'use', 'test',
+            'this',
         ],
         typeKeywords: [
-            'bool', 'f32', 'f64', 'f128', 'void', 'noreturn', 'type', 'error', 'promise',
+            'bool', 'f32', 'f64', 'f128', 'void', 'noreturn', 'type', 'error', 'anyerror', 'promise', 'anyframe',
             'isize', 'usize', 'c_short', 'c_ushort', 'c_int', 'c_uint', 'c_long', 'c_ulong',
             'c_longlong', 'c_ulonglong', 'c_longdouble', 'c_void'
         ],


### PR DESCRIPTION
this PR depends on mattgodbolt/compiler-explorer-image#272 and adds support for the newest version of zig, updates the syntax, and adds support for emitting llvm ir from zig.

Closes #1328 

on as side note: zig 0.4.0 and trunk seem to be broken but i can't get compiler-explorer to build locally to debug it :/. 