### PR TITLE
Ensure the tab dropdown shows in front

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -80,3 +80,4 @@ From oldest to newest contributor, we would like to thank:
 - [Alessandro Vergani](https://github.com/Loghorn)
 - [Sebastian Rath](https://github.com/seb-mtl)
 - [Haze Booth](https://github.com/haze)
+- [Cassie Jones](https://github.com/porglezomp)

--- a/static/explorer.css
+++ b/static/explorer.css
@@ -487,3 +487,8 @@ kbd {
 .lm_content {
     overflow: visible;
 }
+
+.lm_header {
+    /* Needed to prevent the tab selection dropdown getting stuck behind other elements */
+    z-index: 2 !important;
+}


### PR DESCRIPTION
When there are enough tabs, you use a dropdown selection to pick the other tabs. This would display under the compiler selection dropdown list, making it very difficult to use.

The .lm_tab dropdown has its z-index set to 5 to show up on top, but it's stuck inside the .lm_header stacking context, so it can't render in front of that. Raising the z-index of that whole stacking context fixes things.

Fixes #1714 

### Before:
<img width="115" alt="The compiler selection button and tab dropdown button." src="https://user-images.githubusercontent.com/1690225/70381381-6654d800-1917-11ea-9fd0-2c1a74f4954f.png"><img width="133" alt="The tab dropdown tucked behind the compiler selection." src="https://user-images.githubusercontent.com/1690225/70381382-6bb22280-1917-11ea-9aa6-5c696094ccee.png">

### After:
<img width="115" alt="The compiler selection button and tab dropdown button." src="https://user-images.githubusercontent.com/1690225/70381381-6654d800-1917-11ea-9fd0-2c1a74f4954f.png"><img width="137" alt="The tab selection dropdown correctly showing above the compiler selection button." src="https://user-images.githubusercontent.com/1690225/70381388-740a5d80-1917-11ea-8fe4-94cf8755e199.png">
