### PR TITLE
bugfix replace single line /*comments*/

### DIFF
--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -204,7 +204,7 @@ class AsmParser extends AsmRegex {
 
         if (filters.commentOnly) {
             // Remove any block comments that start and end on a line if we're removing comment-only lines.
-            const blockComments = /^\s*\/\*(\*(?!\/)|[^*])*\*\/\s*\r?\n/mg;
+            const blockComments = /^[ \t]*\/\*(\*(?!\/)|[^*])*\*\/\s*/mg;
             asm = asm.replace(blockComments, "");
         }
 


### PR DESCRIPTION
Fixed an annoying thing in the unittests on Windows