### PR TITLE
Log slow requests to sentry

### DIFF
--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -29,3 +29,4 @@ eventLoopLagThresholdErr=1000
 
 staticUrl=https://static.ce-cdn.net/
 sentryEnvironment=prod
+sentrySlowRequestMs=20000

--- a/package-lock.json
+++ b/package-lock.json
@@ -7473,6 +7473,15 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "response-time": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
+      "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
+      "requires": {
+        "depd": "~1.1.0",
+        "on-headers": "~1.0.1"
+      }
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "promise-queue": "2.2.3",
     "pug": "^2.0.4",
     "request": "^2.88.0",
+    "response-time": "^2.3.2",
     "selectize": "0.12.4",
     "semver": "^5.7.1",
     "serve-favicon": "^2.4.5",


### PR DESCRIPTION
Since sentry retails the full request body when `allowStoreCodeDebug` is enabled this will allow us to observe and reproduce successful requests that take an excessive amount of time.

Should help with #1336