### PR TITLE
Fix path handling for clang-style file directive

### DIFF
--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -188,9 +188,9 @@ class AsmParser extends AsmRegex {
             const match = line.match(this.fileFind);
             if (match) {
                 const lineNum = parseInt(match[1]);
-                if (match[3]) {
+                if (match[4]) {
                     // Clang-style file directive '.file X "dir" "filename"'
-                    files[lineNum] = match[2] + "/" + match[3];
+                    files[lineNum] = match[2] + "/" + match[4];
                 } else {
                     files[lineNum] = match[2];
                 }

--- a/test/cases/bug-1229.asm.directives.labels.comments.json
+++ b/test/cases/bug-1229.asm.directives.labels.comments.json
@@ -13,161 +13,161 @@
     {
         "text": "        mov     byte ptr [rsp + 32], 0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp",
             "line": 18
         }
     },
     {
         "text": "        mov     qword ptr [rsp + 24], 0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp",
             "line": 18
         }
     },
     {
         "text": "        mov     qword ptr [rsp + 40], offset .L.str",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     rax, qword ptr [rsp + 24]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     qword ptr [rsp + 48], rax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     al, byte ptr [rsp + 32]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     byte ptr [rsp + 56], al",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     eax, dword ptr [rsp + 33]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     dword ptr [rsp + 57], eax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        movzx   eax, word ptr [rsp + 37]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     word ptr [rsp + 61], ax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     al, byte ptr [rsp + 39]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     byte ptr [rsp + 63], al",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     rax, qword ptr [rsp + 56]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        mov     qword ptr [rsp + 16], rax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        movups  xmm0, xmmword ptr [rsp + 40]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        movups  xmmword ptr [rsp], xmm0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        lea     rdi, [rsp + 64]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        xor     esi, esi",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        mov     edx, offset .L.str",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        mov     ecx, offset .L.str+1",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        mov     r8d, offset .L.str+5",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        call    _ZN4ctre18evaluate_recursiveINS_13regex_resultsIPKcJEEES3_S3_Lm0ELm0EJNS_3anyEEJNS_10assert_endENS_8end_markENS_6acceptEEEET_mT0_SA_T1_S9_N4ctll4listIJNS_6repeatIXT2_EXT3_EJDpT4_EEEDpT5_EEE",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
@@ -188,14 +188,14 @@
     {
         "text": "        mov     rdi, rax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 298
         }
     },
     {
         "text": "        call    __clang_call_terminate",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 298
         }
     },
@@ -222,259 +222,259 @@
     {
         "text": "        push    rbx",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 235
         }
     },
     {
         "text": "        sub     rsp, 80",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 235
         }
     },
     {
         "text": "        mov     rbx, rdi",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 235
         }
     },
     {
         "text": "        mov     rdi, qword ptr [rsp + 96]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 241
         }
     },
     {
         "text": "        movups  xmm0, xmmword ptr [rsp + 104]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        movaps  xmmword ptr [rsp + 64], xmm0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        cmp     r8, rcx",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 65
         }
     },
     {
         "text": "        je      .LBB2_3",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 65
         }
     },
     {
         "text": "        add     rcx, 1",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 67
         }
     },
     {
         "text": "        mov     al, byte ptr [rsp + 79]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 57
         }
     },
     {
         "text": "        mov     byte ptr [rsp + 38], al",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 57
         }
     },
     {
         "text": "        movzx   eax, word ptr [rsp + 77]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 57
         }
     },
     {
         "text": "        mov     word ptr [rsp + 36], ax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 57
         }
     },
     {
         "text": "        mov     eax, dword ptr [rsp + 73]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 57
         }
     },
     {
         "text": "        mov     dword ptr [rsp + 32], eax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 57
         }
     },
     {
         "text": "        add     rsi, 1",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     qword ptr [rsp + 40], rdi",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     qword ptr [rsp + 48], rcx",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     byte ptr [rsp + 56], 0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     eax, dword ptr [rsp + 32]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     dword ptr [rsp + 57], eax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        movzx   eax, word ptr [rsp + 36]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     word ptr [rsp + 61], ax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     al, byte ptr [rsp + 38]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     byte ptr [rsp + 63], al",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     rax, qword ptr [rsp + 56]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     qword ptr [rsp + 16], rax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        movups  xmm0, xmmword ptr [rsp + 40]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        movups  xmmword ptr [rsp], xmm0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     rdi, rbx",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        call    _ZN4ctre18evaluate_recursiveINS_13regex_resultsIPKcJEEES3_S3_Lm0ELm0EJNS_3anyEEJNS_10assert_endENS_8end_markENS_6acceptEEEET_mT0_SA_T1_S9_N4ctll4listIJNS_6repeatIXT2_EXT3_EJDpT4_EEEDpT5_EEE",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        cmp     byte ptr [rbx + 16], 0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp",
             "line": 54
         }
     },
     {
         "text": "        je      .LBB2_2",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 246
         }
     },
     {
         "text": "        mov     rax, rbx",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },
     {
         "text": "        add     rsp, 80",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },
     {
         "text": "        pop     rbx",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },
     {
         "text": "        ret",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },
