### PR TITLE
Make tab view tabs larger on mobile

### DIFF
--- a/static/explorer.css
+++ b/static/explorer.css
@@ -495,5 +495,38 @@ kbd {
 
 .lm_header {
     /* Needed to prevent the tab selection dropdown getting stuck behind other elements */
-    z-index: 2 !important;
+    z-index: 3 !important;
+    height: 20px !important;
+}
+
+@media (max-width: 768px) {
+    .lm_header {
+        height: 50px !important;
+    }
+
+    .lm_header .lm_tabs {
+        height: 100%;
+    }
+
+    .lm_header .lm_tabs .lm_tab {
+        height: 31px;
+        padding-top: 15px;
+    }
+
+    .lm_controls li {
+        padding-top: 20px;
+        transform: scale(1.8);
+        padding-right: 15px;
+    }
+
+    .lm_controls .lm_tabdropdown {
+        padding-top: 8px;
+    }
+
+    .lm_header .lm_tabdropdown_list .lm_tab {
+        height: 50px;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
 }


### PR DESCRIPTION
This increases the size of the tab bar tabs and buttons on mobile, to make it easier to work entirely in tab mode. The media query for this button size begins at 768px because that's where the top bar UI switches to mobile mode.

Fixes #1717

### Comparison:
Standard tab size:
<img alt="Screen Shot 2019-12-10 at 02 46 42" src="https://user-images.githubusercontent.com/1690225/70507223-ed61a600-1af9-11ea-9cc5-b9a368ec431e.png">
New mobile tab size (~60px tall):
<img alt="Screen Shot 2019-12-10 at 02 48 31" src="https://user-images.githubusercontent.com/1690225/70507221-ed61a600-1af9-11ea-9fdd-838f0e7da559.png">