### PR TITLE
Update gfortran compiler versions

### DIFF
--- a/etc/config/fortran.amazon.properties
+++ b/etc/config/fortran.amazon.properties
@@ -1,12 +1,12 @@
 compilers=&gfortran_86:&ifort:&cross
-defaultCompiler=gfortran82
+defaultCompiler=gfortran93
 demangler=/opt/compiler-explorer/gcc-9.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-9.1.0/bin/objdump
 compilerType=fortran
 
 ###############################
 # GCC (as in GNU Compiler Collection) for x86
-group.gfortran_86.compilers=gfortran412:gfortran447:gfortran453:gfortran464:gfortran471:gfortran472:gfortran473:gfortran474:gfortran481:gfortran482:gfortran483:gfortran484:gfortran485:gfortran490:gfortran491:gfortran492:gfortran493:gfortran494:gfortran510:gfortran520:gfortran530:gfortran540:gfortran550:gfortran6:gfortran62:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortransnapshot
+group.gfortran_86.compilers=gfortran412:gfortran447:gfortran453:gfortran464:gfortran471:gfortran472:gfortran473:gfortran474:gfortran481:gfortran482:gfortran483:gfortran484:gfortran485:gfortran490:gfortran491:gfortran492:gfortran493:gfortran494:gfortran510:gfortran520:gfortran530:gfortran540:gfortran550:gfortran6:gfortran62:gfortran63:gfortran71:gfortran72:gfortran73:gfortran81:gfortran82:gfortran83:gfortran91:gfortran92:gfortran93:gfortransnapshot
 group.gfortran_86.groupName=GFORTRAN x86-64
 compiler.gfortran412.exe=/opt/compiler-explorer/gcc-4.1.2/bin/gfortran
 compiler.gfortran412.name=x86-64 gfortran 4.1.2
@@ -70,6 +70,14 @@ compiler.gfortran81.exe=/opt/compiler-explorer/gcc-8.1.0/bin/gfortran
 compiler.gfortran81.name=x86-64 gfortran 8.1
 compiler.gfortran82.exe=/opt/compiler-explorer/gcc-8.2.0/bin/gfortran
 compiler.gfortran82.name=x86-64 gfortran 8.2
+compiler.gfortran83.exe=/opt/compiler-explorer/gcc-8.3.0/bin/gfortran
+compiler.gfortran83.name=x86-64 gfortran 8.3
+compiler.gfortran91.exe=/opt/compiler-explorer/gcc-9.1.0/bin/gfortran
+compiler.gfortran91.name=x86-64 gfortran 9.1
+compiler.gfortran92.exe=/opt/compiler-explorer/gcc-9.2.0/bin/gfortran
+compiler.gfortran92.name=x86-64 gfortran 9.2
+compiler.gfortran93.exe=/opt/compiler-explorer/gcc-9.3.0/bin/gfortran
+compiler.gfortran93.name=x86-64 gfortran 9.3
 compiler.gfortransnapshot.exe=/opt/compiler-explorer/gcc-snapshot/bin/gfortran
 compiler.gfortransnapshot.name=x86-64 gfortran (trunk)
 


### PR DESCRIPTION
It's quite a while since I understood how all this worked, so I hope this doesn't break anything and is correct. I did not run a `make test`, failing to see what this could help for this particular change.

Since invoking `-x f95` for the more recent gcc compilers did work, I assume the gfortran compilers are still automatically installed.  
I did not touch the Intel compilers since I'm less sure those are installed.
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