@@ -485,119 +485,119 @@
     {
         "text": "        lea     rax, [rsp + 96]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 0
         }
     },
     {
         "text": "        mov     rax, qword ptr [rax + 16]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 251
         }
     },
     {
         "text": "        mov     qword ptr [rbx], rdi",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 38
         }
     },
     {
         "text": "        mov     qword ptr [rbx + 8], r8",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 38
         }
     },
     {
         "text": "        mov     byte ptr [rbx + 16], 1",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 39
         }
     },
     {
         "text": "        mov     rcx, rax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 39
         }
     },
     {
         "text": "        shr     rcx, 8",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 39
         }
     },
     {
         "text": "        mov     rdx, rax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 39
         }
     },
     {
         "text": "        shr     rdx, 56",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 39
         }
     },
     {
         "text": "        mov     byte ptr [rbx + 23], dl",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 39
         }
     },
     {
         "text": "        shr     rax, 40",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 39
         }
     },
     {
         "text": "        mov     word ptr [rbx + 21], ax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 39
         }
     },
     {
         "text": "        mov     dword ptr [rbx + 17], ecx",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 39
         }
     },
     {
         "text": "        mov     rax, rbx",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },
     {
         "text": "        add     rsp, 80",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },
     {
         "text": "        pop     rbx",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },
     {
         "text": "        ret",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },
@@ -608,49 +608,49 @@
     {
         "text": "        xorps   xmm0, xmm0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp",
             "line": 18
         }
     },
     {
         "text": "        movups  xmmword ptr [rbx], xmm0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp",
             "line": 18
         }
     },
     {
         "text": "        mov     byte ptr [rbx + 16], 0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp",
             "line": 18
         }
     },
     {
         "text": "        mov     rax, rbx",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },
     {
         "text": "        add     rsp, 80",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },
     {
         "text": "        pop     rbx",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },
     {
         "text": "        ret",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 252
         }
     },

--- a/test/cases/bug-1229.asm.directives.labels.comments.library.json
+++ b/test/cases/bug-1229.asm.directives.labels.comments.library.json
@@ -13,161 +13,161 @@
     {
         "text": "        mov     byte ptr [rsp + 32], 0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp",
             "line": 18
         }
     },
     {
         "text": "        mov     qword ptr [rsp + 24], 0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/return_type.hpp",
             "line": 18
         }
     },
     {
         "text": "        mov     qword ptr [rsp + 40], offset .L.str",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     rax, qword ptr [rsp + 24]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     qword ptr [rsp + 48], rax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     al, byte ptr [rsp + 32]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     byte ptr [rsp + 56], al",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     eax, dword ptr [rsp + 33]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     dword ptr [rsp + 57], eax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        movzx   eax, word ptr [rsp + 37]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     word ptr [rsp + 61], ax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     al, byte ptr [rsp + 39]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     byte ptr [rsp + 63], al",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 64
         }
     },
     {
         "text": "        mov     rax, qword ptr [rsp + 56]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        mov     qword ptr [rsp + 16], rax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        movups  xmm0, xmmword ptr [rsp + 40]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        movups  xmmword ptr [rsp], xmm0",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        lea     rdi, [rsp + 64]",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        xor     esi, esi",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        mov     edx, offset .L.str",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        mov     ecx, offset .L.str+1",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        mov     r8d, offset .L.str+5",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
     {
         "text": "        call    _ZN4ctre18evaluate_recursiveINS_13regex_resultsIPKcJEEES3_S3_Lm0ELm0EJNS_3anyEEJNS_10assert_endENS_8end_markENS_6acceptEEEET_mT0_SA_T1_S9_N4ctll4listIJNS_6repeatIXT2_EXT3_EJDpT4_EEEDpT5_EEE",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 267
         }
     },
