### PR TITLE
Add arm clang menu options

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -82,3 +82,4 @@ From oldest to newest contributor, we would like to thank:
 - [Haze Booth](https://github.com/haze)
 - [Cassie Jones](https://github.com/porglezomp)
 - [Bastien Penavayre](https://github.com/DaemonSnake)
+- [Dave Rodgman](https://github.com/daverodgman)

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&gcc86:&icc:&clang:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443
+compilers=&gcc86:&icc:&clang:&rvclang:&wasmclang:&cl:&cross:&ellcc:&zapcc:&djggp:www.godbolt.ms@443:&armclang32:&armclang64
 defaultCompiler=g92
 demangler=/opt/compiler-explorer/gcc-9.2.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-9.2.0/bin/objdump
@@ -224,6 +224,50 @@ compiler.clang_embed.exe=/opt/compiler-explorer/clang-embed-trunk/bin/clang++
 compiler.clang_embed.semver=(std::embed)
 compiler.clang_embed.options=-std=c++2a -stdlib=libc++
 compiler.clang_embed.notification=Experimental <code>std::embed</code> Support; see <a href="https://github.com/ThePhD/embed" target="_blank" rel="noopener noreferrer">github<sup><small class="fas fa-external-link-alt opens-new-window" title="Opens in a new window"></small></sup></a>
+
+
+# Clang for Arm
+# Provides 32- and 64-bit menu items for clang-9 and trunk
+group.armclang32.groupName=Arm 32-bit clang
+group.armclang32.compilers=armv7-clang-9:armv7-clang-trunk
+group.armclang32.isSemVer=true
+group.armclang32.compilerType=clang
+
+group.armclang64.groupName=Arm 64-bit clang
+group.armclang64.compilers=armv8-clang-9:armv8-clang-trunk:armv8.5-clang-trunk
+group.armclang64.isSemVer=true
+group.armclang64.compilerType=clang
+
+compiler.armv7-clang-9.name=armv7-a clang 9
+compiler.armv7-clang-9.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
+compiler.armv7-clang-9.semver=9.0.0
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-clang-9.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target armv7-none-linux-androideabi
+
+compiler.armv8-clang-9.name=armv8-a clang 9
+compiler.armv8-clang-9.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
+compiler.armv8-clang-9.semver=9.0.0
+# Arm v8-a
+compiler.armv8-clang-9.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target aarch64-none-linux-android
+
+compiler.armv7-clang-trunk.name=armv7-a clang (trunk)
+compiler.armv7-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.armv7-clang-trunk.semver=(trunk)
+# Arm v7-a with Neon and VFPv3
+compiler.armv7-clang-trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target armv7-none-linux-androideabi
+
+compiler.armv8-clang-trunk.name=armv8-a clang (trunk)
+compiler.armv8-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.armv8-clang-trunk.semver=(trunk)
+# Arm v8-a
+compiler.armv8-clang-trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0 -target aarch64-none-linux-android
+
+compiler.armv8.5-clang-trunk.name=armv8.5-a clang (trunk, all architectural features)
+compiler.armv8.5-clang-trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
+compiler.armv8.5-clang-trunk.semver=(trunk allfeats)
+# Arm v8.5-a with all supported architectural features
+compiler.armv8.5-clang-trunk.options=--gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/9 -target aarch64-none-linux-android -mtune=cortex-a53 -march=armv8.5-a+crypto+rcpc+sha3+sm4+profile+rng+memtag+sve2+sve2-bitperm+sve2-sm4+sve2-aes+sve2-sha3+tme
+
 
 # Clang for RISC-V
 group.rvclang.compilers=rv32clang:rv64clang


### PR DESCRIPTION
Add options for compiling with clang for Arm - specifically Armv7,
Armv8 and Armv8.5 using clang 9 and trunk.

Signed-off-by: Dave Rodgman <dave.rodgman@arm.com>

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
