### PR TITLE
Handle K1 MPPA VLIW bundles in assembly

### DIFF
--- a/lib/asm-parser.js
+++ b/lib/asm-parser.js
@@ -218,7 +218,11 @@ class AsmParser extends AsmRegex {
         const files = this.parseFiles(asmLines);
         let prevLabel = "";
 
-        const commentOnly = /^\s*(((#|@|;|\/\/).*)|(\/\*.*\*\/))$/;
+        // Lines matching the following pattern are considered comments:
+        // - starts with '#', '@', '//' or a single ';' (non repeated)
+        // - starts with ';;' and has non-whitespace before end of line
+        const commentOnly = /^\s*(((#|@|\/\/).*)|(\/\*.*\*\/)|(;\s*)|(;[^;].*)|(;;.*\S.*))$/;
+
         const commentOnlyNvcc = /^\s*(((#|;|\/\/).*)|(\/\*.*\*\/))$/;
         const sourceTag = /^\s*\.loc\s+(\d+)\s+(\d+).*/;
         const source6502Dbg = /^\s*\.dbg\s+line,\s*"([^"]+)",\s*(\d+)/;

--- a/test/cases/kalray-hellow.asm
+++ b/test/cases/kalray-hellow.asm
@@ -4,7 +4,7 @@
 .LC0:
 	.string	"%s , %s , %lld , %d , %lld\n"
 	.text
-
+	; This is a comment
 	.align 8
 	.globl toto
 	.type	toto, @function
@@ -12,6 +12,7 @@ toto:
 	add $r12 = $r12, -16
 	get $r8 = $ra
 	;;
+	;; This is also a comment
 	sw 28[$r12] = $r10
 	add $r10 = $r12, 16
 	;;
@@ -40,7 +41,7 @@ toto:
 	add $r12 = $r12, 16
 	;;
 	set $ra = $r1
-	;; /* Can't issue next in the same bundle */
+	;;
 	ret
 	;;
 	.size	toto, .-toto
@@ -74,7 +75,7 @@ main:
 	sd 16[$r12] = $r0r1
 	make $r1 = .LC1
 	make $r0 = .LC0
-	;; /* Can't issue next in the same bundle */
+	;;
 	call printf
 	;;
 	add $r12 = $r10, -16
@@ -88,7 +89,7 @@ main:
 	;;
 .OTHERDUMMY:
 	set $ra = $r1
-	;; /* Can't issue next in the same bundle */
+	;;
 	ret
 	;;
 	.size	main, .-main

--- a/test/cases/kalray-hellow.asm.directives
+++ b/test/cases/kalray-hellow.asm.directives
@@ -1,10 +1,11 @@
 .LC0:
         .string "%s , %s , %lld , %d , %lld\n"
-
+        ; This is a comment
 toto:
         add $r12 = $r12, -16
         get $r8 = $ra
         ;;
+        ;; This is also a comment
         sw 28[$r12] = $r10
         add $r10 = $r12, 16
         ;;
@@ -33,7 +34,7 @@ toto:
         add $r12 = $r12, 16
         ;;
         set $ra = $r1
-        ;; /* Can't issue next in the same bundle */
+        ;;
         ret
         ;;
 
@@ -59,7 +60,7 @@ main:
         sd 16[$r12] = $r0r1
         make $r1 = .LC1
         make $r0 = .LC0
-        ;; /* Can't issue next in the same bundle */
+        ;;
         call printf
         ;;
         add $r12 = $r10, -16
@@ -73,6 +74,6 @@ main:
         ;;
 .OTHERDUMMY:
         set $ra = $r1
-        ;; /* Can't issue next in the same bundle */
+        ;;
         ret
         ;;

--- a/test/cases/kalray-hellow.asm.directives.labels
+++ b/test/cases/kalray-hellow.asm.directives.labels
@@ -1,10 +1,11 @@
 .LC0:
         .string "%s , %s , %lld , %d , %lld\n"
-
+        ; This is a comment
 toto:
         add $r12 = $r12, -16
         get $r8 = $ra
         ;;
+        ;; This is also a comment
         sw 28[$r12] = $r10
         add $r10 = $r12, 16
         ;;
@@ -33,7 +34,7 @@ toto:
         add $r12 = $r12, 16
         ;;
         set $ra = $r1
-        ;; /* Can't issue next in the same bundle */
+        ;;
         ret
         ;;
 
@@ -59,7 +60,7 @@ main:
         sd 16[$r12] = $r0r1
         make $r1 = .LC1
         make $r0 = .LC0
-        ;; /* Can't issue next in the same bundle */
+        ;;
         call printf
         ;;
         add $r12 = $r10, -16
@@ -71,6 +72,6 @@ main:
         add $r12 = $r12, 16
         ;;
         set $ra = $r1
-        ;; /* Can't issue next in the same bundle */
+        ;;
         ret
         ;;


### PR DESCRIPTION
If K1 MPPA compiler gets added someday (see https://github.com/mattgodbolt/compiler-explorer-image/pull/282 ), then this comment parsing tweak should be added.

K1 MPPA uses ;; as a bundle separator (same syntax as IA64,
if it gets added to CE someday...).
The bundle separator must be alone on the line, see for example:

```
        ld $r6 = 16[$r20]
        addx8d $r9 = $r2, $r5
        addw $r10 = $r2, -1
        ;;
        addd $r0 = $r6, $r9
        addd $r17 = $r10, 1
        cb.wlez $r2? .L3
        ;;
        copyd $r15 = $r0
        ;;
        maddd $r15 = $r17, -8
        ;;
```

Single ; or ;; followed by any non whitespace before eol still
considered a comment.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
