### PR TITLE
Do not overwrite LD_LIBRARY_PATH in BaseCompiler

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -337,7 +337,7 @@ class BaseCompiler {
     }
 
     getSharedLibraryPathsAsLdLibraryPaths(/*libraries*/) {
-        return [];
+        return null;
     }
 
     getIncludeArguments(libraries) {


### PR DESCRIPTION
If the value of `execOptions.ldPath` evaluates true, its value is used to overwrite the `LD_LIBRARY_PATH` seen by the respective compiler in its jail. Since `[]` evaluates true, the current implementation sets an empty `LD_LIBRARY_PATH` for all BaseCompilers. With this change, the environment's `LD_LIBRARY_PATH` is respected by default.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
