### PR TITLE
Add gcc-static-analysis-trunk as a C and C++ compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -6,7 +6,7 @@ needsMulti=false
 
 ###############################
 # GCC for x86
-group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g91:g92:gsnapshot:gcontracts-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk
+group.gcc86.compilers=g412:g447:g453:g464:g471:g472:g473:g474:g481:g482:g483:g484:g485:g490:g491:g492:g493:g494:g510:g520:g530:g540:g550:g6:g62:g63:g64:g71:g72:g73:g74:g75:g81:g82:g83:g91:g92:gsnapshot:gcontracts-trunk:gcxx-modules-trunk:gcxx-coroutines-trunk:gcc-embed-trunk:gcc-static-analysis-trunk
 group.gcc86.groupName=GCC x86-64
 group.gcc86.baseName=x86-64 gcc
 group.gcc86.isSemVer=true
@@ -108,6 +108,10 @@ compiler.gcxx-coroutines-trunk.options=-fcoroutines
 compiler.gcc-embed-trunk.exe=/opt/compiler-explorer/gcc-embed-trunk/bin/g++
 compiler.gcc-embed-trunk.semver=(std::embed)
 compiler.gcc-embed-trunk.notification=Experimental <code>std::embed</code> Support; see <a href="https://github.com/ThePhD/embed" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+compiler.gcc-static-analysis-trunk.exe=/opt/compiler-explorer/gcc-static-analysis-trunk/bin/g++
+compiler.gcc-static-analysis-trunk.options=-fanalyzer -fdiagnostics-urls=never -fdiagnostics-color=always
+compiler.gcc-static-analysis-trunk.semver=(static analysis)
+compiler.gcc-static-analysis-trunk.notification=Experimental static analyzer; see <a href="https://gcc.gnu.org/wiki/DavidMalcolm/StaticAnalyzer" target="_blank" rel="noopener noreferrer">GCC wiki page<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
 # Some multilib workarounds for older compilers not built quite right...
 compiler.g63.needsMulti=true

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -6,7 +6,7 @@ needsMulti=false
 
 ###############################
 # GCC for x86
-group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg81:cg82:cg83:cg91:cg92:cgsnapshot
+group.cgcc86.compilers=cg412:cg447:cg453:cg464:cg471:cg472:cg473:cg474:cg481:cg482:cg483:cg484:cg485:cg490:cg491:cg492:cg493:cg494:cg510:cg520:cg530:cg540:cg6:cg62:cg63:cg71:cg72:cg73:cg81:cg82:cg83:cg91:cg92:cgsnapshot:cgstatic-analysis
 group.cgcc86.groupName=GCC x86-64
 group.cgcc86.isSemVer=true
 group.cgcc86.baseName=x86-64 gcc
@@ -81,6 +81,10 @@ compiler.cg92.exe=/opt/compiler-explorer/gcc-9.2.0/bin/gcc
 compiler.cg92.semver=9.2
 compiler.cgsnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gcc
 compiler.cgsnapshot.semver=(trunk)
+compiler.cgstatic-analysis.exe=/opt/compiler-explorer/gcc-static-analysis-trunk/bin/gcc
+compiler.cgstatic-analysis.semver=(static analysis)
+compiler.cgstatic-analysis.options=-fanalyzer -fdiagnostics-urls=never -fdiagnostics-color=always
+compiler.cgstatic-analysis.notification=Experimental static analyzer; see <a href="https://gcc.gnu.org/wiki/DavidMalcolm/StaticAnalyzer" target="_blank" rel="noopener noreferrer">GCC wiki page<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
 
 # Some multilib workarounds for older compilers not built quite right...
 compiler.cg63.needsMulti=true


### PR DESCRIPTION
Here's an attempt at implementing issue #1691

In theory this makes use of the new `gcc` and `g++` built as part of https://github.com/mattgodbolt/compiler-explorer-image/pull/288 - though I don't have the same filesystem layout (hopefully if I messed up the paths, the changes to fix things are obvious).

I've tested a version of this locally by coping and pasting similar lines into my `etc/config/c++.local.properties`.

I ran into an issue with `make check` where the various `test/cases/cfg-clang.*.json` were failing with slight changes in output reported.  I'm assuming that's an issue with the clang I've got installed at this end, and hopefully unrelated to this new code.

For options I put:

- `-fanalyzer` to enable the analyzer
- ` -fdiagnostics-urls=never` since ` -fdiagnostics-urls=always` doesn't work yet (and I may change the default for GCC 10 trunk)
- `-fdiagnostics-color=always` seems to be needed to get colorization in the output

(Each of these can be overridden if need by, e.g. with `-fno-analyzer`)

Test source I've been using with this (for which a colored ASCII art report should be emitted by the compiler):

```
/* Example of a multilevel wrapper around malloc, with an unchecked write.  */

#include <stdlib.h>

void *wrapped_malloc (size_t size)
{
  return malloc (size);
}

typedef struct boxed_int
{
  int i;
} boxed_int;

boxed_int *
make_boxed_int (int i)
{
  boxed_int *result = (boxed_int *)wrapped_malloc (sizeof (boxed_int));
  result->i = i;
  return result;
}
```


<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
