### PR TITLE
LLVM 10

### DIFF
--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -61,7 +61,7 @@ compiler.gnuas93.semver=9.3
 compiler.gnuassnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/as
 compiler.gnuassnapshot.semver=(trunk)
 
-group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas_trunk
+group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas_trunk
 group.llvmas.versionFlag=--version
 group.llvmas.options=-filetype=obj -o example.o
 group.llvmas.versionRe=LLVM version .*
@@ -109,6 +109,8 @@ compiler.llvmas700.exe=/opt/compiler-explorer/clang-7.0.0/bin/llvm-mc
 compiler.llvmas700.semver=7.0.0
 compiler.llvmas800.exe=/opt/compiler-explorer/clang-8.0.0/bin/llvm-mc
 compiler.llvmas800.semver=8.0.0
+compiler.llvmas900.exe=/opt/compiler-explorer/clang-9.0.0/bin/llvm-mc
+compiler.llvmas900.semver=9.0.0
 compiler.llvmas_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mc
 compiler.llvmas_trunk.semver=(trunk)
 

--- a/etc/config/assembly.amazon.properties
+++ b/etc/config/assembly.amazon.properties
@@ -61,7 +61,7 @@ compiler.gnuas93.semver=9.3
 compiler.gnuassnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/as
 compiler.gnuassnapshot.semver=(trunk)
 
-group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas_trunk
+group.llvmas.compilers=llvmas30:llvmas31:llvmas32:llvmas33:llvmas341:llvmas350:llvmas351:llvmas37x:llvmas36x:llvmas371:llvmas380:llvmas381:llvmas390:llvmas391:llvmas400:llvmas401:llvmas500:llvmas600:llvmas700:llvmas800:llvmas900:llvmas1000:llvmas_trunk
 group.llvmas.versionFlag=--version
 group.llvmas.options=-filetype=obj -o example.o
 group.llvmas.versionRe=LLVM version .*
@@ -111,6 +111,8 @@ compiler.llvmas800.exe=/opt/compiler-explorer/clang-8.0.0/bin/llvm-mc
 compiler.llvmas800.semver=8.0.0
 compiler.llvmas900.exe=/opt/compiler-explorer/clang-9.0.0/bin/llvm-mc
 compiler.llvmas900.semver=9.0.0
+compiler.llvmas1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/llvm-mc
+compiler.llvmas1000.semver=10.0.0
 compiler.llvmas_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mc
 compiler.llvmas_trunk.semver=(trunk)
 

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -121,7 +121,7 @@ compiler.g71.needsMulti=true
 compiler.g72.needsMulti=true
 
 # Clang for x86
-group.clang.compilers=clang30:clang31:clang32:clang33:clang341:clang350:clang351:clang37x:clang36x:clang371:clang380:clang381:clang390:clang391:clang400:clang401:clang500:clang600:clang700:clang800:clang900:clang_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_parmexpr:clang_embed
+group.clang.compilers=clang30:clang31:clang32:clang33:clang341:clang350:clang351:clang37x:clang36x:clang371:clang380:clang381:clang390:clang391:clang400:clang401:clang500:clang600:clang700:clang800:clang900:clang1000:clang_trunk:clang_concepts:clang_p1144:clang_autonsdmi:clang_lifetime:clang_parmexpr:clang_embed
 group.clang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.clang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.clang.groupName=Clang x86-64
@@ -199,6 +199,9 @@ compiler.clang800.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0
 compiler.clang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.clang900.semver=9.0.0
 compiler.clang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+compiler.clang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
+compiler.clang1000.semver=10.0.0
+compiler.clang1000.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0
 compiler.clang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.clang_trunk.semver=(trunk)
 compiler.clang_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
@@ -939,7 +942,7 @@ libs.glm.versions.0997.version=0.9.9.7
 libs.glm.versions.0997.path=/opt/compiler-explorer/libs/glm/0.9.9.7
 libs.llvm.name=LLVM
 libs.llvm.description=LLVM
-libs.llvm.versions=trunk:401:500:501:502:600:601:700:701:800:900
+libs.llvm.versions=trunk:401:500:501:502:600:601:700:701:800:900:1000
 libs.llvm.url=https://llvm.org/
 libs.llvm.versions.trunk.version=trunk
 libs.llvm.versions.trunk.path=/opt/compiler-explorer/libs/llvm/trunk/include
@@ -963,6 +966,8 @@ libs.llvm.versions.800.version=8.0.0
 libs.llvm.versions.800.path=/opt/compiler-explorer/libs/llvm/8.0.0/include
 libs.llvm.versions.900.version=9.0.0
 libs.llvm.versions.900.path=/opt/compiler-explorer/libs/llvm/9.0.0/include
+libs.llvm.versions.1000.version=10.0.0
+libs.llvm.versions.1000.path=/opt/compiler-explorer/libs/llvm/10.0.0/include
 libs.catch2.name=Catch2
 libs.catch2.description=Catch2
 libs.catch2.url=https://github.com/catchorg/Catch2

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -102,7 +102,7 @@ compiler.cg127.exe=/opt/compiler-explorer/gcc-1.27/bin/gcc
 compiler.cg127.semver=1.27
 
 # Clang for x86
