### PR TITLE
Separate filters and output options

### DIFF
--- a/static/toggles.js
+++ b/static/toggles.js
@@ -51,9 +51,10 @@ function Togglesv2(root, state) {
             };
 
         // Event Handlers
-        $button.on('click', function () {
+        $button.on('click', function (e) {
             $checkbox.prop('checked', !$checkbox.is(':checked'));
             $checkbox.triggerHandler('change');
+            e.stopPropagation();
         });
         $checkbox.on('change', function () {
             updateDisplay();

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -82,7 +82,7 @@
       include font-size
       .btn-group.btn-group-sm.filters(role="group")
         button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="Compiler output options" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Change how the compiler's output is generated")
-          span.fas.fa-cogs
+          span.fas.fa-cog
           span.hideable &nbsp;Output...
         .dropdown-menu
           .button-checkbox
@@ -108,23 +108,23 @@
         .dropdown-menu
           .button-checkbox
             button.dropdown-item.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Filter unused labels from the output" data-bind="labels" aria-pressed="true")
-              span Filter unused labels
+              span Unused labels
             input.d-none(type="checkbox" checked=true)
           .button-checkbox
             button.dropdown-item.btn.btn-sm.btn-light.active.nonbinary(title="Filter functions from other libraries from the output" data-bind="libraryCode" aria-pressed="true")
-              span Filter library functions
+              span Library functions
             input.d-none(type="checkbox")
           .button-checkbox
             button.dropdown-item.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Filter all assembler directives from the output" data-bind="directives" aria-pressed="true")
-              span Filter directives
+              span Directives
             input.d-none(type="checkbox" checked=true)
           .button-checkbox
             button.dropdown-item.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Remove all lines which are only comments from the output" data-bind="commentOnly" aria-pressed="true")
-              span Filter comments
+              span Comments
             input.d-none(type="checkbox" checked=true)
           .button-checkbox
             button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Trim intra-line whitespace" data-bind="trim" aria-pressed="false")
-              span Trim horizontal whitespace
+              span Horizontal whitespace
             input.d-none(type="checkbox")
       .btn-group.btn-group-sm(role="group" aria-label="Compiler additions")
         button.btn.btn-sm.btn-light.show-libs.dropdown-toggle(title="Include libs" aria-label="Toggle libraries dropdown" aria-pressed="false" aria-haspopup="true")
@@ -155,7 +155,7 @@
             | Graph output
       .btn-group.btn-group-sm(role="group")
         button.btn.btn-sm.btn-light.dropdown-toggle.add-tool(type="button" title="Add tool" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Add tooling to this editor and compiler")
-          span.fas.fa-cogs
+          span.fas.fa-screwdriver
           span.hideable &nbsp;Add tool...
         .dropdown-menu.dropdown-menu-right.toolsmenu
     .monaco-placeholder

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -80,43 +80,47 @@
               span.sr-only Popular arguments
             div.dropdown-menu.dropdown-menu-right
       include font-size
-      .btn-group.btn-group-sm.filters(role="group" aria-label="Compiler filters")
-        .button-checkbox
-          button.btn.btn-sm.btn-light(type="button" title="Compile to binary and disassemble the output" data-bind="binary" aria-pressed="false")
-            span 11010
-          input.d-none(type="checkbox")
-        .button-checkbox
-          button.btn.btn-sm.btn-light(type="button" title="Execute the binary" data-bind="execute" aria-pressed="false")
-            span ./a.out
-          input.d-none(type="checkbox")
-        .button-checkbox
-          button.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Filter unused labels from the output" data-bind="labels" aria-pressed="true")
-            span .LX0:
-          input.d-none(type="checkbox" checked=true)
-        .button-checkbox
-          button.btn.btn-sm.btn-light.active.nonbinary(title="Filter functions from other libraries from the output" data-bind="libraryCode" aria-pressed="true")
-            span lib.f:
-          input.d-none(type="checkbox")
-        .button-checkbox
-          button.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Filter all assembler directives from the output" data-bind="directives" aria-pressed="true")
-            span .text
-          input.d-none(type="checkbox" checked=true)
-        .button-checkbox
-          button.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Remove all lines which are only comments from the output" data-bind="commentOnly" aria-pressed="true")
-            span //
-          input.d-none(type="checkbox" checked=true)
-        .button-checkbox
-          button.btn.btn-sm.btn-light(type="button" title="Trim intra-line whitespace" data-bind="trim" aria-pressed="false")
-            span \s+
-          input.d-none(type="checkbox")
-        .button-checkbox
-          button.btn.btn-sm.btn-light.active(type="button" title="Output disassembly in Intel syntax" data-bind="intel" aria-pressed="true")
-            span Intel
-          input.d-none(type="checkbox" checked=true)
-        .button-checkbox
-          button.btn.btn-sm.btn-light.active(type="button" title="Demangle output" data-bind="demangle" aria-pressed="true")
-            span Demangle
-          input.d-none(type="checkbox" checked=true)
+      .btn-group.btn-group-sm.filters(role="group")
+        button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="Compiler output filters" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Change how the compiler output is filtered")
+          span.fas.fa-filter
+          span.hideable &nbsp;Filters...
+        .dropdown-menu.dropdown-menu-right
+          .button-checkbox.dropdown-item
+            button.btn.btn-sm.btn-light(type="button" title="Compile to binary and disassemble the output" data-bind="binary" aria-pressed="false")
+              span Compile to binary
+            input.d-none(type="checkbox")
+          .button-checkbox.dropdown-item
+            button.btn.btn-sm.btn-light(type="button" title="Execute the binary" data-bind="execute" aria-pressed="false")
+              span Execute
+            input.d-none(type="checkbox")
+          .button-checkbox.dropdown-item
+            button.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Filter unused labels from the output" data-bind="labels" aria-pressed="true")
+              span Filter unused labels
+            input.d-none(type="checkbox" checked=true)
+          .button-checkbox.dropdown-item
+            button.btn.btn-sm.btn-light.active.nonbinary(title="Filter functions from other libraries from the output" data-bind="libraryCode" aria-pressed="true")
+              span Filter library functions
+            input.d-none(type="checkbox")
+          .button-checkbox.dropdown-item
+            button.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Filter all assembler directives from the output" data-bind="directives" aria-pressed="true")
+              span Filter directives
+            input.d-none(type="checkbox" checked=true)
+          .button-checkbox.dropdown-item
+            button.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Remove all lines which are only comments from the output" data-bind="commentOnly" aria-pressed="true")
+              span Filter comments
+            input.d-none(type="checkbox" checked=true)
+          .button-checkbox.dropdown-item
+            button.btn.btn-sm.btn-light(type="button" title="Trim intra-line whitespace" data-bind="trim" aria-pressed="false")
+              span Trim horizontal whitespace
+            input.d-none(type="checkbox")
+          .button-checkbox.dropdown-item
+            button.btn.btn-sm.btn-light.active(type="button" title="Output disassembly in Intel syntax" data-bind="intel" aria-pressed="true")
+              span Intel asm syntax
+            input.d-none(type="checkbox" checked=true)
+          .button-checkbox.dropdown-item
+            button.btn.btn-sm.btn-light.active(type="button" title="Demangle output" data-bind="demangle" aria-pressed="true")
+              span Demangle C++ identifiers
+            input.d-none(type="checkbox" checked=true)
       .btn-group.btn-group-sm(role="group" aria-label="Compiler additions")
         button.btn.btn-sm.btn-light.show-libs.dropdown-toggle(title="Include libs" aria-label="Toggle libraries dropdown" aria-pressed="false" aria-haspopup="true")
           span.fas.fa-book

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -119,7 +119,7 @@
             input.d-none(type="checkbox" checked=true)
           .button-checkbox.dropdown-item
             button.btn.btn-sm.btn-light.active(type="button" title="Demangle output" data-bind="demangle" aria-pressed="true")
-              span Demangle C++ identifiers
+              span Demangle identifiers
             input.d-none(type="checkbox" checked=true)
       .btn-group.btn-group-sm(role="group" aria-label="Compiler additions")
         button.btn.btn-sm.btn-light.show-libs.dropdown-toggle(title="Include libs" aria-label="Toggle libraries dropdown" aria-pressed="false" aria-haspopup="true")

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -81,7 +81,7 @@
             div.dropdown-menu.dropdown-menu-right
       include font-size
       .btn-group.btn-group-sm.filters(role="group")
-        button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="Compiler output filters" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Change how the compiler output is filtered")
+        button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="Compiler output options" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Change how the compiler's output is generated")
           span.fas.fa-cogs
           span.hideable &nbsp;Output...
         .dropdown-menu
@@ -93,6 +93,19 @@
             button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Execute the compiled code and show its output" data-bind="execute" aria-pressed="false")
               span Run the compiled output
             input.d-none(type="checkbox")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light.active(type="button" title="Output disassembly in Intel syntax" data-bind="intel" aria-pressed="true")
+              span Intel asm syntax
+            input.d-none(type="checkbox" checked=true)
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light.active(type="button" title="Demangle output" data-bind="demangle" aria-pressed="true")
+              span Demangle identifiers
+            input.d-none(type="checkbox" checked=true)
+      .btn-group.btn-group-sm.filters(role="group")
+        button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="Compiler output filters" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Change how the compiler output is filtered")
+          span.fas.fa-filter
+          span.hideable &nbsp;Filter...
+        .dropdown-menu
           .button-checkbox
             button.dropdown-item.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Filter unused labels from the output" data-bind="labels" aria-pressed="true")
               span Filter unused labels
@@ -113,14 +126,6 @@
             button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Trim intra-line whitespace" data-bind="trim" aria-pressed="false")
               span Trim horizontal whitespace
             input.d-none(type="checkbox")
-          .button-checkbox
-            button.dropdown-item.btn.btn-sm.btn-light.active(type="button" title="Output disassembly in Intel syntax" data-bind="intel" aria-pressed="true")
-              span Intel asm syntax
-            input.d-none(type="checkbox" checked=true)
-          .button-checkbox
-            button.dropdown-item.btn.btn-sm.btn-light.active(type="button" title="Demangle output" data-bind="demangle" aria-pressed="true")
-              span Demangle identifiers
-            input.d-none(type="checkbox" checked=true)
       .btn-group.btn-group-sm(role="group" aria-label="Compiler additions")
         button.btn.btn-sm.btn-light.show-libs.dropdown-toggle(title="Include libs" aria-label="Toggle libraries dropdown" aria-pressed="false" aria-haspopup="true")
           span.fas.fa-book

--- a/views/templates.pug
+++ b/views/templates.pug
@@ -10,8 +10,8 @@
                   span.current Short
                 ul.dropdown-menu.sources
                   if storageSolution !== "null"
-                      button.dropdown-item.btn.btn-light(data-bind="Short")
-                        | Short
+                    button.dropdown-item.btn.btn-light(data-bind="Short")
+                      | Short
                   button.dropdown-item.btn.btn-light(data-bind="Full")
                     | Full
               input.form-control.permalink(type="text" placeholder="Loading" readonly size="1024")
@@ -82,43 +82,43 @@
       include font-size
       .btn-group.btn-group-sm.filters(role="group")
         button.btn.btn-sm.btn-light.dropdown-toggle(type="button" title="Compiler output filters" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Change how the compiler output is filtered")
-          span.fas.fa-filter
-          span.hideable &nbsp;Filters...
-        .dropdown-menu.dropdown-menu-right
-          .button-checkbox.dropdown-item
-            button.btn.btn-sm.btn-light(type="button" title="Compile to binary and disassemble the output" data-bind="binary" aria-pressed="false")
+          span.fas.fa-cogs
+          span.hideable &nbsp;Output...
+        .dropdown-menu
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Compile to binary and disassemble the output" data-bind="binary" aria-pressed="false")
               span Compile to binary
             input.d-none(type="checkbox")
-          .button-checkbox.dropdown-item
-            button.btn.btn-sm.btn-light(type="button" title="Execute the binary" data-bind="execute" aria-pressed="false")
-              span Execute
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Execute the compiled code and show its output" data-bind="execute" aria-pressed="false")
+              span Run the compiled output
             input.d-none(type="checkbox")
-          .button-checkbox.dropdown-item
-            button.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Filter unused labels from the output" data-bind="labels" aria-pressed="true")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Filter unused labels from the output" data-bind="labels" aria-pressed="true")
               span Filter unused labels
             input.d-none(type="checkbox" checked=true)
-          .button-checkbox.dropdown-item
-            button.btn.btn-sm.btn-light.active.nonbinary(title="Filter functions from other libraries from the output" data-bind="libraryCode" aria-pressed="true")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light.active.nonbinary(title="Filter functions from other libraries from the output" data-bind="libraryCode" aria-pressed="true")
               span Filter library functions
             input.d-none(type="checkbox")
-          .button-checkbox.dropdown-item
-            button.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Filter all assembler directives from the output" data-bind="directives" aria-pressed="true")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Filter all assembler directives from the output" data-bind="directives" aria-pressed="true")
               span Filter directives
             input.d-none(type="checkbox" checked=true)
-          .button-checkbox.dropdown-item
-            button.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Remove all lines which are only comments from the output" data-bind="commentOnly" aria-pressed="true")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light.active.nonbinary(type="button" title="Remove all lines which are only comments from the output" data-bind="commentOnly" aria-pressed="true")
               span Filter comments
             input.d-none(type="checkbox" checked=true)
-          .button-checkbox.dropdown-item
-            button.btn.btn-sm.btn-light(type="button" title="Trim intra-line whitespace" data-bind="trim" aria-pressed="false")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light(type="button" title="Trim intra-line whitespace" data-bind="trim" aria-pressed="false")
               span Trim horizontal whitespace
             input.d-none(type="checkbox")
-          .button-checkbox.dropdown-item
-            button.btn.btn-sm.btn-light.active(type="button" title="Output disassembly in Intel syntax" data-bind="intel" aria-pressed="true")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light.active(type="button" title="Output disassembly in Intel syntax" data-bind="intel" aria-pressed="true")
               span Intel asm syntax
             input.d-none(type="checkbox" checked=true)
-          .button-checkbox.dropdown-item
-            button.btn.btn-sm.btn-light.active(type="button" title="Demangle output" data-bind="demangle" aria-pressed="true")
+          .button-checkbox
+            button.dropdown-item.btn.btn-sm.btn-light.active(type="button" title="Demangle output" data-bind="demangle" aria-pressed="true")
               span Demangle identifiers
             input.d-none(type="checkbox" checked=true)
       .btn-group.btn-group-sm(role="group" aria-label="Compiler additions")


### PR DESCRIPTION
This PR is as much a "what do you think of the look? as it is a code review. Here I'm trying to reduce the width of widgets in the compile window to help with mobile, as well as tidy up and remove confusion that people have had forever over what exactly `11010` means :)

In this PR:

* Output options are separated and placed on a drop-down:
  - compile to binary
  - Run the output
  - Intel syntax
  - Demangle
* Filtering options are separated and placed on a drop-down:
  - Unused labels
  - ...etc

I changed the "tool" icon to a screwdriver and used the cogs to configure output, and then a filter icon for the filters. The change to `toggles.js` is to prevent propagation which causes the dropdown to close every time you click a button.

![Screenshot from 2020-03-03 21-12-29](https://user-images.githubusercontent.com/633973/75841591-bcf57500-5d93-11ea-8901-52601f843530.png)
![Screenshot from 2020-03-03 21-12-23](https://user-images.githubusercontent.com/633973/75841592-bcf57500-5d93-11ea-86e6-99c01d7f60b8.png)
![Screenshot from 2020-03-03 21-12-12](https://user-images.githubusercontent.com/633973/75841594-bcf57500-5d93-11ea-8614-2bd26c6411c2.png)


