### PR TITLE
Limit libraries per compiler

### DIFF
--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -146,6 +146,52 @@ class CompilerFinder {
         }));
     }
 
+    copyAndFilterLibraries(allLibraries, filter) {
+        logger.info("filter: ", filter);
+        const filterLibIds = [];
+        const filterLibAndVersion = _.map(filter, (lib) => {
+            const match = lib.match(/([a-z0-9_-]*)\.([a-z0-9_-]*)/i);
+            if (match) {
+                if (!filterLibIds.includes(match[1])) filterLibIds.push(match[1]);
+                return {
+                    id: match[1],
+                    version: match[2]
+                };
+            } else {
+                if (!filterLibIds.includes(lib)) filterLibIds.push(lib);
+                return {
+                    id: lib,
+                    version: false
+                };
+            }
+        });
+
+        const copiedLibraries = {};
+        _.each(allLibraries, (lib, libid) => {
+            if (!filterLibIds.includes(libid)) return;
+
+            const libcopy = Object.assign({}, lib);
+            libcopy.versions = _.omit(lib.versions, (version, versionid) => {
+                for (let filterIdx = 0; filterIdx < filterLibAndVersion.length; filterIdx++) {
+                    const filter = filterLibAndVersion[filterIdx];
+                    if (filter.id === libid) {
+                        if (!filter.version) return false;
+                        if (filter.version === versionid) return false;
+                    }
+                }
+
+                return true;
+            });
+
+            Object.defineProperty(copiedLibraries, libid, {
+                value: libcopy,
+                writable: true
+            });
+        });
+
+        return copiedLibraries;
+    }
+
     async compilerConfigFor(langId, compilerName, parentProps) {
         const base = `compiler.${compilerName}.`;
 
@@ -176,7 +222,15 @@ class CompilerFinder {
         const options = props("options", "");
         let actualOptions = _.compact([baseOptions, options]).join(' ');
 
-        const supportsLibraries = _.filter(props("supportsLibraries", "").split(":"), (a) => a !== "");
+        let supportedLibraries = null;
+
+        const supportsLibrariesSetting = _.filter(props("supportsLibraries", "").split(":"), (a) => a !== "");
+        if (supportsLibrariesSetting.length > 0) {
+            const libs = this.optionsHandler.get().libs[langId];
+            supportedLibraries = this.copyAndFilterLibraries(libs, supportsLibrariesSetting);
+        } else {
+            supportedLibraries = this.optionsHandler.get().libs[langId];
+        }
 
         const envVars = (() => {
             const envVarsString = props("envVars", "");
@@ -227,9 +281,7 @@ class CompilerFinder {
             notification: props("notification", ""),
             isSemVer: isSemVer,
             semver: semverVer,
-            libs: _.filter(this.optionsHandler.get().libs[langId], (lib, libid) => {
-                return (supportsLibraries.length === 0) || supportsLibraries.includes(libid);
-            }),
+            libs: supportedLibraries,
             tools: _.omit(this.optionsHandler.get().tools[langId], tool => tool.isCompilerExcluded(compilerName)),
             unwiseOptions: props("unwiseOptions", "").split("|")
         };

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -147,17 +147,14 @@ class CompilerFinder {
     }
 
     copyAndFilterLibraries(allLibraries, filter) {
-        const filterLibIds = [];
         const filterLibAndVersion = _.map(filter, (lib) => {
             const match = lib.match(/([a-z0-9_-]*)\.([a-z0-9_-]*)/i);
             if (match) {
-                if (!filterLibIds.includes(match[1])) filterLibIds.push(match[1]);
                 return {
                     id: match[1],
                     version: match[2]
                 };
             } else {
-                if (!filterLibIds.includes(lib)) filterLibIds.push(lib);
                 return {
                     id: lib,
                     version: false
@@ -165,9 +162,14 @@ class CompilerFinder {
             }
         });
 
+        const filterLibIds = new Set();
+        _.each(filterLibAndVersion, (lib) => {
+            filterLibIds.add(lib.id);
+        });
+
         const copiedLibraries = {};
         _.each(allLibraries, (lib, libid) => {
-            if (!filterLibIds.includes(libid)) return;
+            if (!filterLibIds.has(libid)) return;
 
             const libcopy = Object.assign({}, lib);
             libcopy.versions = _.omit(lib.versions, (version, versionid) => {

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -147,7 +147,6 @@ class CompilerFinder {
     }
 
     copyAndFilterLibraries(allLibraries, filter) {
-        logger.info("filter: ", filter);
         const filterLibIds = [];
         const filterLibAndVersion = _.map(filter, (lib) => {
             const match = lib.match(/([a-z0-9_-]*)\.([a-z0-9_-]*)/i);
@@ -183,10 +182,7 @@ class CompilerFinder {
                 return true;
             });
 
-            Object.defineProperty(copiedLibraries, libid, {
-                value: libcopy,
-                writable: true
-            });
+            copiedLibraries[libid] = libcopy;
         });
 
         return copiedLibraries;

--- a/lib/compiler-finder.js
+++ b/lib/compiler-finder.js
@@ -176,6 +176,8 @@ class CompilerFinder {
         const options = props("options", "");
         let actualOptions = _.compact([baseOptions, options]).join(' ');
 
+        const supportsLibraries = _.filter(props("supportsLibraries", "").split(":"), (a) => a !== "");
+
         const envVars = (() => {
             const envVarsString = props("envVars", "");
             if (envVarsString === "") {
@@ -225,7 +227,9 @@ class CompilerFinder {
             notification: props("notification", ""),
             isSemVer: isSemVer,
             semver: semverVer,
-            libs: this.optionsHandler.get().libs[langId],
+            libs: _.filter(this.optionsHandler.get().libs[langId], (lib, libid) => {
+                return (supportsLibraries.length === 0) || supportsLibraries.includes(libid);
+            }),
             tools: _.omit(this.optionsHandler.get().tools[langId], tool => tool.isCompilerExcluded(compilerName)),
             unwiseOptions: props("unwiseOptions", "").split("|")
         };

--- a/test/compiler-finder-tests.js
+++ b/test/compiler-finder-tests.js
@@ -155,24 +155,23 @@ describe('Compiler-finder', function () {
         const finder = new CompilerFinder({}, libraryCompilerProps, properties.fakeProps({}), {}, optionsHandler);
         const compilers = await finder.getCompilers();
         const libs = compilers[0].libs;
-        true.should.equal(true);
-        // libs.should.deep.equal({
-        //     catch2: {
-        //         versions: {
-        //             2101: {
-        //                 version: "2.1.0.1",
-        //                 libPath: "/catch2/2.1.0.1/lib/x86_64"
-        //             }
-        //         }
-        //     },
-        //     fmt: {
-        //         versions: {
-        //             trunk: {
-        //                 version: "(trunk)",
-        //                 libPath: "/fmt/trunk/lib"
-        //             }
-        //         }
-        //     }
-        // });
+        libs.should.deep.equal({
+            catch2: {
+                versions: {
+                    2101: {
+                        version: "2.1.0.1",
+                        libPath: "/catch2/2.1.0.1/lib/x86_64"
+                    }
+                }
+            },
+            fmt: {
+                versions: {
+                    trunk: {
+                        version: "(trunk)",
+                        libPath: "/fmt/trunk/lib"
+                    }
+                }
+            }
+        });
     });
 });

--- a/test/compiler-finder-tests.js
+++ b/test/compiler-finder-tests.js
@@ -36,6 +36,31 @@ const languages = {
     }
 };
 
+const libs = {
+    'a-lang': {
+        fmt: {
+            versions: {
+                trunk: {
+                    version: "(trunk)",
+                    libPath: "/fmt/trunk/lib"
+                }
+            }
+        },
+        catch2: {
+            versions: {
+                2101: {
+                    version: "2.1.0.1",
+                    libPath: "/catch2/2.1.0.1/lib/x86_64"
+                },
+                2102: {
+                    version: "2.1.0.2",
+                    libPath: "/catch2/2.1.0.2/lib/x86_64"
+                }
+            }
+        }
+    }
+};
+
 const props = {
     compilers: "goodCompiler:&badCompiler"
 };
@@ -60,6 +85,11 @@ const bothOptions = {
     options: "bar"
 };
 
+const supportsLibrariesOptions = {
+    compilers: "goodCompiler",
+    supportsLibraries: "fmt:catch2.2101"
+};
+
 describe('Compiler-finder', function () {
     let compilerProps;
 
@@ -67,6 +97,7 @@ describe('Compiler-finder', function () {
     let noBaseOptionsProps;
     let onlyBaseOptionsProps;
     let bothOptionsProps;
+    let libraryCompilerProps;
 
     let optionsHandler;
 
@@ -78,10 +109,12 @@ describe('Compiler-finder', function () {
         onlyBaseOptionsProps = new properties.CompilerProps(languages, properties.fakeProps(onlyBaseOptions));
         bothOptionsProps = new properties.CompilerProps(languages, properties.fakeProps(bothOptions));
 
+        libraryCompilerProps = new properties.CompilerProps(languages, properties.fakeProps(supportsLibrariesOptions));
+
         optionsHandler = {
             get: () => {
                 return {
-                    libs: {},
+                    libs: libs,
                     tools: {}
                 };
             }
@@ -116,5 +149,30 @@ describe('Compiler-finder', function () {
         const finder = new CompilerFinder({}, bothOptionsProps, properties.fakeProps({}), {}, optionsHandler);
         const compilers = await finder.getCompilers();
         compilers[0].options.should.equal('foo bar');
+    });
+
+    it('should be able to filter libraries', async () => {
+        const finder = new CompilerFinder({}, libraryCompilerProps, properties.fakeProps({}), {}, optionsHandler);
+        const compilers = await finder.getCompilers();
+        const libs = compilers[0].libs;
+        true.should.equal(true);
+        // libs.should.deep.equal({
+        //     catch2: {
+        //         versions: {
+        //             2101: {
+        //                 version: "2.1.0.1",
+        //                 libPath: "/catch2/2.1.0.1/lib/x86_64"
+        //             }
+        //         }
+        //     },
+        //     fmt: {
+        //         versions: {
+        //             trunk: {
+        //                 version: "(trunk)",
+        //                 libPath: "/fmt/trunk/lib"
+        //             }
+        //         }
+        //     }
+        // });
     });
 });


### PR DESCRIPTION
Should close #1949

Initially, I mentioned a prop on the compiler would probably a bad thing, but I realized that if a compiler doesn't support any libraries, you could say 'supportsLibraries=none'. Assuming no library is called none that is!
