### PR TITLE
Fix dark-mode save/load UI

### DIFF
--- a/static/themes/dark-theme.css
+++ b/static/themes/dark-theme.css
@@ -148,15 +148,6 @@ a.navbar-brand img.logo.normal {
     background-color: #383838 !important;
 }
 
-.active {
-    background-color: #235765 !important;
-    color: #fff !important;
-}
-
-.active:hover {
-    background-color: #998899 !important;
-}
-
 .dropdown-menu {
     color: #f2f2f2 !important;
     background-color: #303030 !important;


### PR DESCRIPTION
The save/load builds a tabbed list using a .active class to select which tab to show. This class is also used for styling button highlights in pickers. We can remove the bare `.active` and `.active:hover` rules because they exactly match the `.btn-light.active` rules, and every other use of the `active` class also has a `btn-light` class attached to it.

Fixes #1718