### PR TITLE
Change default target for ISPC to avx2-i32x8

### DIFF
--- a/lib/compilers/ispc.js
+++ b/lib/compilers/ispc.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Matt Godbolt & Rubén Rincón
+// Copyright (c) 2017-2020, Matt Godbolt & Rubén Rincón
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,7 @@ const BaseCompiler = require('../base-compiler'),
 
 class ISPCCompiler extends BaseCompiler {
     optionsForFilter(filters, outputFilename) {
-        let options = ['--target=sse2-i32x4', '--emit-asm', '-g', '-o', this.filename(outputFilename)];
+        let options = ['--target=avx2-i32x8', '--emit-asm', '-g', '-o', this.filename(outputFilename)];
         if (this.compiler.intelAsm && filters.intel && !filters.binary) {
             options = options.concat(this.compiler.intelAsm.split(" "));
         }


### PR DESCRIPTION
AVX2 is the most actual target for performance tuning today, so it make sense to target it by default.