-group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang600:cclang700:cclang800:cclang900:cclang_trunk
+group.cclang.compilers=cclang30:cclang31:cclang32:cclang33:cclang341:cclang350:cclang351:cclang37x:cclang36x:cclang371:cclang380:cclang381:cclang390:cclang391:cclang400:cclang401:cclang500:cclang600:cclang700:cclang800:cclang900:cclang1000:cclang_trunk
 group.cclang.intelAsm=-mllvm --x86-asm-syntax=intel
 group.cclang.options=--gcc-toolchain=/opt/compiler-explorer/gcc-7.2.0
 group.cclang.groupName=Clang x86-64
@@ -161,6 +161,9 @@ compiler.cclang800.options=--gcc-toolchain=/opt/compiler-explorer/gcc-8.3.0
 compiler.cclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang
 compiler.cclang900.semver=9.0.0
 compiler.cclang900.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0
+compiler.cclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang
+compiler.cclang1000.semver=10.0.0
+compiler.cclang1000.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.3.0
 compiler.cclang_trunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang
 compiler.cclang_trunk.semver=(trunk)
 compiler.cclang_trunk.options=--gcc-toolchain=/opt/compiler-explorer/gcc-9.2.0

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -4,7 +4,7 @@ defaultCompiler=llctrunk
 demangler=/opt/compiler-explorer/gcc-9.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-9.1.0/bin/objdump
 
-group.irclang.compilers=irclang500:irclang600:irclang700:irclang800:irclang900:irclangtrunk
+group.irclang.compilers=irclang500:irclang600:irclang700:irclang800:irclang900:irclang1000:irclangtrunk
 group.irclang.intelAsm=-masm=intel
 group.irclang.groupName=Clang x86-64
 group.irclang.options=-x ir
@@ -22,10 +22,12 @@ compiler.irclang800.exe=/opt/compiler-explorer/clang-8.0.0/bin/clang++
 compiler.irclang800.semver=8.0.0
 compiler.irclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
 compiler.irclang900.semver=9.0.0
+compiler.irclang1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/clang++
+compiler.irclang1000.semver=10.0.0
 compiler.irclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.irclangtrunk.semver=(trunk)
 
-group.llc.compilers=llc32:llc33:llc391:llc400:llc401:llc500:llc600:llc700:llc800:llc900:llctrunk
+group.llc.compilers=llc32:llc33:llc391:llc400:llc401:llc500:llc600:llc700:llc800:llc900:llc1000:llctrunk
 group.llc.compilerType=llc
 group.llc.supportsExecute=false
 group.llc.intelAsm=-masm=intel
@@ -53,10 +55,12 @@ compiler.llc800.exe=/opt/compiler-explorer/clang-8.0.0/bin/llc
 compiler.llc800.semver=8.0.0
 compiler.llc900.exe=/opt/compiler-explorer/clang-9.0.0/bin/llc
 compiler.llc900.semver=9.0.0
+compiler.llc1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/llc
+compiler.llc1000.semver=10.0.0
 compiler.llctrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llc
 compiler.llctrunk.semver=(trunk)
 
-group.opt.compilers=opt32:opt33:opt391:opt400:opt401:opt500:opt600:opt700:opt800:opt900:opttrunk
+group.opt.compilers=opt32:opt33:opt391:opt400:opt401:opt500:opt600:opt700:opt800:opt900:opt1000:opttrunk
 group.opt.compilerType=opt
 group.opt.supportsBinary=false
 group.opt.supportsExecute=false
@@ -84,6 +88,8 @@ compiler.opt800.exe=/opt/compiler-explorer/clang-8.0.0/bin/opt
 compiler.opt800.semver=8.0.0
 compiler.opt900.exe=/opt/compiler-explorer/clang-9.0.0/bin/opt
 compiler.opt900.semver=9.0.0
+compiler.opt1000.exe=/opt/compiler-explorer/clang-10.0.0/bin/opt
+compiler.opt1000.semver=10.0.0
 compiler.opttrunk.exe=/opt/compiler-explorer/clang-trunk/bin/opt
 compiler.opttrunk.semver=(trunk)
 

--- a/etc/config/llvm.amazon.properties
+++ b/etc/config/llvm.amazon.properties
@@ -4,7 +4,7 @@ defaultCompiler=llctrunk
 demangler=/opt/compiler-explorer/gcc-9.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-9.1.0/bin/objdump
 
-group.irclang.compilers=irclang500:irclang600:irclang700:irclang800:irclangtrunk
+group.irclang.compilers=irclang500:irclang600:irclang700:irclang800:irclang900:irclangtrunk
 group.irclang.intelAsm=-masm=intel
 group.irclang.groupName=Clang x86-64
 group.irclang.options=-x ir
@@ -20,6 +20,8 @@ compiler.irclang700.exe=/opt/compiler-explorer/clang-7.0.0/bin/clang++
 compiler.irclang700.semver=7.0.0
 compiler.irclang800.exe=/opt/compiler-explorer/clang-8.0.0/bin/clang++
 compiler.irclang800.semver=8.0.0
+compiler.irclang900.exe=/opt/compiler-explorer/clang-9.0.0/bin/clang++
+compiler.irclang900.semver=9.0.0
 compiler.irclangtrunk.exe=/opt/compiler-explorer/clang-trunk/bin/clang++
 compiler.irclangtrunk.semver=(trunk)
 


### PR DESCRIPTION
LLVM 10 is in the process of being released today, so prepare our end too.

The first commit adds LLVM 9 where missing to make everything up to date, the second one adds the actual 10 support.

Note: untested.

See https://github.com/mattgodbolt/compiler-explorer-image/pull/326 as well.