@@ -188,14 +188,14 @@
     {
         "text": "        mov     rdi, rax",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 298
         }
     },
     {
         "text": "        call    __clang_call_terminate",
         "source": {
-            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e/ \"/opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp\"",
+            "file": "/tmp/compiler-explorer-compiler1181120-2080-yfo6a1.y1o4e//opt/compiler-explorer/libs/ctre/master/include/ctre/evaluation.hpp",
             "line": 298
         }
     },

--- a/test/cases/bug-1285.asm.directives.labels.comments.json
+++ b/test/cases/bug-1285.asm.directives.labels.comments.json
@@ -5,7 +5,7 @@
     },
     {
         "source": {
-            "file": "/opt/compiler-explorer/gcc-8.3.0/lib/gcc/x86_64-linux-gnu/8.3.0/../../../../include/c++/8.3.0/ \"bitset\"",
+            "file": "/opt/compiler-explorer/gcc-8.3.0/lib/gcc/x86_64-linux-gnu/8.3.0/../../../../include/c++/8.3.0/bitset",
             "line": 433
         },
         "text": "        andq    $775946532, (%rdi)      # imm = 0x2E400124"

--- a/test/cases/bug-1285.asm.directives.labels.comments.library.json
+++ b/test/cases/bug-1285.asm.directives.labels.comments.library.json
@@ -5,7 +5,7 @@
     },
     {
         "source": {
-            "file": "/opt/compiler-explorer/gcc-8.3.0/lib/gcc/x86_64-linux-gnu/8.3.0/../../../../include/c++/8.3.0/ \"bitset\"",
+            "file": "/opt/compiler-explorer/gcc-8.3.0/lib/gcc/x86_64-linux-gnu/8.3.0/../../../../include/c++/8.3.0/bitset",
             "line": 433
         },
         "text": "        andq    $775946532, (%rdi)      # imm = 0x2E400124"

--- a/test/cases/bug-1285b.asm.directives.labels.comments.json
+++ b/test/cases/bug-1285b.asm.directives.labels.comments.json
@@ -20,7 +20,7 @@
   {
     "text": "        cmp     byte ptr [rsp + 16], 0",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/optional.h",
       "line": 447
     }
   },
@@ -115,28 +115,28 @@
   {
     "text": "        je      .LBB0_6",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 92
     }
   },
   {
     "text": "        lea     rdi, [rbx + 8]",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 93
     }
   },
   {
     "text": "        call    _ZN6stringD1Ev",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 93
     }
   },
   {
     "text": "        mov     byte ptr [rbx], 0",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 94
     }
   },
@@ -165,14 +165,14 @@
   {
     "text": "        call    _ZN6stringC1EN4absl11string_viewE",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 152
     }
   },
   {
     "text": "        mov     byte ptr [rbx], 1",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 153
     }
   },

--- a/test/cases/bug-1285b.asm.directives.labels.comments.library.json
+++ b/test/cases/bug-1285b.asm.directives.labels.comments.library.json
@@ -20,7 +20,7 @@
   {
     "text": "        cmp     byte ptr [rsp + 16], 0",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/optional.h",
       "line": 447
     }
   },
@@ -115,28 +115,28 @@
   {
     "text": "        je      .LBB0_6",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 92
     }
   },
   {
     "text": "        lea     rdi, [rbx + 8]",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 93
     }
   },
   {
     "text": "        call    _ZN6stringD1Ev",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 93
     }
   },
   {
     "text": "        mov     byte ptr [rbx], 0",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 94
     }
   },
@@ -165,14 +165,14 @@
   {
     "text": "        call    _ZN6stringC1EN4absl11string_viewE",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 152
     }
   },
   {
     "text": "        mov     byte ptr [rbx], 1",
     "source": {
-      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/ \"optional.h\"",
+      "file": "/opt/compiler-explorer/libs/abseil/absl/types/internal/optional.h",
       "line": 153
     }
   },


### PR DESCRIPTION
E.g. for such directive

    .file   1 "/home/user" "example.c"

now will be constructed valid path:

    '/home/user/example.c'

instead of this broken path:

    '/home/user/ "example.c"'

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
