### PR TITLE
Make dev target submodule proof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ travis-dist: dist  ## Creates a distribution as if we were running on travis
 	@[ -z "$(SENTRY_AUTH_TOKEN)" ]] | $(SENTRY) releases set-commits --auto $(TRAVIS_BUILD_NUMBER)
 
 install-git-hooks:  ## Install git hooks that will ensure code is linted and tests are run before allowing a check in
-	ln -sf $(shell pwd)/etc/scripts/pre-commit .git/hooks/pre-commit
+	ln -sf $(shell pwd)/etc/scripts/pre-commit  $(shell git rev-parse --git-dir)/hooks/pre-commit
 .PHONY: install-git-hooks
 
 changelog:  ## Create the changelog


### PR DESCRIPTION
When compiler-explorer is used as a submodule, it's git-dir is not
in .git.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
