### PR TITLE
Point LDC >= 1.19 to gcc for linking

### DIFF
--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -64,8 +64,10 @@ compiler.ldc1_18.exe=/opt/compiler-explorer/ldc1.18.0/ldc2-1.18.0-linux-x86_64/b
 compiler.ldc1_18.semver=1.18.0
 compiler.ldc1_19.exe=/opt/compiler-explorer/ldc1.19.0/ldc2-1.19.0-linux-x86_64/bin/ldc2
 compiler.ldc1_19.semver=1.19.0
+compiler.ldc1_19.options=-gcc=gcc
 compiler.ldc1_20.exe=/opt/compiler-explorer/ldc1.20.0/ldc2-1.20.0-linux-x86_64/bin/ldc2
 compiler.ldc1_20.semver=1.20.0
+compiler.ldc1_20.options=-gcc=gcc
 compiler.ldcbeta.exe=/opt/compiler-explorer/ldcbeta/bin/ldc2
 compiler.ldcbeta.semver=beta
 compiler.ldclatestci.exe=/opt/compiler-explorer/ldc-latest-ci/ldc/bin/ldc2

--- a/etc/config/d.amazon.properties
+++ b/etc/config/d.amazon.properties
@@ -70,8 +70,10 @@ compiler.ldc1_20.semver=1.20.0
 compiler.ldc1_20.options=-gcc=gcc
 compiler.ldcbeta.exe=/opt/compiler-explorer/ldcbeta/bin/ldc2
 compiler.ldcbeta.semver=beta
+compiler.ldcbeta.options=-gcc=gcc
 compiler.ldclatestci.exe=/opt/compiler-explorer/ldc-latest-ci/ldc/bin/ldc2
 compiler.ldclatestci.semver=latest CI
+compiler.ldclatestci.options=-gcc=gcc
 
 group.dmd.compilers=dmd20783:dmd20790:dmd20791:dmd20801:dmd20812:dmd20820:dmd20890:dmd2nightly
 group.dmd.options=-c


### PR DESCRIPTION
This fixes binary linking for LDC >= 1.19. Fixes https://github.com/mattgodbolt/compiler-explorer/issues/1872