### PR TITLE
Add Hedley to C libraries.

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -471,6 +471,13 @@ libs.cs50.versions.910.path=/opt/compiler-explorer/libs/cs50/9.1.0/include
 libs.cs50.versions.910.libpath=/opt/compiler-explorer/libs/cs50/9.1.0/x86_64/lib:/opt/compiler-explorer/libs/cs50/9.1.0/x86/lib
 libs.cs50.versions.910.liblink=cs50
 
+libs.hedley.name=hedley
+libs.hedley.description=A C/C++ header to help move ifdefs out of your code
+libs.hedley.versions=v12
+libs.hedley.url=https://github.com/nemequ/hedley
+libs.hedley.versions.v12.version=12.0.0
+libs.hedley.versions.v12.path=/opt/compiler-explorer/libs/hedley/v12/
+
 
 #################################
 #################################


### PR DESCRIPTION
As discussed in #1807, this adds Hedley to the list of libraries for C.

I couldn't really test this, so please be careful merging!  The libraries don't seem to work on my machine (Fedora 31); both with and without this patch I get an empty list.

I did notice that there are some extra values in this entry (copied from C++) that aren't present in the other C libraries.  I'm not sure if they're desirable or not here, but if not I'm happy to remove them.