### PR TITLE
c++.amazon.properties: add NamedType

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -1204,6 +1204,12 @@ libs.etl.url=https://github.com/ETLCPP/etl.git
 libs.etl.versions.trunk.version=trunk
 libs.etl.versions.trunk.path=/opt/compiler-explorer/libs/etl/include:/opt/compiler-explorer/libs/etl/include/etl/profiles
 
+libs.namedtype.name=NamedType
+libs.namedtype.versions=trunk
+libs.namedtype.url=https://github.com/joboccara/NamedType.git
+libs.namedtype.versions.trunk.version=trunk
+libs.namedtype.versions.trunk.path=/opt/compiler-explorer/libs/NamedType
+
 #################################
 #################################
 # Installed tools

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -678,7 +678,7 @@ compiler.djggp494.semver=4.9.4
 #################################
 #################################
 # Installed libs
-libs=boost:brigand:kvasir:cmcstl2:mp-units:ctbignum:gsl:expected_lite:nlohmann_json:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl
+libs=boost:brigand:kvasir:cmcstl2:mp-units:ctbignum:gsl:expected_lite:nlohmann_json:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:NamedType
 libs.boost.name=Boost
 libs.boost.versions=164:165:166:167:168:169:170:171:172
 libs.boost.url=https://www.boost.org
@@ -1206,7 +1206,7 @@ libs.etl.versions.trunk.path=/opt/compiler-explorer/libs/etl/include:/opt/compil
 
 libs.namedtype.name=NamedType
 libs.namedtype.versions=trunk
-libs.namedtype.url=https://github.com/joboccara/NamedType.git
+libs.namedtype.url=https://github.com/joboccara/NamedType
 libs.namedtype.versions.trunk.version=trunk
 libs.namedtype.versions.trunk.path=/opt/compiler-explorer/libs/NamedType
 

--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -678,7 +678,7 @@ compiler.djggp494.semver=4.9.4
 #################################
 #################################
 # Installed libs
-libs=boost:brigand:kvasir:cmcstl2:mp-units:ctbignum:gsl:expected_lite:nlohmann_json:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:NamedType
+libs=boost:brigand:kvasir:cmcstl2:mp-units:ctbignum:gsl:expected_lite:nlohmann_json:xtl:xsimd:xtensor:abseil:blaze:ctre:eigen:benchmark:rangesv3:dlib:libguarded:cppcoro:fmt:hfsm:glm:llvm:catch2:doctest:eastl:vcl:outcome:cnl:googletest:tbb:seastar:pegtl:openssl:nanorange:benri:hedley:gnufs:llvmfs:etl:namedtype
 libs.boost.name=Boost
 libs.boost.versions=164:165:166:167:168:169:170:171:172
 libs.boost.url=https://www.boost.org


### PR DESCRIPTION
Add libs.namedtype.name=NamedType
trunk only, from joboccara/NamedType.git
into /opt/compiler-explorer/libs/NamedType

pending tests.
Did I miss anything?
Is it just `make check` to test?

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
