### PR TITLE
Added missing CUDA keywords

### DIFF
--- a/static/modes/cuda-mode.js
+++ b/static/modes/cuda-mode.js
@@ -43,7 +43,7 @@ function definition() {
     cuda.tokenPostfix = '.cu';
 
     // Keywords for CUDA
-    addKeywords(["__host__", "__global__", "__device__"]);
+    addKeywords(["__host__", "__global__", "__device__", "__shared__", "__noinline__", "__forceinline__", "__restrict__"]);
 
     return cuda;
 }


### PR DESCRIPTION
CUDA has some more keywords beyond the three you listed; see the [programming guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html). I've added the missing ones (hopefully that covers them all).

**Note**: This PR is _untested_. I have never built or ran compiler explorer myself before. On the other hand, it's a one-liner, so you be the judge of what to do with it...