### PR TITLE
Typo in MSVC compiler name (must be x64, not x86)

### DIFF
--- a/etc/config/c++.amazon.win32.properties
+++ b/etc/config/c++.amazon.win32.properties
@@ -1,6 +1,6 @@
 # amazon win32 settings
 compilers=vc19:vc19_32
-compiler.cl19.name=x86 msvc 19 (64 bit)
+compiler.cl19.name=x64 msvc 19 (64 bit)
 compiler.cl19.exe=etc\scripts\vc19_amd.bat
 compiler.cl19.includeFlag=/I
 compiler.cl19.versionFlag=/?


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
Just a small mistake in MSVC compiler name. Not great, not terrible.