### PR TITLE
Use a file to execute clang-query commands

### DIFF
--- a/lib/tooling/clang-query-tool.js
+++ b/lib/tooling/clang-query-tool.js
@@ -45,7 +45,10 @@ class ClangQueryTool extends BaseTool {
         }
 
         await fs.writeFile(path.join(dir, "compile_flags.txt"), compileFlags.join('\n'));
-        const toolResult = await super.runTool(compilationInfo, sourcefile, args, stdin);
+        await fs.writeFile(path.join(dir, "query_commands.txt"), stdin);
+        args.push('-f');
+        args.push('query_commands.txt');
+        const toolResult = await super.runTool(compilationInfo, sourcefile, args);
 
         if (toolResult.stdout.length > 0) {
             const lastLine = toolResult.stdout.length - 1;


### PR DESCRIPTION
This is needed to enable multi-line clang-query commands.

For example: https://godbolt.org/z/9GRpgM should work.