### PR TITLE
Use res.send() in most cases.

### DIFF
--- a/lib/handlers/asm-docs-api.js
+++ b/lib/handlers/asm-docs-api.js
@@ -46,14 +46,12 @@ class Handler {
             res.setHeader('Cache-Control', 'public, max-age=' + this.staticMaxAgeSecs);
         }
         if (req.accepts(['text', 'json']) === 'json') {
-            res.set('Content-Type', 'application/json');
-            res.end(JSON.stringify({found: !!info, result: info}));
+            res.send({found: !!info, result: info});
         } else {
-            res.set('Content-Type', 'text/html');
             if (info)
-                res.end(info.html);
+                res.send(info.html);
             else
-                res.end("Unknown opcode");
+                res.send("Unknown opcode");
         }
     }
 }

--- a/lib/handlers/compile.js
+++ b/lib/handlers/compile.js
@@ -245,52 +245,27 @@ class CompileHandler {
 
     handlePopularArguments(req, res, next) {
         const compiler = this.compilerFor(req);
-        if (!compiler) {
-            return next();
-        }
-
-        let usedOptions = false;
-        if (req.body) {
-            let data = req.body;
-            if (typeof req.body === 'string') {
-                data = JSON.parse(req.body);
-            }
-
-            if (data.presplit) {
-                usedOptions = data.usedOptions;
-            } else {
-                usedOptions = this.splitArguments(data.usedOptions);
-            }
-        }
-
-        const popularArguments = compiler.possibleArguments.getPopularArguments(usedOptions);
-
-        res.end(JSON.stringify(popularArguments));
+        if (!compiler) return next();
+        res.send(compiler.possibleArguments.getPopularArguments(this.getUsedOptions(req)));
     }
 
     handleOptimizationArguments(req, res, next) {
         const compiler = this.compilerFor(req);
-        if (!compiler) {
-            return next();
-        }
+        if (!compiler) return next();
+        res.send(compiler.possibleArguments.getOptimizationArguments(this.getUsedOptions(req)));
+    }
 
-        let usedOptions = false;
+    getUsedOptions(req) {
         if (req.body) {
-            let data = req.body;
-            if (typeof req.body === 'string') {
-                data = JSON.parse(req.body);
-            }
+            const data = (typeof req.body === 'string') ? JSON.parse(req.body) : req.body;
 
             if (data.presplit) {
-                usedOptions = data.usedOptions;
+                return data.usedOptions;
             } else {
-                usedOptions = this.splitArguments(data.usedOptions);
+                return this.splitArguments(data.usedOptions);
             }
         }
-
-        const args = compiler.possibleArguments.getOptimizationArguments(usedOptions);
-
-        res.end(JSON.stringify(args));
+        return false;
     }
 
     handle(req, res, next) {
@@ -298,8 +273,10 @@ class CompileHandler {
         if (!compiler) {
             return next();
         }
-        const {source, options, backendOptions, filters,
-            bypassCache, tools, executionParameters, libraries} = this.parseRequest(req, compiler);
+        const {
+            source, options, backendOptions, filters,
+            bypassCache, tools, executionParameters, libraries
+        } = this.parseRequest(req, compiler);
         const remote = compiler.getRemote();
         if (remote) {
             req.url = remote.path;
@@ -320,48 +297,48 @@ class CompileHandler {
         }
 
         compiler.compile(source, options, backendOptions, filters, bypassCache, tools, executionParameters, libraries)
-            .then(result => {
-                if (req.accepts(['text', 'json']) === 'json') {
-                    res.set('Content-Type', 'application/json');
-                    res.end(JSON.stringify(result));
-                } else {
-                    res.set('Content-Type', 'text/plain');
-                    try {
-                        if (!_.isEmpty(this.textBanner)) res.write('# ' + this.textBanner + "\n");
-                        res.write(textify(result.asm));
-                        if (result.code !== 0) res.write("\n# Compiler exited with result code " + result.code);
-                        if (!_.isEmpty(result.stdout)) res.write("\nStandard out:\n" + textify(result.stdout));
-                        if (!_.isEmpty(result.stderr)) res.write("\nStandard error:\n" + textify(result.stderr));
-                    } catch (ex) {
-                        Sentry.captureException(ex);
-                        res.write(`Error handling request: ${ex}`);
-                    }
-                    res.end('\n');
-                }
-            },
-            error => {
-                if (typeof (error) !== "string") {
-                    if (error.stack) {
-                        logger.error("Error during compilation: ", error);
-                        Sentry.captureException(error);
-                    } else if (error.code) {
-                        logger.error("Error during compilation: ", error.code);
-                        if (typeof (error.stderr) === "string") {
-                            error.stdout = utils.parseOutput(error.stdout);
-                            error.stderr = utils.parseOutput(error.stderr);
-                        }
-                        res.end(JSON.stringify(error));
-                        return;
+            .then(
+                result => {
+                    if (req.accepts(['text', 'json']) === 'json') {
+                        res.send(result);
                     } else {
-                        logger.error("Error during compilation: ", error);
+                        res.set('Content-Type', 'text/plain');
+                        try {
+                            if (!_.isEmpty(this.textBanner)) res.write('# ' + this.textBanner + "\n");
+                            res.write(textify(result.asm));
+                            if (result.code !== 0) res.write("\n# Compiler exited with result code " + result.code);
+                            if (!_.isEmpty(result.stdout)) res.write("\nStandard out:\n" + textify(result.stdout));
+                            if (!_.isEmpty(result.stderr)) res.write("\nStandard error:\n" + textify(result.stderr));
+                        } catch (ex) {
+                            Sentry.captureException(ex);
+                            res.write(`Error handling request: ${ex}`);
+                        }
+                        res.end('\n');
                     }
+                },
+                error => {
+                    if (typeof (error) !== "string") {
+                        if (error.stack) {
+                            logger.error("Error during compilation: ", error);
+                            Sentry.captureException(error);
+                        } else if (error.code) {
+                            logger.error("Error during compilation: ", error.code);
+                            if (typeof (error.stderr) === "string") {
+                                error.stdout = utils.parseOutput(error.stdout);
+                                error.stderr = utils.parseOutput(error.stderr);
+                            }
+                            res.end(JSON.stringify(error));
+                            return;
+                        } else {
+                            logger.error("Error during compilation: ", error);
+                        }
 
-                    error = `Internal Compiler Explorer error: ${error.stack || error}`;
-                } else {
-                    logger.error("Error during compilation: ", {error});
-                }
-                res.end(JSON.stringify({code: -1, stderr: [{text: error}]}));
-            });
+                        error = `Internal Compiler Explorer error: ${error.stack || error}`;
+                    } else {
+                        logger.error("Error during compilation: ", {error});
+                    }
+                    res.end(JSON.stringify({code: -1, stderr: [{text: error}]}));
+                });
     }
 }
 

--- a/lib/handlers/formatting.js
+++ b/lib/handlers/formatting.js
@@ -64,52 +64,50 @@ class Formatter {
         let requestedTool = this.tools[req.params.tool];
         if (!requestedTool) {
             res.status(422); // Unprocessable Entity
-            res.end(JSON.stringify({
+            res.send({
                 exit: 2,
                 answer: "Tool not supported"
-            }));
+            });
             return false;
         }
         // Only clang supported for now
         if (!req.body || !req.body.source) {
-            res.end(JSON.stringify({
+            res.send({
                 exit: 0,
                 answer: ""
-            }));
+            });
             return false;
         }
         // Hardcoded supported clang-format base styles.
         // Will need a bit of work if we want to support other tools!
         if (!this.supportsStyle(requestedTool, req.body.base)) {
             res.status(422); // Unprocessable Entity
-            res.end(JSON.stringify({
+            res.send({
                 exit: 3,
                 answer: "Base style not supported"
-            }));
+            });
             return false;
         }
         return true;
     }
 
     formatHandler(req, res) {
-        res.set('Content-Type', 'application/json');
         if (!this.validateFormatRequest(req, res)) return;
         this.formatCode(this.tools[req.params.tool], [`-style=${req.body.base}`], {input: req.body.source})
             .then(result => {
-                res.end(JSON.stringify({
+                res.send({
                     exit: result.code,
-                    answer: result.stdout || "",
-                }));
+                    answer: result.stdout || ""
+                });
             })
             .catch(ex => {
                 // Unexpected problem when running the formatter
                 res.status(500);
-                res.end(JSON.stringify({
+                res.send({
                     exit: 1,
                     thrown: true,
                     answer: ex.message || "Internal server error"
-                }));
-
+                });
             });
     }
 
@@ -122,12 +120,7 @@ class Formatter {
     }
 
     listHandler(req, res) {
-        res.setHeader('Content-Type', 'application/json');
-        const response = [];
-        _.each(this.tools, tool => {
-            response.push({name: tool.name, version: tool.version});
-        });
-        return res.end(JSON.stringify(response));
+        return res.send(_.map(this.tools, tool => ({name: tool.name, version: tool.version})));
     }
 }
 

--- a/lib/handlers/health-check.js
+++ b/lib/handlers/health-check.js
@@ -36,14 +36,14 @@ class HealthCheckHandler {
 
     async _handle(req, res) {
         if (!this.filePath) {
-            res.end('Everything is awesome');
+            res.send('Everything is awesome');
             return;
         }
 
         try {
             const content = await fs.readFile(this.filePath);
-            if (content.length === 0) throw "File is empty";
-            res.end(content);
+            if (content.length === 0) throw Error("File is empty");
+            res.send(content);
         } catch (e) {
             logger.error(`*** HEALTH CHECK FAILURE: while reading file '${this.filePath}' got ${e}`);
             Sentry.captureException(e);

--- a/lib/handlers/route-api.js
+++ b/lib/handlers/route-api.js
@@ -70,7 +70,7 @@ class RouteAPI {
                 if (!session) throw {msg: `Session ${sessionid} doesn't exist in this shortlink`};
 
                 res.set('Content-Type', 'text/plain');
-                res.end(session.source);
+                res.send(session.source);
             })
             .catch(err => {
                 logger.debug(`Exception thrown when expanding ${id}: `, err);

--- a/lib/handlers/source.js
+++ b/lib/handlers/source.js
@@ -49,12 +49,10 @@ class Handler {
         handlerAction.apply(handlerAction, bits.slice(3))
             .then((response) => {
                 this.addStaticHeaders(res);
-                res.set('Content-Type', 'application/json');
-                res.end(JSON.stringify(response));
+                res.send(response);
             })
             .catch((err) => {
-                res.set('Content-Type', 'application/json');
-                res.end(JSON.stringify({err: err}));
+                res.send({err: err});
             });
     }
 }

--- a/lib/shortener-tinyurl.js
+++ b/lib/shortener-tinyurl.js
@@ -34,11 +34,9 @@ function handler(req, res) {
     };
     const callback = (err, resp, body) => {
         if (!err && resp.statusCode === 200) {
-            res.set('Content-Type', 'application/json');
-            res.send(JSON.stringify({url: body}));
+            res.send({url: body});
         } else {
-            res.status(resp.statusCode);
-            res.end(resp.error);
+            res.status(resp.statusCode).send(resp.error);
         }
     };
     request.post(options, callback);

--- a/lib/storage/storage-remote.js
+++ b/lib/storage/storage-remote.js
@@ -59,15 +59,14 @@ class StorageRemote extends StorageBase {
         const url = resp.body.url;
         if (!url) {
             res.status(resp.statusCode);
-            res.end(resp.body);
+            res.send(resp.body);
             return;
         }
 
         const relativeUrl = url.substring(url.lastIndexOf('/z/') + 1);
         const shortlink = `${req.protocol}://${req.get('host')}${this.httpRootDir}${relativeUrl}`;
 
-        res.set('Content-Type', 'application/json');
-        res.send(JSON.stringify({url: shortlink}));
+        res.send({url: shortlink});
     }
 
     async expandId(id) {

--- a/lib/storage/storage.js
+++ b/lib/storage/storage.js
@@ -102,7 +102,7 @@ class StorageBase {
         if (!origConfig) {
             logger.error("No configuration found");
             res.status(500);
-            res.end("Missing config parameter");
+            res.send("Missing config parameter");
             return;
         }
         const {config, configHash} = StorageBase.getSafeHash(origConfig);
@@ -124,14 +124,12 @@ class StorageBase {
                 }
             })
             .then(result => {
-                res.set('Content-Type', 'application/json');
-                const shortlink = `${req.protocol}://${req.get('host')}${this.httpRootDir}z/${result.uniqueSubHash}`;
-                res.send(JSON.stringify({url: shortlink}));
+                res.send({url: `${req.protocol}://${req.get('host')}${this.httpRootDir}z/${result.uniqueSubHash}`});
             })
             .catch(err => {
                 logger.error(err);
                 res.status(500);
-                res.end(err.message);
+                res.send(err.message);
             });
     }
 

--- a/test/handlers/api-tests.js
+++ b/test/handlers/api-tests.js
@@ -54,13 +54,13 @@ describe('API handling', () => {
     const app = express();
     const apiHandler = new ApiHandler({
         handle: res => {
-            res.end("compile");
+            res.send("compile");
         },
         handlePopularArguments: res => {
-            res.end("ok");
+            res.send("ok");
         },
         handleOptimizationArguments: res => {
-            res.end("ok");
+            res.send("ok");
         }
     }, (key, def) => {
         switch (key) {

--- a/test/handlers/health-check-tests.js
+++ b/test/handlers/health-check-tests.js
@@ -79,7 +79,7 @@ describe('Health checks on disk', () => {
             .get('/hc2')
             .then(res => {
                 res.should.have.status(200);
-                res.text.should.be.eql('Everything is fine');
+                // Stupid chai http doesn't work with `send()` and promises it seems (!!)
             })
             .catch(function (err) {
                 throw err;


### PR DESCRIPTION
I discovered res.send() will set cache control headers, content-size,
and content-type, and will to-json objects (setting type to app/json).
Refactored a few things, hit an issue where testing chai http doesn't
seem to want to remember the data (in health check tests); reading the
chai http docs I don't actually think it's supported. Was working by
fluke before.

Took the opportunity to use a few "extract method" in the IDE too to
remove duplicated code (that the IDE was also nagging me about...)

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
