### PR TITLE
Fix the contrast on some dark-mode icons

### DIFF
--- a/static/themes/dark-theme.css
+++ b/static/themes/dark-theme.css
@@ -434,3 +434,20 @@ div.argmenuitem span.argdescription {
 a {
     color: #45bbe0 !important;
 }
+
+.fa, .fas {
+    color: white;
+}
+
+.close:hover {
+    color: white;
+}
+
+.navbar-light .navbar-toggler-icon {
+    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='rgba(255, 255, 255, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+.navbar-light .navbar-toggler {
+    color: rgba(255,255,255,.5);
+    border-color: rgba(255,255,255,.1);
+}


### PR DESCRIPTION
This adds some overrides for the hamburger menu styles in dark-mode, as well as some low-specificity rules for the `fa` icons. As far as I can tell, this doesn't overwrite the manually colored icons: the green and red checks and xs in the status bars seem to all be colored correctly with these rules.

**Before:**
<img width="61" alt="The hamburger menu displayed in very low contrast black-on-grey." src="https://user-images.githubusercontent.com/1690225/70503225-f1d59100-1af0-11ea-9cc1-fd71fc2e1361.png"> <img width="70" alt="Some icon buttons displayed in very low contrast black-on-grey." src="https://user-images.githubusercontent.com/1690225/70503226-f26e2780-1af0-11ea-841c-8bb12108366e.png">

**After:**
<img width="65" alt="The hamburger menu displayed with better contrast." src="https://user-images.githubusercontent.com/1690225/70503420-598bdc00-1af1-11ea-9fee-f85dc9d50374.png"> <img width="60" alt="Some icon buttons displayed with better contrast." src="https://user-images.githubusercontent.com/1690225/70503421-598bdc00-1af1-11ea-8a7a-f246a5fc2b46.png">

Fixes #1720