### PR TITLE
Point python compilers to opt installed source. Enable non-3.6 versions

### DIFF
--- a/etc/config/python.amazon.properties
+++ b/etc/config/python.amazon.properties
@@ -1,14 +1,15 @@
 compilers=&python3
 defaultCompiler=python36
 
-# Disable newer pythons for now until #1649 gets resolved
-group.python3.compilers=python36
+group.python3.compilers=python35:python36:python37:python38
+compiler.python35.name=Python 3.5
+compiler.python35.exe=/opt/compiler-explorer/python/bin/python3.5
 compiler.python36.name=Python 3.6
-compiler.python36.exe=/usr/bin/python3.6
+compiler.python36.exe=/opt/compiler-explorer/python/bin/python3.6
 compiler.python37.name=Python 3.7
-compiler.python37.exe=python3.7
+compiler.python37.exe=/opt/compiler-explorer/python/bin/python3.7
 compiler.python38.name=Python 3.8
-compiler.python38.exe=python3.8
+compiler.python38.exe=/opt/compiler-explorer/python/bin/python3.8
 
 supportsBinary=false
 compilerType=python

--- a/etc/config/python.defaults.properties
+++ b/etc/config/python.defaults.properties
@@ -2,13 +2,13 @@ compilers=&python3
 
 group.python3.compilers=python35:python36:python37:python38
 compiler.python35.name=Python 3.5
-compiler.python35.exe=/opt/compiler-explorer/python/bin/python3.5
+compiler.python35.exe=/usr/bin/python3.5
 compiler.python36.name=Python 3.6
-compiler.python36.exe=/opt/compiler-explorer/python/bin/python3.6
+compiler.python36.exe=/usr/bin/python3.6
 compiler.python37.name=Python 3.7
-compiler.python37.exe=/opt/compiler-explorer/python/bin/python3.7
+compiler.python37.exe=/usr/bin/python3.7
 compiler.python38.name=Python 3.8
-compiler.python38.exe=/opt/compiler-explorer/python/bin/python3.8
+compiler.python38.exe=/usr/bin/python3.8
 
 supportsBinary=false
 compilerType=python

--- a/etc/config/python.defaults.properties
+++ b/etc/config/python.defaults.properties
@@ -1,12 +1,14 @@
 compilers=&python3
 
-group.python3.compilers=python36:python37:python38
+group.python3.compilers=python35:python36:python37:python38
+compiler.python35.name=Python 3.5
+compiler.python35.exe=/opt/compiler-explorer/python/bin/python3.5
 compiler.python36.name=Python 3.6
-compiler.python36.exe=python3.6
+compiler.python36.exe=/opt/compiler-explorer/python/bin/python3.6
 compiler.python37.name=Python 3.7
-compiler.python37.exe=python3.7
+compiler.python37.exe=/opt/compiler-explorer/python/bin/python3.7
 compiler.python38.name=Python 3.8
-compiler.python38.exe=python3.8
+compiler.python38.exe=/opt/compiler-explorer/python/bin/python3.8
 
 supportsBinary=false
 compilerType=python

--- a/etc/config/python.defaults.properties
+++ b/etc/config/python.defaults.properties
@@ -2,13 +2,13 @@ compilers=&python3
 
 group.python3.compilers=python35:python36:python37:python38
 compiler.python35.name=Python 3.5
-compiler.python35.exe=/usr/bin/python3.5
+compiler.python35.exe=python3.5
 compiler.python36.name=Python 3.6
-compiler.python36.exe=/usr/bin/python3.6
+compiler.python36.exe=python3.6
 compiler.python37.name=Python 3.7
-compiler.python37.exe=/usr/bin/python3.7
+compiler.python37.exe=python3.7
 compiler.python38.name=Python 3.8
-compiler.python38.exe=/usr/bin/python3.8
+compiler.python38.exe=python3.8
 
 supportsBinary=false
 compilerType=python


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
Closes #1748
Relies on https://github.com/mattgodbolt/compiler-explorer-image/pull/313 for the compilers existing in the labelled locations