### PR TITLE
Add C/Fortran support for Arm Compiler for Linux

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -492,7 +492,7 @@ compiler.riscv820.objdumper=/opt/compiler-explorer/riscv64/gcc-8.2.0/riscv64-unk
 group.armhpc.compilers=armhpc-ac193a64
 group.armhpc.groupName=Arm Compiler for Linux
 group.armhpc.isSemVer=true
-compiler.armhpc-ac193a64.exe=/opt/arm/19.3/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin/armclang-wrapper
+compiler.armhpc-ac193a64.exe=/opt/arm/19.3/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin/armclang++-wrapper
 compiler.armhpc-ac193a64.name=ARM armclang++ 19.3
 compiler.armhpc-ac193a64.semver=19.3
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -199,7 +199,7 @@ compiler.cicc191.options=-x c -gcc-name=/opt/compiler-explorer/gcc-8.2.0/bin/gcc
 
 ###############################
 # Cross GCC
-group.ccross.compilers=&cppc:&cmips:&cmsp:&cgccarm:&cavr:&cplatspec
+group.ccross.compilers=&cppc:&cmips:&cmsp:&cgccarm:&cavr:&cplatspec:&armhpc
 group.ccross.supportsBinary=false
 group.ccross.groupName=Cross GCC
 
@@ -360,6 +360,15 @@ compiler.cmips564.semver=5.4
 compiler.cmips564el.exe=/opt/compiler-explorer/mips64el/gcc-5.4.0/mips64el-unknown-linux-gnu/bin/mips64el-unknown-linux-gnu-gcc
 compiler.cmips564el.name=MIPS64 gcc 5.4 (el)
 compiler.cmips564el.semver=5.4
+
+###############################
+# ARM HPC
+group.armhpc.compilers=armhpc-ac193a64
+group.armhpc.groupName=Arm Compiler for Linux
+group.armhpc.isSemVer=true
+compiler.armhpc-ac193a64.exe=/opt/arm/19.3/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin/armclang-wrapper
+compiler.armhpc-ac193a64.name=ARM armclang 19.3
+compiler.armhpc-ac193a64.semver=19.3
 
 ################################
 # Windows Compilers

--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -91,7 +91,7 @@ compiler.ifort19.semver=19.0.0
 
 ###############################
 # GCC Cross-Compilers
-group.cross.compilers=&gccarm:&gccaarch64:&ppc
+group.cross.compilers=&gccarm:&gccaarch64:&ppc:&armhpc
 group.cross.supportsBinary=false
 group.cross.groupName=Cross GCC
 
@@ -128,6 +128,15 @@ compiler.fppc64leg8.semver=(snapshot)
 compiler.fppc64g8.exe=/opt/compiler-explorer/powerpc64/gcc-at12/powerpc64-unknown-linux-gnu/bin/powerpc64-unknown-linux-gnu-gfortran
 compiler.fppc64g8.name=power64 AT12.0
 compiler.fppc64g8.semver=(snapshot)
+
+###############################
+# ARM HPC
+group.armhpc.compilers=armhpc-ac193a64
+group.armhpc.groupName=Arm Compiler for Linux
+group.armhpc.isSemVer=true
+compiler.armhpc-ac193a64.exe=/opt/arm/19.3/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin/armflang-wrapper
+compiler.armhpc-ac193a64.name=ARM armflang 19.3
+compiler.armhpc-ac193a64.semver=19.3
 
 #################################
 #################################


### PR DESCRIPTION
Hi folks,

The patch is pretty striaghtfoward (and passess make check) but I wouldn't be surprised if this uncovered issues with armclang++ and/or armflang, since they haven't been enabled before.  Can we try it out on beta?