### PR TITLE
enable binary button in asm to allow codelens

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -1,7 +1,8 @@
 compilers=&nasm:&gnuas:&llvmas
 compilerType=assembly
 objdumper=/opt/compiler-explorer/gcc-9.1.0/bin/objdump
-supportsBinary=false
+supportsBinary=true
+supportsExecute=false
 demangler=
 defaultCompiler=nasm21402
 

--- a/etc/config/assembly.defaults.properties
+++ b/etc/config/assembly.defaults.properties
@@ -1,7 +1,8 @@
 compilers=&nasm:&gnuas
 compilerType=assembly
 objdumper=objdump
-supportsBinary=false
+supportsBinary=true
+supportsExecute=false
 demangler=
 
 group.nasm.compilers=defaultnasm


### PR DESCRIPTION
fixes #1567 
only enables button so people can check/uncheck it to enable the binary codelens, doesn't change serverside handling