### PR TITLE
Nim Fix, change in object file name

### DIFF
--- a/lib/compilers/nim.js
+++ b/lib/compilers/nim.js
@@ -87,7 +87,7 @@ class NimCompiler extends BaseCompiler {
         if (!extension)
             return null;
         const moduleName = path.basename(inputFilename);
-        const resultName = moduleName + extension;
+        const resultName = '@m' + moduleName + extension;
         return path.join(cacheDir, resultName);
     }
 

--- a/test/nim-tests.js
+++ b/test/nim-tests.js
@@ -63,9 +63,9 @@ describe('Nim', () => {
             input = "test.min",
             folder = "/tmp/",
             expected = {
-                "cpp": folder + input + ".cpp.o",
-                "c": folder + input + ".c.o",
-                "objc": folder + input + ".m.o",
+                "cpp": folder + '@m' + input + ".cpp.o",
+                "c": folder + '@m' + input + ".c.o",
+                "objc": folder + '@m' + input + ".m.o",
             };
 
         for (const lang of ["cpp", "c", "objc"]) {


### PR DESCRIPTION
Fix for https://github.com/mattgodbolt/compiler-explorer/issues/1760
Since 1.0.0 the object file in the nimcache folder has changed from `module_name.nim.lang_ext.o` to 
`@mmodule_name.nim.lang_ext.o`.
Tested for 1.0.4 (latest release), fixes the issue

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
