### PR TITLE
Fix Rust Max_array examples

### DIFF
--- a/examples/rust/Max_array.rs
+++ b/examples/rust/Max_array.rs
@@ -1,5 +1,5 @@
 pub fn max_array(x: &mut [f64; 65536], y: &[f64; 65536]) {
-    for (x, y) in x.iter_mut().zip(y.iter_mut()) {
+    for (x, y) in x.iter_mut().zip(y.iter()) {
         *x = if *y > *x { *y } else { *x };
     }
 }

--- a/examples/rust/Max_array_(Optimized).rs
+++ b/examples/rust/Max_array_(Optimized).rs
@@ -4,7 +4,7 @@
 pub struct Aligned<T: ?Sized>(T);
 
 pub fn max_array(x: &mut Aligned<[f64; 65536]>, y: &Aligned<[f64; 65536]>) {
-    for (x, y) in x.0.iter_mut().zip(y.0.iter_mut()) {
+    for (x, y) in x.0.iter_mut().zip(y.0.iter()) {
         *x = if *y > *x { *y } else { *x };
     }
 }


### PR DESCRIPTION
Fix two Rust max_array examples. 

The previous examples failed to compile as `y` was not borrowed as a mutable reference but used to produce a mutable iterator. Changing from `iter_mut()` to `iter()` resolved this issue.

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
