### PR TITLE
Perform some general maintenance on the test suite

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -100,7 +100,7 @@ exports.logToPapertrail = (host, port, identifier) => {
 };
 
 exports.suppressConsoleLog = () => {
-    logger.remove(consoleTransportInstance);
+    consoleTransportInstance.silent = true;
 };
 
 exports.logger = logger;

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -1,0 +1,6 @@
+const logger = require('../lib/logger');
+
+// this hook will run once before any tests are executed
+before(() => {
+    logger.suppressConsoleLog();
+});

--- a/test/analysis-tests.js
+++ b/test/analysis-tests.js
@@ -31,16 +31,19 @@ const languages = {
     analysis: {id: 'analysis'}
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
-
 describe('LLVM-mca tool definition', () => {
-    const ce = new CompilationEnvironment(compilerProps);
-    const info = {
-        exe: null,
-        remote: true,
-        lang: languages.analysis.id
-    };
-    const a = new LLVMmcaTool(info, ce);
+    let ce, a;
+
+    before(() => {
+        const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+        ce = new CompilationEnvironment(compilerProps);
+        const info = {
+            exe: null,
+            remote: true,
+            lang: languages.analysis.id
+        };
+        a = new LLVMmcaTool(info, ce);
+    });
 
     it('should have most filters disabled', () => {
         a.compiler.disabledFilters.should.be.deep.equal(['labels', 'directives', 'commentOnly', 'trim']);

--- a/test/base-compiler-tests.js
+++ b/test/base-compiler-tests.js
@@ -42,7 +42,7 @@ const languages = {
 const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
 
 describe('Basic compiler invariants', function () {
-    const ce = new CompilationEnvironment(compilerProps);
+    let ce, compiler;
     const info = {
         exe: null,
         remote: true,
@@ -50,7 +50,10 @@ describe('Basic compiler invariants', function () {
         ldPath: []
     };
 
-    const compiler = new BaseCompiler(info, ce);
+    before(() => {
+        ce = new CompilationEnvironment(compilerProps);
+        compiler = new BaseCompiler(info, ce);
+    });
 
     it('should recognize when optOutput has been request', () => {
         compiler.optOutputRequested(["please", "recognize", "-fsave-optimization-record"]).should.equal(true);
@@ -90,7 +93,7 @@ describe('Basic compiler invariants', function () {
 });
 
 describe('Compiler execution', function () {
-    const ce = new CompilationEnvironment(compilerProps);
+    let ce, compiler;
     const info = {
         exe: null,
         remote: true,
@@ -98,9 +101,12 @@ describe('Compiler execution', function () {
         ldPath: []
     };
 
-    afterEach(() => sinon.restore());
+    before(() => {
+        ce = new CompilationEnvironment(compilerProps);
+        compiler = new BaseCompiler(info, ce);
+    });
 
-    const compiler = new BaseCompiler(info, ce);
+    afterEach(() => sinon.restore());
 
     function stubOutCallToExec(execStub, compiler, content, result, nthCall) {
         execStub.onCall(nthCall || 0).callsFake((compiler, args, options) => {

--- a/test/cache-tests.js
+++ b/test/cache-tests.js
@@ -71,7 +71,7 @@ function basicTests(factory) {
 
     it('should store and retrieve binary buffers', () => {
         const cache = factory();
-        const buffer = Buffer.alloc(2 * 1024 * 1024);
+        const buffer = Buffer.alloc(2 * 1024);
         buffer.fill('@');
         return cache.put('a key', buffer, 'bob')
             .then(() => {
@@ -160,9 +160,9 @@ describe('On disk caches', () => {
         return cache.put('a key', 'a value', 'bob')
             .then(() => {
                 const promises = [];
-                const oneK = "".padEnd(1024);
-                for (let i = 0; i < 1024; i++) {
-                    promises.push(cache.put(`key${i}`, oneK));
+                const oneHundredK = "".padEnd(1024 * 100);
+                for (let i = 0; i < 12; i++) {
+                    promises.push(cache.put(`key${i}`, oneHundredK));
                 }
                 return Promise.all(promises);
             })

--- a/test/compilation-env.js
+++ b/test/compilation-env.js
@@ -36,9 +36,13 @@ const props = {
     cacheConfig: 'InMemory(10)'
 };
 
-const compilerProps = new properties.CompilerProps({}, properties.fakeProps(props));
-
 describe('Compilation environment', () => {
+    let compilerProps;
+
+    before(() => {
+        compilerProps = new properties.CompilerProps({}, properties.fakeProps(props));
+    });
+
     it('Should cache by default', () => {
         const ce = new CompilationEnvironment(compilerProps);
         return ce.cacheGet('foo').should.eventually.equal(null)

--- a/test/compiler-finder-tests.js
+++ b/test/compiler-finder-tests.js
@@ -40,9 +40,13 @@ const props = {
     compilers: "goodCompiler:&badCompiler"
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps(props));
-
 describe('Compiler-finder', function () {
+    let compilerProps;
+
+    before(() => {
+        compilerProps = new properties.CompilerProps(languages, properties.fakeProps(props));
+    });
+
     it('should not hang for undefined groups (Bug #860)', () => {
         const optionsHandler = {
             get: () => {

--- a/test/compilers/argument-parsers-tests.js
+++ b/test/compilers/argument-parsers-tests.js
@@ -36,11 +36,15 @@ const languages = {
     'c++': {id: 'c++'}
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+let env;
 
 function makeCompiler(stdout, stderr, code) {
+    if (env === undefined) {
+        const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+        env = new CompilationEnvironment(compilerProps);
+    }
+
     if (code === undefined) code = 0;
-    const env = new CompilationEnvironment(compilerProps);
     const compiler = new FakeCompiler({lang: languages['c++'].id, remote: true}, env);
     compiler.exec = () => Promise.resolve({code: code, stdout: stdout || "", stderr: stderr || ""});
     compiler.execCompilerCached = compiler.exec;
@@ -155,7 +159,11 @@ describe('pascal parser', () => {
 });
 
 describe('popular compiler arguments', () => {
-    let compiler = makeCompiler("-fsave-optimization-record\n-x\n-g\n-fcolor-diagnostics\n-O<number> optimization level\n-std=<c++11,c++14,c++17z>");
+    let compiler;
+
+    before(() => {
+        compiler = makeCompiler("-fsave-optimization-record\n-x\n-g\n-fcolor-diagnostics\n-O<number> optimization level\n-std=<c++11,c++14,c++17z>");
+    });
 
     it('should return 5 arguments', () => {
         return parsers.Clang.parse(compiler).then(compiler => {

--- a/test/d-tests.js
+++ b/test/d-tests.js
@@ -36,15 +36,18 @@ const languages = {
     d: {id: 'd'}
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
-
 describe('D', () => {
-    const ce = new CompilationEnvironment(compilerProps);
+    let ce;
     const info = {
         exe: null,
         remote: true,
         lang: languages.d.id
     };
+
+    before(() => {
+        const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+        ce = new CompilationEnvironment(compilerProps);
+    });
 
     it('LDC should not allow -run parameter', () => {
         const compiler = new LDCCompiler(info, ce);

--- a/test/filter-tests.js
+++ b/test/filter-tests.js
@@ -38,12 +38,14 @@ function processAsm(filename, filters) {
     return parser.process(file, filters);
 }
 
-const cases = fs.readdirSync(__dirname + '/cases')
+const filesInCaseDir = fs.readdirSync(__dirname + '/cases')
+    .map(function (x) {
+        return 'cases/' + x;
+    });
+
+const cases = filesInCaseDir
     .filter(function (x) {
         return x.match(/\.asm$/);
-    })
-    .map(function (x) {
-        return __dirname + '/cases/' + x;
     });
 
 function bless(filename, output, filters) {
@@ -58,24 +60,24 @@ function dump(file) {
 }
 
 function testFilter(filename, suffix, filters) {
-    const result = processAsm(filename, filters);
-
     const expected = filename + suffix;
-    let json = false;
+    const json = filesInCaseDir.includes(expected + '.json');
+
     let file;
-    try {
-        file = fs.readFileSync(expected + '.json', 'utf-8');
-        json = true;
-    } catch (e) {
+
+    if (json) {
+        file = fs.readFileSync(__dirname + '/' + expected + '.json', 'utf-8');
     }
-    if (!file) {
-        try {
-            file = fs.readFileSync(expected, 'utf-8');
-        } catch (e) {
-            return;
-        }
+    else if (filesInCaseDir.includes(expected)) {
+        file = fs.readFileSync(__dirname + '/' + expected, 'utf-8');
     }
-    it(filename, function () {
+    else {
+        return;
+    }
+
+    it(filename, () => {
+        const result = processAsm(__dirname + '/' + filename, filters);
+
         if (json) {
             file = JSON.parse(file);
         } else {

--- a/test/golang-tests.js
+++ b/test/golang-tests.js
@@ -36,9 +36,7 @@ const languages = {
     go: {id: 'go'}
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
-
-const ce = new CompilationEnvironment(compilerProps);
+let ce;
 const info = {
     exe: null,
     remote: true,
@@ -71,6 +69,11 @@ function testGoAsm(basefilename) {
 }
 
 describe('GO asm tests', () => {
+    before(() => {
+        const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+        ce = new CompilationEnvironment(compilerProps);
+    });
+
     it('Handles unknown line number correctly', () => {
         return testGoAsm("test/golang/bug-901");
     });

--- a/test/handlers/api-tests.js
+++ b/test/handlers/api-tests.js
@@ -46,54 +46,60 @@ const languages = {
         extensions: ['.pas']
     }
 };
+const compilers = [
+    {
+        id: "gcc900",
+        name: "GCC 9.0.0",
+        lang: "c++"
+    },
+    {
+        id: "fpc302",
+        name: "FPC 3.0.2",
+        lang: "pascal"
+    },
+    {
+        id: "clangtrunk",
+        name: "Clang trunk",
+        lang: "c++"
+    }
+];
 
 chai.use(require("chai-http"));
 chai.should();
 
 describe('API handling', () => {
-    const app = express();
-    const apiHandler = new ApiHandler({
-        handle: res => {
-            res.send("compile");
-        },
-        handlePopularArguments: res => {
-            res.send("ok");
-        },
-        handleOptimizationArguments: res => {
-            res.send("ok");
-        }
-    }, (key, def) => {
-        switch (key) {
-            case "formatters":
-                return "formatt:badformatt";
-            case "formatter.formatt.exe":
-                return "echo";
-            case "formatter.formatt.version":
-                return "Release";
-            case "formatter.formatt.name":
-                return "FormatT";
-            default:
-                return def;
-        }
+    let app;
+
+    before(() => {
+        app = express();
+        const apiHandler = new ApiHandler({
+            handle: res => {
+                res.send("compile");
+            },
+            handlePopularArguments: res => {
+                res.send("ok");
+            },
+            handleOptimizationArguments: res => {
+                res.send("ok");
+            }
+        }, (key, def) => {
+            switch (key) {
+                case "formatters":
+                    return "formatt:badformatt";
+                case "formatter.formatt.exe":
+                    return "echo";
+                case "formatter.formatt.version":
+                    return "Release";
+                case "formatter.formatt.name":
+                    return "FormatT";
+                default:
+                    return def;
+            }
+        });
+        app.use('/api', apiHandler.handle);
+        apiHandler.setCompilers(compilers);
+        apiHandler.setLanguages(languages);
     });
-    app.use('/api', apiHandler.handle);
-    const compilers = [{
-        id: "gcc900",
-        name: "GCC 9.0.0",
-        lang: "c++"
-    },
-        {
-            id: "fpc302",
-            name: "FPC 3.0.2",
-            lang: "pascal"
-        },
-        {
-            id: "clangtrunk",
-            name: "Clang trunk",
-            lang: "c++"
-        }];
-    apiHandler.setCompilers(compilers);
-    apiHandler.setLanguages(languages);
 
     it('should respond to plain text compiler requests', () => {
         return chai.request(app)

--- a/test/handlers/compile-tests.js
+++ b/test/handlers/compile-tests.js
@@ -39,14 +39,19 @@ const languages = {
     d: {id: 'd'}
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
 
 describe('Compiler tests', () => {
-    const app = express();
-    app.use(bodyParser.json()).use(bodyParser.text());
-    const compilationEnvironment = new CompilationEnvironment(compilerProps);
-    const compileHandler = new CompileHandler(compilationEnvironment);
-    app.post('/:compiler/compile', compileHandler.handle.bind(compileHandler));
+    let app, compileHandler;
+
+    before(() => {
+        const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+        const compilationEnvironment = new CompilationEnvironment(compilerProps);
+        compileHandler = new CompileHandler(compilationEnvironment);
+
+        app = express();
+        app.use(bodyParser.json()).use(bodyParser.text());
+        app.post('/:compiler/compile', compileHandler.handle.bind(compileHandler));
+    });
 
     it('throws for unknown compilers', () => {
         return chai.request(app)

--- a/test/llvm-ir-tests.js
+++ b/test/llvm-ir-tests.js
@@ -37,10 +37,14 @@ const languages = {
     llvm: {id: 'llvm'}
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+let ce;
 
 function createCompiler(compiler) {
-    const ce = new CompilationEnvironment(compilerProps);
+    if (ce === undefined) {
+        const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+        ce = new CompilationEnvironment(compilerProps);
+    }
+
     const info = {
         exe: null,
         remote: true,
@@ -50,47 +54,48 @@ function createCompiler(compiler) {
     return new compiler(info, ce);
 }
 
-describe('llc options for at&t assembly', function () {
-    let compiler = createCompiler(LLCCompiler);
+describe('LLVM IR Compiler', () => {
+    let compiler;
 
-    compiler.optionsForFilter({
-        'intel': false,
-        'binary': false
-    }, 'output.s').should.eql(['-o', 'output.s']);
-});
+    before(() => {
+        compiler = createCompiler(LLCCompiler);
+    });
 
-describe('llc options for intel assembly', function () {
-    let compiler = createCompiler(LLCCompiler);
 
-    compiler.optionsForFilter({
-        'intel': true,
-        'binary': false
-    }, 'output.s').should.eql(['-o', 'output.s', '-x86-asm-syntax=intel']);
-});
+    it('llc options for at&t assembly', function () {
+        compiler.optionsForFilter({
+            'intel': false,
+            'binary': false
+        }, 'output.s').should.eql(['-o', 'output.s']);
+    });
 
-describe('llc options for at&t binary', function () {
-    let compiler = createCompiler(LLCCompiler);
+    it('llc options for intel assembly', function () {
+        compiler.optionsForFilter({
+            'intel': true,
+            'binary': false
+        }, 'output.s').should.eql(['-o', 'output.s', '-x86-asm-syntax=intel']);
+    });
 
-    compiler.optionsForFilter({
-        'intel': false,
-        'binary': true
-    }, 'output.s').should.eql(['-o', 'output.s', '-filetype=obj']);
-});
+    it('llc options for at&t binary', function () {
+        compiler.optionsForFilter({
+            'intel': false,
+            'binary': true
+        }, 'output.s').should.eql(['-o', 'output.s', '-filetype=obj']);
+    });
 
-describe('llc options for intel binary', function () {
-    let compiler = createCompiler(LLCCompiler);
+    it('llc options for intel binary', function () {
+        compiler.optionsForFilter({
+            'intel': true,
+            'binary': true
+        }, 'output.s').should.eql(['-o', 'output.s', '-filetype=obj']);
+    });
 
-    compiler.optionsForFilter({
-        'intel': true,
-        'binary': true
-    }, 'output.s').should.eql(['-o', 'output.s', '-filetype=obj']);
-});
+    it('opt options', function () {
+        const compiler = createCompiler(OPTCompiler);
 
-describe('opt options', function () {
-    let compiler = createCompiler(OPTCompiler);
-
-    compiler.optionsForFilter({
-        'intel': false,
-        'binary': false
-    }, 'output.s').should.eql(['-o', 'output.s', '-S']);
+        compiler.optionsForFilter({
+            'intel': false,
+            'binary': false
+        }, 'output.s').should.eql(['-o', 'output.s', '-S']);
+    });
 });

--- a/test/nim-tests.js
+++ b/test/nim-tests.js
@@ -35,15 +35,18 @@ const languages = {
     nim: {id: 'nim'}
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
-
 describe('Nim', () => {
-    const ce = new CompilationEnvironment(compilerProps);
+    let ce;
     const info = {
         exe: null,
         remote: true,
         lang: languages.nim.id
     };
+
+    before(() => {
+        const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+        ce = new CompilationEnvironment(compilerProps);
+    });
 
     it('Nim should not allow --run/-r parameter', () => {
         const compiler = new NimCompiler(info, ce);

--- a/test/options-handler.js
+++ b/test/options-handler.js
@@ -98,12 +98,6 @@ const moreLibProps = {
     'libs.autolib.versions.autodetect.staticliblink': 'hello',
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps(libProps));
-const optionsHandler = new OptionsHandler([], compilerProps, {});
-
-const moreCompilerProps = new properties.CompilerProps(languages, properties.fakeProps(moreLibProps));
-const moreOptionsHandler = new OptionsHandler([], moreCompilerProps, {});
-
 const makeFakeCompilerInfo = (id, lang, group, semver, isSemver) => {
     return {
         id: id,
@@ -117,6 +111,19 @@ const makeFakeCompilerInfo = (id, lang, group, semver, isSemver) => {
 };
 
 describe('Options handler', () => {
+    let compilerProps;
+    let optionsHandler;
+    let moreCompilerProps;
+    let moreOptionsHandler;
+
+    before(() => {
+        compilerProps = new properties.CompilerProps(languages, properties.fakeProps(libProps));
+        optionsHandler = new OptionsHandler([], compilerProps, {});
+
+        moreCompilerProps = new properties.CompilerProps(languages, properties.fakeProps(moreLibProps));
+        moreOptionsHandler = new OptionsHandler([], moreCompilerProps, {});
+    });
+
     it('should always return an array of paths', () => {
         const libs = optionsHandler.parseLibraries({'fake': libProps.libs});
         _.each(libs[languages.fake.id]['fakelib'].versions, version => {

--- a/test/pascal-tests.js
+++ b/test/pascal-tests.js
@@ -38,338 +38,328 @@ const languages = {
     pascal: {id: 'pascal'}
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
-
-describe('Basic compiler setup', function () {
-    const ce = new CompilationEnvironment(compilerProps);
-    const info = {
-        exe: null,
-        remote: true,
-        lang: languages.pascal.id
-    };
-
-    const compiler = new PascalCompiler(info, ce);
-
-    if (process.platform === "win32") {
-        compiler.getOutputFilename("/tmp/", "output.pas").should.equal("\\tmp\\output.s");
-    } else {
-        compiler.getOutputFilename("/tmp/", "output.pas").should.equal("/tmp/output.s");
-    }
-});
-
-describe('Pascal signature composer function', function () {
-    const demangler = new PascalDemangler();
-
-    it('Handle 0 parameter methods', function () {
-        demangler.composeReadableMethodSignature("", "", "myfunc", "").should.equal("myfunc()");
-        demangler.composeReadableMethodSignature("output", "", "myfunc", "").should.equal("myfunc()");
-        demangler.composeReadableMethodSignature("output", "tmyclass", "myfunc", "").should.equal("tmyclass.myfunc()");
-    });
-
-    it('Handle 1 parameter methods', function () {
-        demangler.composeReadableMethodSignature("output", "", "myfunc", "integer").should.equal("myfunc(integer)");
-        demangler.composeReadableMethodSignature("output", "tmyclass", "myfunc", "integer").should.equal("tmyclass.myfunc(integer)");
-    });
-
-    it('Handle 2 parameter methods', function () {
-        demangler.composeReadableMethodSignature("output", "", "myfunc", "integer,string").should.equal("myfunc(integer,string)");
-        demangler.composeReadableMethodSignature("output", "tmyclass", "myfunc", "integer,string").should.equal("tmyclass.myfunc(integer,string)");
-    });
-});
-
-describe('Pascal Demangling FPC 2.6', function () {
-    const demangler = new PascalDemangler();
-
-    it('Should demangle OUTPUT_MAXARRAY$array_of_DOUBLE$array_of_DOUBLE', function () {
-        demangler.demangle("OUTPUT_MAXARRAY$array_of_DOUBLE$array_of_DOUBLE:").should.equal("maxarray(array_of_double,array_of_double)");
-    });
-
-    it('Should demangle OUTPUT_TMYCLASS_$__MYPROC$ANSISTRING', function () {
-        demangler.demangle("OUTPUT_TMYCLASS_$__MYPROC$ANSISTRING:").should.equal("tmyclass.myproc(ansistring)");
-    });
-
-    it('Should demangle OUTPUT_TMYCLASS_$__MYFUNC$$ANSISTRING', function () {
-        demangler.demangle("OUTPUT_TMYCLASS_$__MYFUNC$$ANSISTRING:").should.equal("tmyclass.myfunc()");
-    });
-
-    it('Should demangle OUTPUT_NOPARAMFUNC$$ANSISTRING', function () {
-        demangler.demangle("OUTPUT_NOPARAMFUNC$$ANSISTRING:").should.equal("noparamfunc()");
-    });
-
-    it('Should demangle OUTPUT_NOPARAMPROC', function () {
-        demangler.demangle("OUTPUT_NOPARAMPROC:").should.equal("noparamproc()");
-    });
-
-    it('Should demangle U_OUTPUT_MYGLOBALVAR', function () {
-        demangler.demangle("U_OUTPUT_MYGLOBALVAR:").should.equal("myglobalvar");
-    });
-
-    it('Should demangle OUTPUT_INIT (custom method)', function () {
-        demangler.demangle("OUTPUT_INIT:").should.equal("init()");
-    });
-
-    it('Should demangle OUTPUT_init (builtin symbol)', function () {
-        demangler.demangle("OUTPUT_init:").should.equal("unit_initialization");
-    });
-});
-
-describe('Pascal Demangling FPC 3.2', function () {
-    const demangler = new PascalDemangler();
-
-    it('Should demangle OUTPUT_$$_SQUARE$LONGINT$$LONGINT', function () {
-        demangler.demangle("OUTPUT_$$_SQUARE$LONGINT$$LONGINT:").should.equal("square(longint)");
-    });
-
-    it('Should demangle OUTPUT_$$_MAXARRAY$array_of_DOUBLE$array_of_DOUBLE', function () {
-        demangler.demangle("OUTPUT_$$_MAXARRAY$array_of_DOUBLE$array_of_DOUBLE:").should.equal("maxarray(array_of_double,array_of_double)");
-    });
-
-    it('Should demangle OUTPUT$_$TMYCLASS_$__$$_MYPROC$ANSISTRING', function () {
-        demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYPROC$ANSISTRING:").should.equal("tmyclass.myproc(ansistring)");
-    });
-
-    it('Should demangle OUTPUT$_$TMYCLASS_$__$$_MYFUNC$$ANSISTRING', function () {
-        demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYFUNC$$ANSISTRING:").should.equal("tmyclass.myfunc()");
-    });
-
-    it('Should demangle OUTPUT$_$TMYCLASS_$__$$_MYFUNC$ANSISTRING$$INTEGER', function () {
-        demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYFUNC$ANSISTRING$$INTEGER:").should.equal("tmyclass.myfunc(ansistring)");
-    });
-
-    it('Should demangle OUTPUT$_$TMYCLASS_$__$$_MYFUNC$ANSISTRING$INTEGER$INTEGER$$INTEGER', function () {
-        demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYFUNC$ANSISTRING$INTEGER$INTEGER$$INTEGER:").should.equal("tmyclass.myfunc(ansistring,integer,integer)");
-    });
-
-    it('Should demangle OUTPUT_$$_NOPARAMFUNC$$ANSISTRING', function () {
-        demangler.demangle("OUTPUT_$$_NOPARAMFUNC$$ANSISTRING:").should.equal("noparamfunc()");
-    });
-
-    it('Should demangle OUTPUT_$$_NOPARAMPROC', function () {
-        demangler.demangle("OUTPUT_$$_NOPARAMPROC:").should.equal("noparamproc()");
-    });
-
-    it('Should demangle OUTPUT_$$_INIT', function () {
-        demangler.demangle("OUTPUT_$$_INIT:").should.equal("init()");
-    });
-
-    it('Should demangle U_$OUTPUT_$$_MYGLOBALVAR', function () {
-        demangler.demangle("U_$OUTPUT_$$_MYGLOBALVAR:").should.equal("myglobalvar");
-    });
-});
-
-describe('Pascal Demangling Fixed Symbols FPC 2.6', function () {
-    const demangler = new PascalDemangler();
-
-    it('Should demangle OUTPUT_finalize_implicit', function () {
-        demangler.demangle("OUTPUT_finalize_implicit:").should.equal("unit_finalization_implicit");
-    });
-});
-
-describe('Pascal Demangling Fixed Symbols FPC 3.2', function () {
-    const demangler = new PascalDemangler();
-
-    it('Should demangle OUTPUT_$$_init', function () {
-        demangler.demangle("OUTPUT_$$_init:").should.equal("unit_initialization");
-    });
-
-    it('Should demangle OUTPUT_$$_finalize', function () {
-        demangler.demangle("OUTPUT_$$_finalize:").should.equal("unit_finalization");
-    });
-
-    it('Should demangle OUTPUT_$$_init_implicit', function () {
-        demangler.demangle("OUTPUT_$$_init_implicit:").should.equal("unit_initialization_implicit");
-    });
-
-    it('Should demangle OUTPUT_$$_finalize_implicit', function () {
-        demangler.demangle("OUTPUT_$$_finalize_implicit:").should.equal("unit_finalization_implicit");
-    });
-
-    it('Should demangle OUTPUT_$$_finalize_implicit', function () {
-        demangler.demangle("OUTPUT_$$_finalize_implicit:").should.equal("unit_finalization_implicit");
-    });
-});
-
-describe('Pascal NOT Demangling certain symbols FPC 2.6', function () {
-    const demangler = new PascalDemangler();
-
-    it('Should NOT demangle VMT_OUTPUT_TMYCLASS', function () {
-        demangler.demangle("VMT_OUTPUT_TMYCLASS:").should.equal(false);
-    });
-
-    it('Should NOT demangle RTTI_OUTPUT_TMYCLASS', function () {
-        demangler.demangle("RTTI_OUTPUT_TMYCLASS:").should.equal(false);
-    });
-
-    it('Should NOT demangle INIT$_OUTPUT', function () {
-        demangler.demangle("INIT$_OUTPUT:").should.equal(false);
-    });
-
-    it('Should NOT demangle FINALIZE$_OUTPUT', function () {
-        demangler.demangle("FINALIZE$_OUTPUT:").should.equal(false);
-    });
-
-    it('Should NOT demangle DEBUGSTART_OUTPUT', function () {
-        demangler.demangle("DEBUGSTART_OUTPUT:").should.equal(false);
-    });
-
-    it('Should NOT demangle DBGREF_OUTPUT_THELLO', function () {
-        demangler.demangle("DBGREF_OUTPUT_THELLO:").should.equal(false);
-    });
-
-    it('Should NOT demangle non-label', function () {
-        demangler.demangle("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST2").should.equal(false);
-    });
-});
-
-describe('Pascal NOT Demangling certain symbols FPC 3.2', function () {
-    const demangler = new PascalDemangler();
-
-    it('Should NOT demangle RTTI_$OUTPUT_$$_TMYCLASS', function () {
-        demangler.demangle("RTTI_$OUTPUT_$$_TMYCLASS:").should.equal(false);
-    });
-
-    it('Should NOT demangle .Ld1', function () {
-        demangler.demangle(".Ld1:").should.equal(false);
-    });
-
-    it('Should NOT demangle _$OUTPUT$_Ld3 (Same in FPC 2.6 and 3.2)', function () {
-        demangler.demangle("_$OUTPUT$_Ld3:").should.equal(false);
-    });
-
-    it('Should NOT demangle INIT$_$OUTPUT', function () {
-        demangler.demangle("INIT$_$OUTPUT:").should.equal(false);
-    });
-
-    it('Should NOT demangle DEBUGSTART_$OUTPUT', function () {
-        demangler.demangle("DEBUGSTART_$OUTPUT:").should.equal(false);
-    });
-
-    it('Should NOT demangle DBGREF_$OUTPUT_$$_THELLO', function () {
-        demangler.demangle("DBGREF_$OUTPUT_$$_THELLO:").should.equal(false);
-    });
-});
-
-describe('Add, order and demangle inline', function () {
-    const demangler = new PascalDemangler();
-
-    demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYTEST:");
-    demangler.demangle("U_$OUTPUT_$$_MYGLOBALVAR:");
-    demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYTEST2:");
-    demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$ANSISTRING:");
-    demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$INTEGER:");
-
-    demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST2").should.equal("  call tmyclass.mytest2()");
-    demangler.demangleIfNeeded("  movl U_$OUTPUT_$$_MYGLOBALVAR,%eax").should.equal("  movl myglobalvar,%eax");
-    demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST2").should.equal("  call tmyclass.mytest2()");
-    demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST").should.equal("  call tmyclass.mytest()");
-    demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$ANSISTRING").should.equal("  call tmyclass.myoverload(ansistring)");
-    demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$INTEGER").should.equal("  call tmyclass.myoverload(integer)");
-
-    demangler.demangleIfNeeded(".Le1").should.equal(".Le1");
-    demangler.demangleIfNeeded("_$SomeThing").should.equal("_$SomeThing");
-});
-
-describe('Add, order and demangle inline - using addDemangleToCache()', function () {
-    const demangler = new PascalDemangler();
-
-    demangler.addDemangleToCache("OUTPUT$_$TMYCLASS_$__$$_MYTEST:");
-    demangler.addDemangleToCache("U_$OUTPUT_$$_MYGLOBALVAR:");
-    demangler.addDemangleToCache("OUTPUT$_$TMYCLASS_$__$$_MYTEST2:");
-    demangler.addDemangleToCache("OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$ANSISTRING:");
-    demangler.addDemangleToCache("OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$INTEGER:");
-
-    demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST2").should.equal("  call tmyclass.mytest2()");
-    demangler.demangleIfNeeded("  movl U_$OUTPUT_$$_MYGLOBALVAR,%eax").should.equal("  movl myglobalvar,%eax");
-    demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST2").should.equal("  call tmyclass.mytest2()");
-    demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST").should.equal("  call tmyclass.mytest()");
-    demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$ANSISTRING").should.equal("  call tmyclass.myoverload(ansistring)");
-    demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$INTEGER").should.equal("  call tmyclass.myoverload(integer)");
-
-    demangler.demangleIfNeeded(".Le1").should.equal(".Le1");
-});
-
-describe('Pascal Ignored Symbols', function () {
-    const demangler = new PascalDemangler();
-
-    it('Should ignore certain labels', function () {
-        demangler.shouldIgnoreSymbol(".Le1").should.equal(true);
-        demangler.shouldIgnoreSymbol("_$SomeThing").should.equal(true);
-    });
-
-    it('Should be able to differentiate between System and User functions', function () {
-        demangler.shouldIgnoreSymbol("RTTI_OUTPUT_MyProperty").should.equal(true);
-        demangler.shouldIgnoreSymbol("Rtti_Output_UserFunction").should.equal(false);
-    });
-});
-
-describe('Pascal ASM line number injection', function () {
-    const ce = new CompilationEnvironment(compilerProps);
-    const info = {
-        exe: null,
-        remote: true,
-        lang: languages.pascal.id
-    };
-
-    const compiler = new PascalCompiler(info, ce);
-    compiler.demanglerClass = require("../lib/demangler-pascal").Demangler;
-    compiler.demangler = new compiler.demanglerClass(null, compiler);
-
-    it('Should have line numbering', function () {
-        return new Promise(function (resolve, reject) {
-            fs.readFile("test/pascal/asm-example.s", function (err, buffer) {
-                const asmLines = utils.splitLines(buffer.toString());
-                compiler.preProcessLines(asmLines);
-
-                resolve(Promise.all([
-                    asmLines.should.include("# [output.pas]"),
-                    asmLines.should.include("  .file 1 \"<stdin>\""),
-                    asmLines.should.include("# [13] Square := num * num + 14;"),
-                    asmLines.should.include("  .loc 1 13 0"),
-                    asmLines.should.include(".Le0:"),
-                    asmLines.should.include("  .cfi_endproc")
-                ]));
-            });
-        });
-    });
-});
-
-describe('Pascal objdump filtering', function () {
-    it('Should filter out most of the runtime', function () {
-        return new Promise(function (resolve, reject) {
-            fs.readFile("test/pascal/objdump-example.s", function (err, buffer) {
-                const output = PascalCompiler.preProcessBinaryAsm(buffer.toString());
-                resolve(Promise.all([
-                    utils.splitLines(output).length.should.be.below(500),
-                    output.should.not.include("fpc_zeromem():"),
-                    output.should.include("SQUARE():")
-                ]));
-            });
-        });
-    });
-});
-
-describe('Pascal parseOutput', () => {
-    const ce = new CompilationEnvironment(compilerProps);
-    const info = {
-        exe: null,
-        remote: true,
-        lang: languages.pascal.id
-    };
-
-    const compiler = new PascalCompiler(info, ce);
-
-    it('should return parsed output', () => {
-        const result = {
-            stdout: "Hello, world!",
-            stderr: ""
+describe('Pascal', () => {
+    let compiler;
+
+    before(() => {
+        const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+        const ce = new CompilationEnvironment(compilerProps);
+        const info = {
+            exe: null,
+            remote: true,
+            lang: languages.pascal.id
         };
 
-        compiler.parseOutput(result, "/tmp/path/output.pas", "/tmp/path").should.deep.equal({
-            inputFilename: "output.pas",
-            stdout: [{
-                "text": "Hello, world!"
-            }],
-            stderr: []
+        compiler = new PascalCompiler(info, ce);
+    });
+
+    it('Basic compiler setup', () => {
+        if (process.platform === "win32") {
+            compiler.getOutputFilename("/tmp/", "output.pas").should.equal("\\tmp\\output.s");
+        } else {
+            compiler.getOutputFilename("/tmp/", "output.pas").should.equal("/tmp/output.s");
+        }
+    });
+
+    describe('Pascal signature composer function', function () {
+        const demangler = new PascalDemangler();
+
+        it('Handle 0 parameter methods', function () {
+            demangler.composeReadableMethodSignature("", "", "myfunc", "").should.equal("myfunc()");
+            demangler.composeReadableMethodSignature("output", "", "myfunc", "").should.equal("myfunc()");
+            demangler.composeReadableMethodSignature("output", "tmyclass", "myfunc", "").should.equal("tmyclass.myfunc()");
+        });
+
+        it('Handle 1 parameter methods', function () {
+            demangler.composeReadableMethodSignature("output", "", "myfunc", "integer").should.equal("myfunc(integer)");
+            demangler.composeReadableMethodSignature("output", "tmyclass", "myfunc", "integer").should.equal("tmyclass.myfunc(integer)");
+        });
+
+        it('Handle 2 parameter methods', function () {
+            demangler.composeReadableMethodSignature("output", "", "myfunc", "integer,string").should.equal("myfunc(integer,string)");
+            demangler.composeReadableMethodSignature("output", "tmyclass", "myfunc", "integer,string").should.equal("tmyclass.myfunc(integer,string)");
+        });
+    });
+
+    describe('Pascal Demangling FPC 2.6', function () {
+        const demangler = new PascalDemangler();
+
+        it('Should demangle OUTPUT_MAXARRAY$array_of_DOUBLE$array_of_DOUBLE', function () {
+            demangler.demangle("OUTPUT_MAXARRAY$array_of_DOUBLE$array_of_DOUBLE:").should.equal("maxarray(array_of_double,array_of_double)");
+        });
+
+        it('Should demangle OUTPUT_TMYCLASS_$__MYPROC$ANSISTRING', function () {
+            demangler.demangle("OUTPUT_TMYCLASS_$__MYPROC$ANSISTRING:").should.equal("tmyclass.myproc(ansistring)");
+        });
+
+        it('Should demangle OUTPUT_TMYCLASS_$__MYFUNC$$ANSISTRING', function () {
+            demangler.demangle("OUTPUT_TMYCLASS_$__MYFUNC$$ANSISTRING:").should.equal("tmyclass.myfunc()");
+        });
+
+        it('Should demangle OUTPUT_NOPARAMFUNC$$ANSISTRING', function () {
+            demangler.demangle("OUTPUT_NOPARAMFUNC$$ANSISTRING:").should.equal("noparamfunc()");
+        });
+
+        it('Should demangle OUTPUT_NOPARAMPROC', function () {
+            demangler.demangle("OUTPUT_NOPARAMPROC:").should.equal("noparamproc()");
+        });
+
+        it('Should demangle U_OUTPUT_MYGLOBALVAR', function () {
+            demangler.demangle("U_OUTPUT_MYGLOBALVAR:").should.equal("myglobalvar");
+        });
+
+        it('Should demangle OUTPUT_INIT (custom method)', function () {
+            demangler.demangle("OUTPUT_INIT:").should.equal("init()");
+        });
+
+        it('Should demangle OUTPUT_init (builtin symbol)', function () {
+            demangler.demangle("OUTPUT_init:").should.equal("unit_initialization");
+        });
+    });
+
+    describe('Pascal Demangling FPC 3.2', function () {
+        const demangler = new PascalDemangler();
+
+        it('Should demangle OUTPUT_$$_SQUARE$LONGINT$$LONGINT', function () {
+            demangler.demangle("OUTPUT_$$_SQUARE$LONGINT$$LONGINT:").should.equal("square(longint)");
+        });
+
+        it('Should demangle OUTPUT_$$_MAXARRAY$array_of_DOUBLE$array_of_DOUBLE', function () {
+            demangler.demangle("OUTPUT_$$_MAXARRAY$array_of_DOUBLE$array_of_DOUBLE:").should.equal("maxarray(array_of_double,array_of_double)");
+        });
+
+        it('Should demangle OUTPUT$_$TMYCLASS_$__$$_MYPROC$ANSISTRING', function () {
+            demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYPROC$ANSISTRING:").should.equal("tmyclass.myproc(ansistring)");
+        });
+
+        it('Should demangle OUTPUT$_$TMYCLASS_$__$$_MYFUNC$$ANSISTRING', function () {
+            demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYFUNC$$ANSISTRING:").should.equal("tmyclass.myfunc()");
+        });
+
+        it('Should demangle OUTPUT$_$TMYCLASS_$__$$_MYFUNC$ANSISTRING$$INTEGER', function () {
+            demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYFUNC$ANSISTRING$$INTEGER:").should.equal("tmyclass.myfunc(ansistring)");
+        });
+
+        it('Should demangle OUTPUT$_$TMYCLASS_$__$$_MYFUNC$ANSISTRING$INTEGER$INTEGER$$INTEGER', function () {
+            demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYFUNC$ANSISTRING$INTEGER$INTEGER$$INTEGER:").should.equal("tmyclass.myfunc(ansistring,integer,integer)");
+        });
+
+        it('Should demangle OUTPUT_$$_NOPARAMFUNC$$ANSISTRING', function () {
+            demangler.demangle("OUTPUT_$$_NOPARAMFUNC$$ANSISTRING:").should.equal("noparamfunc()");
+        });
+
+        it('Should demangle OUTPUT_$$_NOPARAMPROC', function () {
+            demangler.demangle("OUTPUT_$$_NOPARAMPROC:").should.equal("noparamproc()");
+        });
+
+        it('Should demangle OUTPUT_$$_INIT', function () {
+            demangler.demangle("OUTPUT_$$_INIT:").should.equal("init()");
+        });
+
+        it('Should demangle U_$OUTPUT_$$_MYGLOBALVAR', function () {
+            demangler.demangle("U_$OUTPUT_$$_MYGLOBALVAR:").should.equal("myglobalvar");
+        });
+    });
+
+    describe('Pascal Demangling Fixed Symbols FPC 2.6', function () {
+        const demangler = new PascalDemangler();
+
+        it('Should demangle OUTPUT_finalize_implicit', function () {
+            demangler.demangle("OUTPUT_finalize_implicit:").should.equal("unit_finalization_implicit");
+        });
+    });
+
+    describe('Pascal Demangling Fixed Symbols FPC 3.2', function () {
+        const demangler = new PascalDemangler();
+
+        it('Should demangle OUTPUT_$$_init', function () {
+            demangler.demangle("OUTPUT_$$_init:").should.equal("unit_initialization");
+        });
+
+        it('Should demangle OUTPUT_$$_finalize', function () {
+            demangler.demangle("OUTPUT_$$_finalize:").should.equal("unit_finalization");
+        });
+
+        it('Should demangle OUTPUT_$$_init_implicit', function () {
+            demangler.demangle("OUTPUT_$$_init_implicit:").should.equal("unit_initialization_implicit");
+        });
+
+        it('Should demangle OUTPUT_$$_finalize_implicit', function () {
+            demangler.demangle("OUTPUT_$$_finalize_implicit:").should.equal("unit_finalization_implicit");
+        });
+
+        it('Should demangle OUTPUT_$$_finalize_implicit', function () {
+            demangler.demangle("OUTPUT_$$_finalize_implicit:").should.equal("unit_finalization_implicit");
+        });
+    });
+
+    describe('Pascal NOT Demangling certain symbols FPC 2.6', function () {
+        const demangler = new PascalDemangler();
+
+        it('Should NOT demangle VMT_OUTPUT_TMYCLASS', function () {
+            demangler.demangle("VMT_OUTPUT_TMYCLASS:").should.equal(false);
+        });
+
+        it('Should NOT demangle RTTI_OUTPUT_TMYCLASS', function () {
+            demangler.demangle("RTTI_OUTPUT_TMYCLASS:").should.equal(false);
+        });
+
+        it('Should NOT demangle INIT$_OUTPUT', function () {
+            demangler.demangle("INIT$_OUTPUT:").should.equal(false);
+        });
+
+        it('Should NOT demangle FINALIZE$_OUTPUT', function () {
+            demangler.demangle("FINALIZE$_OUTPUT:").should.equal(false);
+        });
+
+        it('Should NOT demangle DEBUGSTART_OUTPUT', function () {
+            demangler.demangle("DEBUGSTART_OUTPUT:").should.equal(false);
+        });
+
+        it('Should NOT demangle DBGREF_OUTPUT_THELLO', function () {
+            demangler.demangle("DBGREF_OUTPUT_THELLO:").should.equal(false);
+        });
+
+        it('Should NOT demangle non-label', function () {
+            demangler.demangle("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST2").should.equal(false);
+        });
+    });
+
+    describe('Pascal NOT Demangling certain symbols FPC 3.2', function () {
+        const demangler = new PascalDemangler();
+
+        it('Should NOT demangle RTTI_$OUTPUT_$$_TMYCLASS', function () {
+            demangler.demangle("RTTI_$OUTPUT_$$_TMYCLASS:").should.equal(false);
+        });
+
+        it('Should NOT demangle .Ld1', function () {
+            demangler.demangle(".Ld1:").should.equal(false);
+        });
+
+        it('Should NOT demangle _$OUTPUT$_Ld3 (Same in FPC 2.6 and 3.2)', function () {
+            demangler.demangle("_$OUTPUT$_Ld3:").should.equal(false);
+        });
+
+        it('Should NOT demangle INIT$_$OUTPUT', function () {
+            demangler.demangle("INIT$_$OUTPUT:").should.equal(false);
+        });
+
+        it('Should NOT demangle DEBUGSTART_$OUTPUT', function () {
+            demangler.demangle("DEBUGSTART_$OUTPUT:").should.equal(false);
+        });
+
+        it('Should NOT demangle DBGREF_$OUTPUT_$$_THELLO', function () {
+            demangler.demangle("DBGREF_$OUTPUT_$$_THELLO:").should.equal(false);
+        });
+    });
+
+    describe('Add, order and demangle inline', function () {
+        const demangler = new PascalDemangler();
+
+        demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYTEST:");
+        demangler.demangle("U_$OUTPUT_$$_MYGLOBALVAR:");
+        demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYTEST2:");
+        demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$ANSISTRING:");
+        demangler.demangle("OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$INTEGER:");
+
+        demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST2").should.equal("  call tmyclass.mytest2()");
+        demangler.demangleIfNeeded("  movl U_$OUTPUT_$$_MYGLOBALVAR,%eax").should.equal("  movl myglobalvar,%eax");
+        demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST2").should.equal("  call tmyclass.mytest2()");
+        demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST").should.equal("  call tmyclass.mytest()");
+        demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$ANSISTRING").should.equal("  call tmyclass.myoverload(ansistring)");
+        demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$INTEGER").should.equal("  call tmyclass.myoverload(integer)");
+
+        demangler.demangleIfNeeded(".Le1").should.equal(".Le1");
+        demangler.demangleIfNeeded("_$SomeThing").should.equal("_$SomeThing");
+    });
+
+    describe('Add, order and demangle inline - using addDemangleToCache()', function () {
+        const demangler = new PascalDemangler();
+
+        demangler.addDemangleToCache("OUTPUT$_$TMYCLASS_$__$$_MYTEST:");
+        demangler.addDemangleToCache("U_$OUTPUT_$$_MYGLOBALVAR:");
+        demangler.addDemangleToCache("OUTPUT$_$TMYCLASS_$__$$_MYTEST2:");
+        demangler.addDemangleToCache("OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$ANSISTRING:");
+        demangler.addDemangleToCache("OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$INTEGER:");
+
+        demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST2").should.equal("  call tmyclass.mytest2()");
+        demangler.demangleIfNeeded("  movl U_$OUTPUT_$$_MYGLOBALVAR,%eax").should.equal("  movl myglobalvar,%eax");
+        demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST2").should.equal("  call tmyclass.mytest2()");
+        demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYTEST").should.equal("  call tmyclass.mytest()");
+        demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$ANSISTRING").should.equal("  call tmyclass.myoverload(ansistring)");
+        demangler.demangleIfNeeded("  call OUTPUT$_$TMYCLASS_$__$$_MYOVERLOAD$INTEGER").should.equal("  call tmyclass.myoverload(integer)");
+
+        demangler.demangleIfNeeded(".Le1").should.equal(".Le1");
+    });
+
+    describe('Pascal Ignored Symbols', function () {
+        const demangler = new PascalDemangler();
+
+        it('Should ignore certain labels', function () {
+            demangler.shouldIgnoreSymbol(".Le1").should.equal(true);
+            demangler.shouldIgnoreSymbol("_$SomeThing").should.equal(true);
+        });
+
+        it('Should be able to differentiate between System and User functions', function () {
+            demangler.shouldIgnoreSymbol("RTTI_OUTPUT_MyProperty").should.equal(true);
+            demangler.shouldIgnoreSymbol("Rtti_Output_UserFunction").should.equal(false);
+        });
+    });
+
+    describe('Pascal ASM line number injection', function () {
+        before(() => {
+            compiler.demanglerClass = require("../lib/demangler-pascal").Demangler;
+            compiler.demangler = new compiler.demanglerClass(null, compiler);
+        });
+
+        it('Should have line numbering', function () {
+            return new Promise(function (resolve, reject) {
+                fs.readFile("test/pascal/asm-example.s", function (err, buffer) {
+                    const asmLines = utils.splitLines(buffer.toString());
+                    compiler.preProcessLines(asmLines);
+
+                    resolve(Promise.all([
+                        asmLines.should.include("# [output.pas]"),
+                        asmLines.should.include("  .file 1 \"<stdin>\""),
+                        asmLines.should.include("# [13] Square := num * num + 14;"),
+                        asmLines.should.include("  .loc 1 13 0"),
+                        asmLines.should.include(".Le0:"),
+                        asmLines.should.include("  .cfi_endproc")
+                    ]));
+                });
+            });
+        });
+    });
+
+    describe('Pascal objdump filtering', function () {
+        it('Should filter out most of the runtime', function () {
+            return new Promise(function (resolve, reject) {
+                fs.readFile("test/pascal/objdump-example.s", function (err, buffer) {
+                    const output = PascalCompiler.preProcessBinaryAsm(buffer.toString());
+                    resolve(Promise.all([
+                        utils.splitLines(output).length.should.be.below(500),
+                        output.should.not.include("fpc_zeromem():"),
+                        output.should.include("SQUARE():")
+                    ]));
+                });
+            });
+        });
+    });
+
+    describe('Pascal parseOutput', () => {
+        it('should return parsed output', () => {
+            const result = {
+                stdout: "Hello, world!",
+                stderr: ""
+            };
+
+            compiler.parseOutput(result, "/tmp/path/output.pas", "/tmp/path").should.deep.equal({
+                inputFilename: "output.pas",
+                stdout: [{
+                    "text": "Hello, world!"
+                }],
+                stderr: []
+            });
         });
     });
 });

--- a/test/ppci-tests.js
+++ b/test/ppci-tests.js
@@ -35,15 +35,18 @@ const languages = {
     c: {id: 'c'}
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
-
 describe('PPCI', function () {
-    const ce = new CompilationEnvironment(compilerProps);
+    let ce;
     const info = {
         exe: null,
         remote: true,
         lang: languages.c.id
     };
+
+    before(() => {
+        const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+        ce = new CompilationEnvironment(compilerProps);
+    });
 
     it('Should be ok with most arguments', () => {
         const compiler = new PPCICompiler(info, ce);

--- a/test/properties-test.js
+++ b/test/properties-test.js
@@ -25,13 +25,22 @@
 const should = require('chai').should();
 const properties = require('../lib/properties');
 
-
-properties.initialize('test/example-config/', ['test', 'overridden-base', 'overridden-tip']);
-
-const casesProps = properties.propsFor("cases");
-const overridingProps = properties.propsFor("overwrite");
+const languages = {
+    a: {id: 'a'}
+};
 
 describe('Properties', () => {
+    let casesProps, overridingProps, compilerProps;
+
+    before(() => {
+        properties.initialize('test/example-config/', ['test', 'overridden-base', 'overridden-tip']);
+        casesProps = properties.propsFor("cases");
+        overridingProps = properties.propsFor("overwrite");
+        compilerProps = new properties.CompilerProps(languages, properties.fakeProps({
+            foo: '1'
+        }));
+    });
+
     it('Has working propsFor', () => {
         should.equal(properties.get("cases", "exampleProperty"), casesProps("exampleProperty"));
     });
@@ -112,12 +121,6 @@ describe('Properties', () => {
     it('Should fall back from overridden', () => {
         should.equal(overridingProps("localProperty"), 11235813);
     });
-    const languages = {
-        a: {id: 'a'}
-    };
-    const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({
-        foo: '1'
-    }));
     it('should have an identity function if none provided', () => {
         should.equal(compilerProps.get('a', 'foo', '0', undefined), '1');
         compilerProps.get(languages, 'foo', '0', undefined).should.deep.equal({a: '1'});

--- a/test/storage/storage-s3-tests.js
+++ b/test/storage/storage-s3-tests.js
@@ -38,7 +38,6 @@ function mockerise(service, method) {
     const handlers = [];
 
     beforeEach(() => {
-        console.log(`Mockerising ${service}/${method}`);
         AWS.mock(service, method, (q, callback) => {
             const qh = handlers.shift();
             should.exist(qh);
@@ -50,7 +49,6 @@ function mockerise(service, method) {
         });
     });
     afterEach(() => {
-        console.log(`Democking ${service}/${method}`);
         AWS.restore(service, method);
     });
     return handlers;

--- a/test/win-path-tests.js
+++ b/test/win-path-tests.js
@@ -35,31 +35,26 @@ const languages = {
     'c++': {id: 'c++'}
 };
 
-const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+const info = {
+    lang: languages['c++'].id,
+    exe: null,
+    remote: true
+};
 
 describe('Paths', () => {
+    let env;
+
+    before(() => {
+        const compilerProps = new properties.CompilerProps(languages, properties.fakeProps({}));
+        env = new CompilationEnvironment(compilerProps);
+    });
+
     it('Linux -> Wine path', () => {
-        const info = {
-            lang: languages['c++'].id,
-            exe: null,
-            remote: true
-        };
-
-        const env = new CompilationEnvironment(compilerProps);
-
         const compiler = new WineCL(info, env);
         compiler.filename("/tmp/123456/output.s").should.equal("Z:/tmp/123456/output.s");
     });
 
     it('Linux -> Windows path', function () {
-        const info = {
-            lang: languages['c++'].id,
-            exe: null,
-            remote: true
-        };
-
-        const env = new CompilationEnvironment(compilerProps);
-
         process.env.winTmp = "/mnt/c/tmp";
 
         const compiler = new WslCL(info, env);


### PR DESCRIPTION
- suppress log output when running the test suite
  - part of this was having to move any log-generating code that was executing outside of test cases into `before` hooks
- optimize test runtime
  - `filter-tests.js` was erroneously performing a lot of extra work by running `processAsm` before test case creation
  - entire test suite runtime went from ~9s to ~2s on my machine
- fixed a few cases where assertions were happening outside `it` blocks
  - these assertions were still happening, but were not actually part of a test case
  - I'm not entirely sure what would happen if they failed - probably the entire test suite halting