### PR TITLE
Fix ASM output for the zig compiler

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -79,3 +79,4 @@ From oldest to newest contributor, we would like to thank:
 - [Christian Vonrüti](https://github.com/alshain)
 - [Alessandro Vergani](https://github.com/Loghorn)
 - [Sebastian Rath](https://github.com/seb-mtl)
+- [Haze Booth](https://github.com/haze)

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -158,7 +158,9 @@ class CompilerFinder {
         const supportsExecute = supportsBinary && !!props("supportsExecute", true);
         const supportsLibraryCodeFilter = !!props("supportsLibraryCodeFilter", true);
         const group = props("group", "");
-        const demangler = path.normalize(props("demangler", "").replace("${ceToolsPath}", ceToolsPath));
+        const demanglerProp = props("demangler", undefined);
+        const demangler = demanglerProp === undefined ?
+            "" : path.normalize(demanglerProp.replace("${ceToolsPath}", ceToolsPath));
         const isSemVer = props("isSemVer", false);
         const baseName = props("baseName", null);
         const semverVer = props("semver", "");

--- a/lib/compilers/zig.js
+++ b/lib/compilers/zig.js
@@ -63,9 +63,12 @@ class ZigCompiler extends BaseCompiler {
         let options = [filters.execute ? 'build-exe' : 'build-obj'];
         if (this.compiler.semver === 'trunk' || Semver.gt(this.compiler.semver, '0.3.0')) {
             const outputDir = path.dirname(outputFilename);
+            const desiredName = path.basename(outputFilename);
+            // strip '.s' if we aren't executing
+            const name = filters.execute ? desiredName : desiredName.slice(0, -2);
             options.push('--cache-dir', outputDir,
                 '--output-dir', outputDir,
-                '--name', path.basename(outputFilename));
+                '--name', name);
         } else {
             // Older versions use a different command line interface (#1304)
             options.push('--cache-dir', path.dirname(outputFilename),


### PR DESCRIPTION
This fixes #1689 by using the suggestion @andrewrk made.

This also properly disables the demangler for compilers that don't provide one.
(There was a bug where `path.normalize` would turn an empty string into `.`.)