### PR TITLE
Rename and update MPPA compiler

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -465,15 +465,19 @@ compiler.arm921.supportsBinary=false
 
 ###############################
 # GCC for Kalray
-group.kalray.compilers=k1cg741:k1cg750
+group.kalray.compilers=kvxg750:k1cg741:k1cg750
 group.kalray.groupName=Kalray MPPA GCC
 group.kalray.isSemVer=true
+compiler.kvxg750.exe=/opt/compiler-explorer/kvx/gcc-7.5.0/kvx-unknown-elf/bin/kvx-unknown-elf-g++
+compiler.kvxg750.name=KVX gcc 7.5
+compiler.kvxg750.semver=7.5.0
+compiler.kvxg750.objdumper=/opt/compiler-explorer/kvx/gcc-7.5.0/kvx-unknown-elf/bin/kvx-unknown-elf-objdump
 compiler.k1cg741.exe=/opt/compiler-explorer/k1/gcc-7.4.1/k1-unknown-elf/bin/k1-unknown-elf-g++
-compiler.k1cg741.name=K1C gcc 7.4
+compiler.k1cg741.name=K1C gcc 7.4 (obsolete)
 compiler.k1cg741.semver=7.4.1
 compiler.k1cg741.objdumper=/opt/compiler-explorer/k1/gcc-7.4.1/k1-unknown-elf/bin/k1-unknown-elf-objdump
 compiler.k1cg750.exe=/opt/compiler-explorer/k1/gcc-7.5.0/k1-unknown-elf/bin/k1-unknown-elf-g++
-compiler.k1cg750.name=K1C gcc 7.5
+compiler.k1cg750.name=K1C gcc 7.5 (obsolete)
 compiler.k1cg750.semver=7.5.0
 compiler.k1cg750.objdumper=/opt/compiler-explorer/k1/gcc-7.5.0/k1-unknown-elf/bin/k1-unknown-elf-objdump
 

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -358,9 +358,13 @@ compiler.carmce820.semver=8.2.0
 
 ###############################
 # GCC for Kalray
-group.ckalray.compilers=ck1cg741:ck1cg750
+group.ckalray.compilers=ckvxg750:ck1cg741:ck1cg750
 group.ckalray.groupName=Kalray MPPA GCC
 group.ckalray.isSemVer=true
+compiler.ckvxcg750.exe=/opt/compiler-explorer/kvx/gcc-7.5.0/kvx-unknown-elf/bin/kvx-unknown-elf-gcc
+compiler.ckvxcg750.name=KVX gcc 7.5
+compiler.ckvxcg750.semver=7.5.0
+compiler.ckvxcg750.objdumper=/opt/compiler-explorer/kvx/gcc-7.5.0/kvx-unknown-elf/bin/kvx-unknown-elf-objdump
 compiler.ck1cg741.exe=/opt/compiler-explorer/k1/gcc-7.4.1/k1-unknown-elf/bin/k1-unknown-elf-gcc
 compiler.ck1cg741.name=K1C gcc 7.4
 compiler.ck1cg741.semver=7.4.1


### PR DESCRIPTION
Kalray's core has been renamed from k1/k1c to kvx/kv3.
It has been decided to keep old compilers but to mark them
as obsolete.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
