### PR TITLE
Update CPPX trunk language standard to C++20

### DIFF
--- a/etc/config/cppx.amazon.properties
+++ b/etc/config/cppx.amazon.properties
@@ -16,7 +16,7 @@ compiler.cppx_20180922.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapsh
 
 compiler.cppx_trunk.exe=/opt/compiler-explorer/clang-cppx-trunk/bin/clang++
 compiler.cppx_trunk.name=Latest trunk
-compiler.cppx_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot -std=c++1z -Xclang -freflection -I/opt/compiler-explorer/clang-cppx-trunk/include -stdlib=libc++ -include experimental/meta -include experimental/compiler
+compiler.cppx_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-snapshot -std=c++2a -Xclang -freflection -I/opt/compiler-explorer/clang-cppx-trunk/include -stdlib=libc++ -include experimental/meta -include experimental/compiler
 
 #################################
 #################################


### PR DESCRIPTION
Update the CPPX trunk language standard to C++20 to prevent issues with the consteval keyword not being registered.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
